### PR TITLE
Fix block device build error propagation

### DIFF
--- a/src/vhost_backend/backend.rs
+++ b/src/vhost_backend/backend.rs
@@ -241,9 +241,8 @@ fn build_block_device(
         block_device::UringBlockDevice::new(PathBuf::from(&path), options.queue_size, false)
             .map_err(|e| {
                 error!("Failed to create block device: {:?}", e);
-                Box::new(e)
-            })
-            .unwrap();
+                e
+            })?;
 
     if let Some((key1, key2)) = &options.encryption_key {
         block_device =


### PR DESCRIPTION
## Summary
- avoid unwrapping on block device creation failure

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683faaea2b308327aab16a722e7477d8