### PR TITLE
Limit workflow build steps to tagged dispatch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,10 +52,12 @@ jobs:
         run: cargo test --all
 
       - name: Build project
+        if: github.event_name == 'workflow_dispatch' && github.ref_type == 'tag'
         run: |
           cargo build --release --target=${{ matrix.target }}
 
       - name: Package
+        if: github.event_name == 'workflow_dispatch' && github.ref_type == 'tag'
         run: |
           cd target/${{ matrix.target }}/release
           tar -czf vhost-backend-${{ matrix.arch }}.tar.gz vhost-backend init-metadata


### PR DESCRIPTION
## Summary
- restrict Build project and Package steps to run only for manually dispatched tag events

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6840d7351fa0832794be27b2b69a8164