### PR TITLE
Add configurable device ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The configuration YAML must define:
 - `copy_on_read`: (Optional) Copy stripes from the image only when accessed.
 - `encryption_key`: (Optional) AES-XTS keys provided as base64 encoded strings.
 - `io_debug_path`: (Optional) Path for I/O debug log.
+- `device_id`: (Optional) Identifier returned to the guest for GET_ID.
 
 **Examples:**
 ```bash
@@ -73,6 +74,7 @@ poll_queue_timeout_us: 500               # Integer: poll timeout in microseconds
 io_debug_path: "/tmp/io_debug.log"       # Optional: path for I/O debug log
 skip_sync: false                         # Optional: skip flush handling
 copy_on_read: false                      # Optional: copy stripes on first read
+device_id: "ubiblk"                      # Optional: device identifier
 encryption_key:                          # Optional: AES‐XTS keys (base64 encoded)
   - "x74Yhe/ovgxY4BrBaM6Wm/9firf9k/N+ayvGsskBo+hjQtrL+nslCDC5oR/HpSDL"
   - "TJn65Jb//AYqu/a8zlpb0IlXC4vwFQ5DtbQkMTeliEAwafr0DEH+5hNro8FuVzQ+"

--- a/src/vhost_backend/backend.rs
+++ b/src/vhost_backend/backend.rs
@@ -437,10 +437,14 @@ mod tests {
             skip_sync: false,
             copy_on_read: false,
             encryption_key: None,
+            device_id: "ubiblk".to_string(),
         };
         let mem = GuestMemoryAtomic::new(GuestMemoryMmap::new());
         let block_device = Box::new(TestBlockDevice::new(SECTOR_SIZE as u64 * 8));
         let result = UbiBlkBackend::new(&options, mem, block_device);
-        assert!(matches!(result, Err(VhostUserBlockError::InvalidParameter { .. })));
+        assert!(matches!(
+            result,
+            Err(VhostUserBlockError::InvalidParameter { .. })
+        ));
     }
 }

--- a/src/vhost_backend/backend_thread.rs
+++ b/src/vhost_backend/backend_thread.rs
@@ -45,6 +45,7 @@ pub struct UbiBlkBackendThread {
     request_slots: Vec<RequestSlot>,
     io_debug_file: Option<fs::File>,
     skip_sync: bool,
+    device_id: String,
 }
 
 impl UbiBlkBackendThread {
@@ -96,6 +97,7 @@ impl UbiBlkBackendThread {
             request_slots,
             io_debug_file,
             skip_sync: options.skip_sync,
+            device_id: options.device_id.clone(),
         })
     }
 
@@ -339,7 +341,7 @@ impl UbiBlkBackendThread {
         vring: &mut Vring<'_>,
     ) {
         let (data_addr, _) = request.data_descriptors[0];
-        let serial = "some_id";
+        let serial = &self.device_id;
         let mem = desc_chain.memory();
         let status = if let Err(_) = mem.write_slice(serial.as_bytes(), data_addr) {
             VIRTIO_BLK_S_IOERR

--- a/src/vhost_backend/options.rs
+++ b/src/vhost_backend/options.rs
@@ -67,6 +67,10 @@ fn default_copy_on_read() -> bool {
     false
 }
 
+fn default_device_id() -> String {
+    "ubiblk".to_string()
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct Options {
     pub path: String,
@@ -98,6 +102,9 @@ pub struct Options {
 
     #[serde(default, deserialize_with = "decode_encryption_keys")]
     pub encryption_key: Option<(Vec<u8>, Vec<u8>)>,
+
+    #[serde(default = "default_device_id")]
+    pub device_id: String,
 }
 
 #[cfg(test)]
@@ -185,5 +192,6 @@ mod tests {
         "#;
         let options: Options = from_str(yaml).unwrap();
         assert!(!options.copy_on_read);
+        assert_eq!(options.device_id, "ubiblk".to_string());
     }
 }


### PR DESCRIPTION
## Summary
- allow configuring `device_id` via backend `Options`
- expose the `device_id` in `UbiBlkBackendThread`
- return the configured device ID when handling `GET_ID`
- document the new field in README
- test the default value

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68420206fa7c83278e310691cbc0573e