### PR TITLE
Improve bdev_uring coverage

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,7 @@ jobs:
         run: cargo install cargo-llvm-cov --locked
 
       - name: Run tests with coverage
-        run: cargo llvm-cov --fail-under-lines 62 --ignore-filename-regex src/bin/
+        run: cargo llvm-cov --fail-under-lines 63 --ignore-filename-regex src/bin/
 
       - name: Build project
         if: github.event_name == 'workflow_dispatch' && github.ref_type == 'tag'


### PR DESCRIPTION
## Summary
- comment existing bdev_uring tests
- add tests for busy/flush logic, queue overflow, and invalid path
- ignore `isa-l_crypto` directory in git

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6841e7fa677c832780c28fe22ddbbf9b