### PR TITLE
Refactor metadata handling

### DIFF
--- a/src/bin/init-metadata.rs
+++ b/src/bin/init-metadata.rs
@@ -1,0 +1,115 @@
+use clap::{Arg, Command};
+use log::error;
+use serde_yaml;
+use std::fs::File;
+use std::process;
+use ubiblk::vhost_backend::*;
+
+const STRIPE_SECTOR_COUNT_SHIFT_MIN: u8 = 6;
+const STRIPE_SECTOR_COUNT_SHIFT_MAX: u8 = 16;
+
+fn main() {
+    env_logger::builder().format_timestamp(None).init();
+
+    let cmd_arguments = Command::new("vhost-user-blk metadata init")
+        .version(env!("CARGO_PKG_VERSION"))
+        .author(env!("CARGO_PKG_AUTHORS"))
+        .about("Initialize metadata for a vhost-user-blk backend.")
+        .arg(
+            Arg::new("config")
+                .short('f')
+                .long("config")
+                .required(true)
+                .help("Path to the configuration YAML file."),
+        )
+        .arg(
+            Arg::new("kek")
+                .short('k')
+                .long("kek")
+                .help("Path to the key encryption key file."),
+        )
+        .arg(
+            Arg::new("unlink-kek")
+                .short('u')
+                .long("unlink-kek")
+                .action(clap::ArgAction::SetTrue)
+                .help("Unlink the key encryption key file after use."),
+        )
+        .arg(
+            Arg::new("stripe-sector-count-shift")
+                .short('s')
+                .long("stripe-sector-count-shift")
+                .value_parser(clap::value_parser!(u8))
+                .default_value("11")
+                .help("Stripe sector count shift."),
+        )
+        .get_matches();
+
+    let config_path = cmd_arguments.get_one::<String>("config").unwrap();
+    let file = match File::open(config_path) {
+        Ok(file) => file,
+        Err(e) => {
+            error!("Error opening config file {}: {}", config_path, e);
+            process::exit(1);
+        }
+    };
+
+    let options: Options = match serde_yaml::from_reader(file) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            error!("Error parsing config file {}: {}", config_path, e);
+            process::exit(1);
+        }
+    };
+
+    let mut kek = KeyEncryptionCipher {
+        method: CipherMethod::None,
+        key: None,
+        init_vector: None,
+        auth_data: None,
+    };
+
+    let stripe_sector_count_shift = cmd_arguments
+        .get_one::<u8>("stripe-sector-count-shift")
+        .unwrap();
+
+    if *stripe_sector_count_shift > STRIPE_SECTOR_COUNT_SHIFT_MAX || *stripe_sector_count_shift < STRIPE_SECTOR_COUNT_SHIFT_MIN {
+        error!(
+            "stripe-sector-count-shift must be between {} and {}.",
+            STRIPE_SECTOR_COUNT_SHIFT_MIN, STRIPE_SECTOR_COUNT_SHIFT_MAX
+        );
+        process::exit(1);
+    }
+
+    if let Some(kek_path) = cmd_arguments.get_one::<String>("kek") {
+        let file = match File::open(kek_path) {
+            Ok(file) => file,
+            Err(e) => {
+                error!("Error opening KEK file {}: {}", kek_path, e);
+                process::exit(1);
+            }
+        };
+
+        kek = match serde_yaml::from_reader(file) {
+            Ok(kek) => kek,
+            Err(e) => {
+                error!("Error parsing KEK file {}: {}", kek_path, e);
+                process::exit(1);
+            }
+        };
+
+        if let Some(unlink_kek) = cmd_arguments.get_one::<bool>("unlink-kek") {
+            if *unlink_kek {
+                if let Err(e) = std::fs::remove_file(kek_path) {
+                    error!("Error unlinking KEK file {}: {}", kek_path, e);
+                    process::exit(1);
+                }
+            }
+        }
+    }
+
+    if let Err(e) = init_metadata(&options, kek, *stripe_sector_count_shift) {
+        error!("Error initializing metadata: {}", e);
+        process::exit(1);
+    }
+}

--- a/src/block_device/bdev_lazy/mod.rs
+++ b/src/block_device/bdev_lazy/mod.rs
@@ -4,3 +4,4 @@ mod stripe_metadata_manager;
 
 pub use bdev_lazy::LazyBlockDevice;
 pub use stripe_fetcher::StripeFetcher;
+pub use stripe_metadata_manager::UbiMetadata;

