### PR TITLE
Add test for unaligned file size

### DIFF
--- a/src/block_device/bdev_uring.rs
+++ b/src/block_device/bdev_uring.rs
@@ -266,7 +266,7 @@ mod tests {
                 VhostUserBlockError::IoError { source: e }
             })?;
         let path = tmpfile.path().to_owned();
-        let result = UringBlockDevice::new(path.clone(), 8, false);
+        let result = UringBlockDevice::new(path, 8, false);
         assert!(result.is_err());
         Ok(())
     }

--- a/src/block_device/bdev_uring.rs
+++ b/src/block_device/bdev_uring.rs
@@ -251,4 +251,23 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn new_with_unaligned_size_fails() -> Result<()> {
+        let mut tmpfile = NamedTempFile::new().map_err(|e| {
+            error!("Failed to create temporary file: {}", e);
+            VhostUserBlockError::IoError { source: e }
+        })?;
+        tmpfile
+            .as_file_mut()
+            .set_len(SECTOR_SIZE as u64 + 1)
+            .map_err(|e| {
+                error!("Failed to set temporary file size: {}", e);
+                VhostUserBlockError::IoError { source: e }
+            })?;
+        let path = tmpfile.path().to_owned();
+        let result = UringBlockDevice::new(path.clone(), 8, false);
+        assert!(result.is_err());
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary
- add a test that uses a temporary file whose size isn't a multiple of 512

## Testing
- `cargo test --no-run --locked --offline` *(fails: no matching package named `aes` found)*

------
https://chatgpt.com/codex/tasks/task_e_683facc2e5e88327acccdb1385f8ec5f