### PR TITLE
Add request.rs unit tests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,7 @@ jobs:
         run: cargo install cargo-llvm-cov --locked
 
       - name: Run tests with coverage
-        run: cargo llvm-cov --fail-under-lines 56 --ignore-filename-regex src/bin/
+        run: cargo llvm-cov --fail-under-lines 60 --ignore-filename-regex src/bin/
 
       - name: Build project
         if: github.event_name == 'workflow_dispatch' && github.ref_type == 'tag'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,7 @@ aes-gcm = "0.10.3"
 
 [build-dependencies]
 bindgen = "0.71.1"
+
+[dev-dependencies]
+virtio-queue = { version = "0.14.0", features = ["test-utils"] }
+vm-memory = { version = "0.16.1", features = ["backend-mmap", "backend-atomic"] }


### PR DESCRIPTION
## Summary
- add dev dependencies for test helpers
- ignore local isa-l_crypto build artifacts
- add comprehensive unit tests for request parsing

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6841e373d0e883279e41221ba71a92cb