--- a/src/block_device/bdev_lazy/stripe_metadata_manager.rs
+++ b/src/block_device/bdev_lazy/stripe_metadata_manager.rs
@@ -1,7 +1,7 @@
 use std::{cell::RefCell, mem::MaybeUninit, ptr::copy_nonoverlapping, rc::Rc};
 
 use super::super::*;
-use crate::{vhost_backend::SECTOR_SIZE, Result};
+use crate::{vhost_backend::SECTOR_SIZE, Result, VhostUserBlockError};
 use log::{error, info};
 
 #[repr(u8)]
@@ -15,11 +15,7 @@ pub enum StripeStatus {
 
 const UBI_MAGIC_SIZE: usize = 9;
 const UBI_MAX_STRIPES: usize = 2 * 1024 * 1024;
-const UBI_METADATA_SIZE: usize = 8388608; // 8MB
-const UBI_METADATA_SECTOR_COUNT: u32 = (UBI_METADATA_SIZE / SECTOR_SIZE) as u32;
 const UBI_MAGIC: &[u8] = b"BDEV_UBI\0"; // 9 bytes
-const _STRIPE_SIZE: usize = 1024 * 1024; // 1MB
-const STRIPE_SECTOR_COUNT: u32 = (_STRIPE_SIZE / SECTOR_SIZE) as u32;
 
 const METADATA_WRITE_ID: usize = 0;
 const METADATA_FLUSH_ID: usize = 1;
@@ -28,7 +24,7 @@ const METADATA_FLUSH_ID: usize = 1;
 pub struct StripeStatusVec {
     pub data: Vec<StripeStatus>,
     pub stripe_sector_count: u64,
-    pub device_sector_count: u64,
+    pub source_sector_count: u64,
     pub stripe_count: u64,
 }
 
@@ -53,18 +49,14 @@ impl StripeStatusVec {
     pub fn stripe_sector_count(&self, stripe_id: usize) -> u32 {
         let stripe_sector_count = self
             .stripe_sector_count
-            .min(self.device_sector_count - (stripe_id as u64 * self.stripe_sector_count))
+            .min(self.source_sector_count - (stripe_id as u64 * self.stripe_sector_count))
             as usize;
         stripe_sector_count as u32
-    }
-
-    pub fn translate_sector(&self, sector: u64) -> u64 {
-        UBI_METADATA_SECTOR_COUNT as u64 + sector
     }
 }
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub struct UbiMetadata {
     pub magic: [u8; UBI_MAGIC_SIZE],
 
@@ -72,16 +64,87 @@ pub struct UbiMetadata {
     pub version_major: [u8; 2],
     pub version_minor: [u8; 2],
 
-    pub reserved: u8,
+    pub stripe_sector_count_shift: u8,
 
-    // Each header is 2 bytes, 32 stripes
-    pub stripe_headers: [[u8; 2]; UBI_MAX_STRIPES],
+    // bit 0: fetched or not
+    // bit 1: written or not
+    pub stripe_headers: [u8; UBI_MAX_STRIPES],
 }
 
 impl UbiMetadata {
     #[cfg(test)]
     pub fn stripe_headers_offset(&self, stripe_id: usize) -> usize {
-        stripe_id * std::mem::size_of::<u16>() + UBI_MAGIC_SIZE + 5
+        stripe_id + UBI_MAGIC_SIZE + 5
+    }
+
+    pub fn new(stripe_sector_count_shift: u8) -> Box<Self> {
+        let mut metadata: Box<MaybeUninit<Self>> = Box::new_uninit();
+        unsafe {
+            let metadata_ptr = metadata.assume_init_mut();
+            metadata_ptr.magic.copy_from_slice(UBI_MAGIC);
+            metadata_ptr.version_major.copy_from_slice(&[0, 0]);
+            metadata_ptr.version_minor.copy_from_slice(&[0, 0]);
+            metadata_ptr.stripe_sector_count_shift = stripe_sector_count_shift;
+            metadata_ptr.stripe_headers.fill(0);
+        }
+        unsafe { metadata.assume_init() }
+    }
+
+    pub fn write(&self, ch: &mut Box<dyn IoChannel>) -> Result<()> {
+        let metadata_size = std::mem::size_of::<UbiMetadata>();
+        let sectors = (metadata_size + SECTOR_SIZE - 1) / SECTOR_SIZE;
+        let buf = Rc::new(RefCell::new(vec![0u8; sectors * SECTOR_SIZE]));
+        unsafe {
+            let src = &*self as *const UbiMetadata as *const u8;
+            let dst = buf.borrow_mut().as_mut_ptr();
+            copy_nonoverlapping(src, dst, metadata_size);
+        }
+        ch.add_write(0, sectors as u32, buf.clone(), 0);
+        ch.submit()?;
+
+        let timeout = std::time::Duration::from_secs(5);
+        let start_time = std::time::Instant::now();
+        let mut completed = false;
+        while start_time.elapsed() < timeout && !completed {
+            std::thread::sleep(std::time::Duration::from_millis(1));
+            for (id, success) in ch.poll() {
+                if id == 0 {
+                    if !success {
+                        error!("Failed to write metadata");
+                        return Err(VhostUserBlockError::IoError {
+                            source: std::io::Error::new(
+                                std::io::ErrorKind::Other,
+                                "Failed to write metadata",
+                            ),
+                        });
+                    }
+
+                    completed = true;
+                    break;
+                } else {
+                    error!("Unexpected ID: {}", id);
+                    return Err(VhostUserBlockError::IoError {
+                        source: std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            format!("Unexpected ID: {}", id),
+                        ),
+                    });
+                }
+            }
+        }
+
+        if !completed {
+            error!("Timeout while writing metadata");
+            return Err(VhostUserBlockError::IoError {
+                source: std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "Timeout while writing metadata",
+                ),
+            });
+        }
+        info!("Metadata written successfully");
+
+        Ok(())
     }
 }
 
