### PR TITLE
Write full metadata segment instead of only the used part

### DIFF
--- a/src/block_device/bdev_crypt.rs
+++ b/src/block_device/bdev_crypt.rs
@@ -94,7 +94,7 @@ impl IoChannel for CryptIoChannel {
     fn add_read(&mut self, sector: u64, buf: SharedBuffer, len: usize, id: usize) {
         if len % 512 != 0 {
             // programming error, so panic
-            panic!("Read length must be a multiple of 512");
+            panic!("Read length must be a multiple of 512 (sector={},len={})", sector, len);
         }
         self.read_requests[id] = Some(Request {
             sector,
@@ -107,7 +107,7 @@ impl IoChannel for CryptIoChannel {
     fn add_write(&mut self, sector: u64, buf: SharedBuffer, len: usize, id: usize) {
         if len % 512 != 0 {
             // programming error, so panic
-            panic!("Write length must be a multiple of 512");
+            panic!("Write length must be a multiple of 512 (sector={},len={})", sector, len);
         }
         self.encrypt(buf.borrow_mut().as_mut_slice(), sector, (len / 512) as u64);
         self.base.add_write(sector, buf.clone(), len, id);

--- a/src/block_device/bdev_lazy/stripe_metadata_manager.rs
+++ b/src/block_device/bdev_lazy/stripe_metadata_manager.rs
@@ -138,8 +138,8 @@ impl StripeMetadataManager {
     }
 
     pub fn start_flush(&mut self) -> Result<()> {
-        // copy metadata to metadata buffer
         let metadata_buf = self.metadata_buf.clone();
+        let metadata_buf_size = metadata_buf.borrow().len();
         let metadata_size = std::mem::size_of::<UbiMetadata>();
         unsafe {
             let src = &*self.metadata as *const UbiMetadata as *const u8;
@@ -148,7 +148,7 @@ impl StripeMetadataManager {
         }
 
         self.channel
-            .add_write(0, metadata_buf, metadata_size, METADATA_WRITE_ID);
+            .add_write(0, metadata_buf, metadata_buf_size, METADATA_WRITE_ID);
 
         self.channel.submit()?;
 


### PR DESCRIPTION
The size of the used metadata wasn't a multiple of 512 bytes, which caused encryption errors when writing partial data. This change ensures the entire metadata segment is written, avoiding alignment issues.