### PR TITLE
Add decode_hex error tests

### DIFF
--- a/src/utils/debug.rs
+++ b/src/utils/debug.rs
@@ -86,4 +86,16 @@ mod tests {
         let expected = b"Hello".to_vec();
         assert_eq!(decode_hex(hex).unwrap(), expected);
     }
+
+    #[test]
+    fn test_decode_hex_odd_len() {
+        let hex = "abc";
+        assert!(decode_hex(hex).is_err());
+    }
+
+    #[test]
+    fn test_decode_hex_non_hex_chars() {
+        let hex = "zz";
+        assert!(decode_hex(hex).is_err());
+    }
 }


### PR DESCRIPTION
## Summary
- expand debug utils tests for decode_hex to cover odd-length input and non-hex characters

## Testing
- `cargo test --quiet` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683fa410a830832793bcf13ba7bca8eb