### PR TITLE
Add additional bdev_crypt tests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,7 @@ jobs:
         run: cargo install cargo-llvm-cov --locked
 
       - name: Run tests with coverage
-        run: cargo llvm-cov --fail-under-lines 60 --ignore-filename-regex src/bin/
+        run: cargo llvm-cov --fail-under-lines 62 --ignore-filename-regex src/bin/
 
       - name: Build project
         if: github.event_name == 'workflow_dispatch' && github.ref_type == 'tag'

--- a/src/block_device/bdev_crypt.rs
+++ b/src/block_device/bdev_crypt.rs
@@ -467,4 +467,105 @@ mod tests {
             CryptBlockDevice::new(Box::new(base), key1.clone(), key2.clone(), kek);
         assert!(matches!(result, Err(VhostUserBlockError::InvalidParameter { .. })));
     }
+
+    #[test]
+    fn test_missing_kek_parameters() {
+        let kek = KeyEncryptionCipher {
+            method: CipherMethod::Aes256Gcm,
+            key: None,
+            init_vector: None,
+            auth_data: None,
+        };
+        let base = TestBlockDevice::new(1024 * 1024);
+        let key1 = vec![0u8; 32];
+        let key2 = vec![0u8; 32];
+
+        let result = CryptBlockDevice::new(Box::new(base), key1, key2, kek);
+        assert!(matches!(result, Err(VhostUserBlockError::InvalidParameter { .. })));
+    }
+
+    #[test]
+    fn test_invalid_iv_length() {
+        let kek = KeyEncryptionCipher {
+            method: CipherMethod::Aes256Gcm,
+            key: Some(vec![0u8; 32]),
+            init_vector: Some(vec![0u8; 8]),
+            auth_data: Some(vec![]),
+        };
+        let base = TestBlockDevice::new(1024 * 1024);
+        let key1 = vec![0u8; 48];
+        let key2 = vec![0u8; 48];
+
+        let result = CryptBlockDevice::new(Box::new(base), key1, key2, kek);
+        assert!(matches!(result, Err(VhostUserBlockError::InvalidParameter { .. })));
+    }
+
+    #[test]
+    fn test_get_initial_tweak() {
+        let base = TestBlockDevice::new(1024 * 1024);
+        let base_chan = base.create_channel().unwrap();
+        let chan = CryptIoChannel::new(base_chan, [1u8; 32], [2u8; 32]);
+
+        let sector = 0x1122_3344_5566_7788u64;
+        let tweak = chan.get_initial_tweak(sector);
+
+        assert_eq!(&tweak[0..8], &[0u8; 8]);
+        assert_eq!(&tweak[8..16], &sector.to_le_bytes());
+    }
+
+    #[test]
+    fn test_decrypt_block_failure() {
+        use aes_gcm::Aes256Gcm;
+
+        let cipher = Aes256Gcm::new_from_slice(&[0u8; 32]).unwrap();
+        let nonce = GenericArray::from_slice(&[0u8; 12]);
+        let enc = vec![0u8; 48];
+
+        let res = decrypt_block(&cipher, nonce, &[], &enc);
+        assert!(matches!(res, Err(VhostUserBlockError::InvalidParameter { .. })));
+    }
+
+    #[test]
+    fn test_sector_count() {
+        let base = TestBlockDevice::new(1024 * 1024);
+        let bdev = CryptBlockDevice::new(
+            Box::new(base),
+            vec![0u8; 32],
+            vec![0u8; 32],
+            KeyEncryptionCipher {
+                method: CipherMethod::None,
+                key: None,
+                init_vector: None,
+                auth_data: None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(bdev.sector_count(), 2048);
+    }
+
+    #[test]
+    fn test_invalid_kek_key_length() {
+        let kek = KeyEncryptionCipher {
+            method: CipherMethod::Aes256Gcm,
+            key: Some(vec![0u8; 31]),
+            init_vector: Some(vec![0u8; 12]),
+            auth_data: Some(vec![]),
+        };
+        let base = TestBlockDevice::new(1024 * 1024);
+        let res = CryptBlockDevice::new(Box::new(base), vec![0u8; 32], vec![0u8; 32], kek);
+        assert!(matches!(res, Err(VhostUserBlockError::InvalidParameter { .. })));
+    }
+
+    #[test]
+    fn test_decrypt_block_bad_plain_length() {
+        use aes_gcm::{Aes256Gcm, KeyInit};
+        let cipher = Aes256Gcm::new_from_slice(&[0u8; 32]).unwrap();
+        let nonce = GenericArray::from_slice(&[0u8; 12]);
+        let data = [1u8; 8];
+        let enc = cipher.encrypt(nonce, Payload { msg: &data, aad: b"" }).unwrap();
+
+        let res = decrypt_block(&cipher, nonce, b"", &enc);
+        assert!(matches!(res, Err(VhostUserBlockError::InvalidParameter { .. })));
+    }
 }


### PR DESCRIPTION
## Summary
- extend bdev_crypt test coverage to reach ~95%
- new tests validate sector count, cipher init failures, and bad plaintext length

## Testing
- `cargo test -- --nocapture`
- `cargo tarpaulin --timeout 120 --out Stdout --skip-clean`

------
https://chatgpt.com/codex/tasks/task_e_68411b442598832789a551fe9eafee67