### PR TITLE
Add code coverage workflow

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,0 +1,44 @@
+name: Coverage
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y autoconf libtool nasm clang build-essential
+
+      - name: Clone and build isa-l_crypto
+        run: |
+          git clone --depth 1 --branch v2.25.0 https://github.com/intel/isa-l_crypto
+          cd isa-l_crypto
+          ./autogen.sh
+          ./configure --prefix=/usr --libdir=/usr/lib
+          make -j$(nproc)
+          sudo make install
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Install Tarpaulin
+        run: cargo install cargo-tarpaulin
+
+      - name: Run coverage
+        run: cargo tarpaulin --out xml --output-dir coverage
+
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage/cobertura.xml
+          fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -112,3 +112,14 @@ disk image. The log is produced by the backend when `io_debug_path` is set.
 ```bash
 replay-log --log io_debug.log --disk disk.img
 ```
+
+## Coverage
+
+The project uses [cargo-tarpaulin](https://github.com/xd009642/tarpaulin) to generate test coverage.
+To produce a local report run:
+
+```bash
+cargo tarpaulin --out Html
+```
+
+Coverage is also collected in CI via `.github/workflows/coverage.yaml` and uploaded to Codecov.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tarpaulin and upload to Codecov
- document how to run coverage locally

## Testing
- `cargo test --locked`
- `cargo fmt --all -- --check`


------
https://chatgpt.com/codex/tasks/task_e_68411dd4b3c48327801f1e74ae520047