@@ -93,20 +156,22 @@ pub struct StripeMetadataManager {
 }
 
 impl StripeMetadataManager {
-    pub fn new(source: &dyn BlockDevice, target: &dyn BlockDevice) -> Result<Box<Self>> {
-        let mut channel = target.create_channel()?;
-        let metadata = Self::load_metadata(&mut channel);
-        let stripe_status_vec = Self::create_stripe_status_vec(&metadata, source.sector_count());
+    pub fn new(metadata_dev: &dyn BlockDevice, source_sector_count: u64) -> Result<Box<Self>> {
+        let mut channel = metadata_dev.create_channel()?;
+        let metadata = Self::load_metadata(&mut channel)?;
+        let stripe_status_vec = Self::create_stripe_status_vec(&metadata, source_sector_count);
+        let metadata_size = std::mem::size_of::<UbiMetadata>();
+        let metadata_buf_size = ((metadata_size + SECTOR_SIZE - 1) / SECTOR_SIZE) * SECTOR_SIZE;
         Ok(Box::new(StripeMetadataManager {
             channel,
             metadata,
             stripe_status_vec,
-            metadata_buf: Rc::new(RefCell::new(vec![0u8; UBI_METADATA_SIZE])),
+            metadata_buf: Rc::new(RefCell::new(vec![0u8; metadata_buf_size])),
         }))
     }
 
-    pub fn metadata_sector_count(&self) -> u64 {
-        UBI_METADATA_SECTOR_COUNT as u64
+    pub fn stripe_sector_count(&self) -> u64 {
+        (1 as u64) << self.metadata.stripe_sector_count_shift
     }
 
     pub fn stripe_status(&self, stripe_id: usize) -> StripeStatus {
@@ -117,25 +182,21 @@ impl StripeMetadataManager {
         self.stripe_status_vec.set_stripe_status(stripe_id, status);
         match status {
             StripeStatus::NotFetched => {
-                self.metadata.stripe_headers[stripe_id] = [0, 0];
+                self.metadata.stripe_headers[stripe_id] = 0;
             }
             StripeStatus::Fetched => {
-                self.metadata.stripe_headers[stripe_id] = [1, 0];
+                self.metadata.stripe_headers[stripe_id] = 1;
             }
             _ => {}
         }
     }
 
     pub fn stripe_source_sector_offset(&self, stripe_id: usize) -> u64 {
-        stripe_id as u64 * STRIPE_SECTOR_COUNT as u64
+        stripe_id as u64 * self.stripe_sector_count() as u64
     }
 
     pub fn stripe_target_sector_offset(&self, stripe_id: usize) -> u64 {
-        stripe_id as u64 * STRIPE_SECTOR_COUNT as u64 + UBI_METADATA_SECTOR_COUNT as u64
-    }
-
-    pub fn stripe_sector_count(&self, stripe_id: usize) -> u32 {
-        self.stripe_status_vec.stripe_sector_count(stripe_id)
+        stripe_id as u64 * self.stripe_sector_count() as u64
     }
 
     pub fn stripe_status_vec(&self) -> StripeStatusVec {
@@ -151,12 +212,9 @@ impl StripeMetadataManager {
             copy_nonoverlapping(src, dst, metadata_size);
         }
 
-        self.channel.add_write(
-            0,
-            UBI_METADATA_SECTOR_COUNT,
-            metadata_buf,
-            METADATA_WRITE_ID,
-        );
+        let sector_count = metadata_buf.borrow().len() / SECTOR_SIZE;
+        self.channel
+            .add_write(0, sector_count as u32, metadata_buf, METADATA_WRITE_ID);
 
         self.channel.submit()?;
 
@@ -189,12 +247,14 @@ impl StripeMetadataManager {
         None
     }
 
-    fn load_metadata(io_channel: &mut Box<dyn IoChannel>) -> Box<UbiMetadata> {
+    fn load_metadata(io_channel: &mut Box<dyn IoChannel>) -> Result<Box<UbiMetadata>> {
         info!("Loading metadata from device");
-        let buf: Rc<RefCell<Vec<u8>>> = Rc::new(RefCell::new(vec![0u8; UBI_METADATA_SIZE]));
 
-        io_channel.add_read(0, UBI_METADATA_SECTOR_COUNT, buf.clone(), 0);
-        io_channel.submit().unwrap();
+        let sector_count = (std::mem::size_of::<UbiMetadata>() + SECTOR_SIZE - 1) / SECTOR_SIZE;
+        let buf: Rc<RefCell<Vec<u8>>> =
+            Rc::new(RefCell::new(vec![0u8; sector_count * SECTOR_SIZE]));
+        io_channel.add_read(0, sector_count as u32, buf.clone(), 0);
+        io_channel.submit()?;
 
         let mut results = io_channel.poll();
         while io_channel.busy() {
@@ -205,12 +265,18 @@ impl StripeMetadataManager {
         }
 
         if results.len() != 1 {
-            panic!("Failed to read metadata");
+            error!("Failed to read metadata");
+            return Err(VhostUserBlockError::MetadataError {
+                description: format!("Expected 1 result, got {}", results.len()),
+            });
         }
 
         let (id, success) = results.pop().unwrap();
         if !success || id != 0 {
-            panic!("Failed to read metadata");
+            error!("Failed to read metadata");
+            return Err(VhostUserBlockError::MetadataError {
+                description: format!("Failed to read metadata, id: {}, success: {}", id, success),
+            });
         }
 
         let mut metadata: Box<MaybeUninit<UbiMetadata>> = Box::new_uninit();
@@ -223,44 +289,45 @@ impl StripeMetadataManager {
             );
         }
 
-        let mut metadata: Box<UbiMetadata> = unsafe { metadata.assume_init() };
+        let metadata: Box<UbiMetadata> = unsafe { metadata.assume_init() };
 
         if metadata.magic != *UBI_MAGIC {
-            info!("Metadata magic mismatch, assuming new device");
-            metadata.magic.copy_from_slice(UBI_MAGIC);
-            metadata.version_major.copy_from_slice(&[0, 0]);
-            metadata.version_minor.copy_from_slice(&[0, 0]);
-            metadata.reserved = 0;
-            metadata.stripe_headers = [[0; 2]; UBI_MAX_STRIPES];
+            error!("Metadata magic mismatch!");
+            return Err(VhostUserBlockError::MetadataError {
+                description: format!(
+                    "Metadata magic mismatch! Expected: {:?}, Found: {:?}",
+                    UBI_MAGIC, metadata.magic
+                ),
+            });
         }
 
         info!("Metadata loaded successfully");
 
-        metadata
+        Ok(metadata)
     }
 
     fn create_stripe_status_vec(
         metadata: &Box<UbiMetadata>,
-        device_sector_count: u64,
+        source_sector_count: u64,
     ) -> StripeStatusVec {
         let v = metadata
             .stripe_headers
             .iter()
             .map(|header| {
-                let stripe_id = u16::from_le_bytes(*header);
-                if stripe_id == 0 {
+                if *header == 0 {
                     StripeStatus::NotFetched
                 } else {
                     StripeStatus::Fetched
                 }
             })
             .collect::<Vec<StripeStatus>>();
-        let stripe_sector_count = STRIPE_SECTOR_COUNT as u64;
-        let stripe_count = (device_sector_count + stripe_sector_count - 1) / stripe_sector_count;
+        let stripe_sector_count = 1u64 << metadata.stripe_sector_count_shift;
+        let stripe_count = (source_sector_count + stripe_sector_count - 1) / stripe_sector_count;
+
         StripeStatusVec {
             data: v,
             stripe_sector_count,
-            device_sector_count,
+            source_sector_count,
             stripe_count,
         }
     }
@@ -273,20 +340,22 @@ mod tests {
 
     #[test]
     fn test_stripe_metadata_manager() -> Result<()> {
-        let source = TestBlockDevice::new(29 * 1024 * 1024 + 3 * 1024);
-        let target = TestBlockDevice::new(40 * 1024 * 1024);
-        let mut manager = StripeMetadataManager::new(&source, &target)?;
+        let metadata_dev = TestBlockDevice::new(40 * 1024 * 1024);
+        let stripe_sector_count_shift = 11;
+        let stripe_sector_count = 1 << stripe_sector_count_shift;
+        let source_sector_count = 29 * stripe_sector_count + 4;
+        let stripe_count = (source_sector_count + stripe_sector_count - 1) / stripe_sector_count;
 
-        assert_eq!(
-            manager.metadata_sector_count(),
-            UBI_METADATA_SECTOR_COUNT as u64
-        );
+        let mut ch = metadata_dev.create_channel()?;
+        UbiMetadata::new(stripe_sector_count_shift)
+            .write(&mut ch)
+            .unwrap();
+
+        let mut manager = StripeMetadataManager::new(&metadata_dev, source_sector_count)?;
+
         assert_eq!(manager.stripe_status(0), StripeStatus::NotFetched);
         assert_eq!(manager.stripe_source_sector_offset(0), 0);
-        assert_eq!(
-            manager.stripe_target_sector_offset(0),
-            UBI_METADATA_SECTOR_COUNT as u64
-        );
+        assert_eq!(manager.stripe_target_sector_offset(0), 0);
 
         let stripes_to_fetch = vec![0, 3, 7, 8];
 
@@ -304,40 +373,28 @@ mod tests {
         }
 
         let stripe_status_vec = manager.stripe_status_vec();
-        assert_eq!(stripe_status_vec.stripe_count, 30);
+        assert_eq!(stripe_status_vec.stripe_count, stripe_count as u64);
 
-        for stripe_id in 0..30 {
-            let expected_sector_count = if stripe_id == 29 {
-                6
-            } else {
-                STRIPE_SECTOR_COUNT
-            };
-            assert_eq!(
-                manager.stripe_sector_count(stripe_id),
-                expected_sector_count
-            );
-        }
-
-        assert_eq!(target.flushes(), 0);
+        assert_eq!(metadata_dev.flushes(), 0);
         manager.start_flush().unwrap();
         assert_eq!(manager.poll_flush(), None);
         assert_eq!(manager.poll_flush(), Some(true));
-        assert_eq!(target.flushes(), 1);
+        assert_eq!(metadata_dev.flushes(), 1);
 
         for i in 0..UBI_MAX_STRIPES {
             let offset = manager.metadata.stripe_headers_offset(i);
-            let mut header_buf = [0u8; 2];
-            target.read(offset, &mut header_buf, 2);
+            let mut header_buf = [0u8; 1];
+            metadata_dev.read(offset, &mut header_buf, 1);
             let expected_header = if stripes_to_fetch.contains(&i) {
-                [1, 0]
+                [1]
             } else {
-                [0, 0]
+                [0]
             };
             assert_eq!(header_buf, expected_header);
         }
 
         let mut magic_buf = [0u8; UBI_MAGIC_SIZE];
-        target.read(0, &mut magic_buf, UBI_MAGIC_SIZE);
+        metadata_dev.read(0, &mut magic_buf, UBI_MAGIC_SIZE);
         assert_eq!(magic_buf, *UBI_MAGIC);
 
         Ok(())

--- a/src/block_device/bdev_uring.rs
+++ b/src/block_device/bdev_uring.rs
@@ -2,6 +2,7 @@ use super::{BlockDevice, IoChannel, SharedBuffer};
 use crate::{vhost_backend::SECTOR_SIZE, Result, VhostUserBlockError};
 use io_uring::IoUring;
 use log::error;
+use nix::errno::Errno;
 use std::{
     fs::{File, OpenOptions},
     os::fd::AsRawFd,
@@ -112,6 +113,7 @@ impl IoChannel for UringIoChannel {
                     let id = entry.user_data();
                     if result < 0 {
                         finished_requests.push((id as usize, false));
+                        error!("IO request failed: {}", Errno::from_i32(-result));
                     } else {
                         finished_requests.push((id as usize, true));
                     }

--- a/src/block_device/mod.rs
+++ b/src/block_device/mod.rs
@@ -29,5 +29,6 @@ mod bdev_test;
 pub use bdev_crypt::CryptBlockDevice;
 pub use bdev_lazy::LazyBlockDevice;
 pub use bdev_lazy::StripeFetcher;
+pub use bdev_lazy::UbiMetadata;
 pub use bdev_sync::SyncBlockDevice;
 pub use bdev_uring::UringBlockDevice;

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,25 +4,89 @@ use thiserror::Error;
 pub enum VhostUserBlockError {
     #[error("Thread creation error")]
     ThreadCreation,
-    #[error("I/O channel creation error")]
+    #[error("I/O channel creation error: {source}")]
     IoChannelCreation {
         #[source]
         source: std::io::Error,
     },
-    #[error("Guest memory access error")]
+    #[error("Guest memory access error: {source}")]
     GuestMemoryAccess {
         #[source]
         source: vm_memory::GuestMemoryError,
     },
-    #[error("I/O error")]
+    #[error("I/O error: {source}")]
     IoError {
         #[source]
         source: std::io::Error,
     },
     #[error("Channel error")]
     ChannelError,
-    #[error("Invalid parameter error")]
+    #[error("Invalid parameter error: {description}")]
     InvalidParameter { description: String },
+    #[error("Metadata error: {description}")]
+    MetadataError { description: String },
 }
 
 pub type Result<T> = std::result::Result<T, VhostUserBlockError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_invalid_parameter_format() {
+        let error = VhostUserBlockError::InvalidParameter {
+            description: "Test error".to_string(),
+        };
+        assert_eq!(format!("{}", error), "Invalid parameter error: Test error");
+    }
+
+    #[test]
+    fn test_io_error_format() {
+        let io_error = std::io::Error::new(std::io::ErrorKind::Other, "Test IO error");
+        let error = VhostUserBlockError::IoError { source: io_error };
+        assert_eq!(format!("{}", error), "I/O error: Test IO error");
+    }
+
+    #[test]
+    fn test_guest_memory_access_format() {
+        let guest_memory_error = vm_memory::GuestMemoryError::InvalidBackendAddress;
+        let error = VhostUserBlockError::GuestMemoryAccess {
+            source: guest_memory_error,
+        };
+        assert_eq!(
+            format!("{}", error),
+            "Guest memory access error: Guest memory error: invalid backend address"
+        );
+    }
+
+    #[test]
+    fn test_thread_creation_format() {
+        let error = VhostUserBlockError::ThreadCreation;
+        assert_eq!(format!("{}", error), "Thread creation error");
+    }
+
+    #[test]
+    fn test_io_channel_creation_format() {
+        let io_error = std::io::Error::new(std::io::ErrorKind::Other, "Test IO error");
+        let error = VhostUserBlockError::IoChannelCreation { source: io_error };
+        assert_eq!(
+            format!("{}", error),
+            "I/O channel creation error: Test IO error"
+        );
+    }
+
+    #[test]
+    fn test_channel_error_format() {
+        let error = VhostUserBlockError::ChannelError;
+        assert_eq!(format!("{}", error), "Channel error");
+    }
+
+    #[test]
+    fn test_metadata_error_format() {
+        let error = VhostUserBlockError::MetadataError {
+            description: "Test metadata error".to_string(),
+        };
+        assert_eq!(format!("{}", error), "Metadata error: Test metadata error");
+    }
+}

--- a/src/vhost_backend/mod.rs
+++ b/src/vhost_backend/mod.rs
@@ -1,7 +1,7 @@
 mod backend;
 mod options;
 mod request;
-pub use backend::block_backend_loop;
+pub use backend::{block_backend_loop, init_metadata};
 pub use options::{CipherMethod, KeyEncryptionCipher, Options};
 mod backend_thread;
 

--- a/src/vhost_backend/options.rs
+++ b/src/vhost_backend/options.rs
@@ -67,6 +67,7 @@ fn default_skip_sync() -> bool {
 pub struct Options {
     pub path: String,
     pub image_path: Option<String>,
+    pub metadata_path: Option<String>,
     pub io_debug_path: Option<String>,
     pub socket: String,
 


### PR DESCRIPTION
- Store metadata in a separate file to unify address layout between disk and image files.
- Add an explicit metadata initialization tool. Metadata is no longer auto-initialized on magic mismatch; it now results in an error.
- Make stripe size configurable via the init tool; it is stored in the metadata header.