### PR TITLE
Add backend.rs tests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,7 @@ jobs:
         run: cargo install cargo-llvm-cov --locked
 
       - name: Run tests with coverage
-        run: cargo llvm-cov --fail-under-lines 70 --ignore-filename-regex src/bin/
+        run: cargo llvm-cov --fail-under-lines 77 --ignore-filename-regex src/bin/
 
       - name: Build project
         if: github.event_name == 'workflow_dispatch' && github.ref_type == 'tag'

--- a/src/vhost_backend/backend.rs
+++ b/src/vhost_backend/backend.rs
@@ -417,34 +417,6 @@ pub fn init_metadata(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::block_device::bdev_test::TestBlockDevice;
+mod backend_tests;
 
-    #[test]
-    fn test_invalid_queue_size() {
-        let options = Options {
-            path: "test.img".to_string(),
-            image_path: None,
-            metadata_path: None,
-            io_debug_path: None,
-            socket: "sock".to_string(),
-            num_queues: 1,
-            queue_size: 30,
-            seg_size_max: 65536,
-            seg_count_max: 4,
-            poll_queue_timeout_us: 1000,
-            skip_sync: false,
-            copy_on_read: false,
-            encryption_key: None,
-            device_id: "ubiblk".to_string(),
-        };
-        let mem = GuestMemoryAtomic::new(GuestMemoryMmap::new());
-        let block_device = Box::new(TestBlockDevice::new(SECTOR_SIZE as u64 * 8));
-        let result = UbiBlkBackend::new(&options, mem, block_device);
-        assert!(matches!(
-            result,
-            Err(VhostUserBlockError::InvalidParameter { .. })
-        ));
-    }
-}
+

--- a/src/vhost_backend/backend/backend_tests.rs
+++ b/src/vhost_backend/backend/backend_tests.rs
@@ -1,0 +1,113 @@
+#[cfg(test)]
+mod tests {
+    use super::super::{init_metadata, start_block_backend, UbiBlkBackend};
+    use crate::vhost_backend::{CipherMethod, KeyEncryptionCipher, Options, SECTOR_SIZE};
+    use crate::block_device::bdev_test::TestBlockDevice;
+    use crate::VhostUserBlockError;
+    use tempfile::NamedTempFile;
+    use vmm_sys_util::epoll::EventSet;
+    use vm_memory::{GuestMemoryAtomic, GuestMemoryMmap};
+    use virtio_bindings::virtio_blk::VIRTIO_BLK_F_FLUSH;
+    use vhost::vhost_user::message::VhostUserProtocolFeatures;
+    use vhost_user_backend::VhostUserBackend;
+
+    fn default_options(path: String) -> Options {
+        Options {
+            path,
+            image_path: None,
+            metadata_path: None,
+            io_debug_path: None,
+            socket: "sock".to_string(),
+            num_queues: 1,
+            queue_size: 32,
+            seg_size_max: 65536,
+            seg_count_max: 4,
+            poll_queue_timeout_us: 1000,
+            skip_sync: false,
+            copy_on_read: false,
+            encryption_key: None,
+            device_id: "ubiblk".to_string(),
+        }
+    }
+
+    /// Building the backend with a queue size that is not a power of two should fail.
+    #[test]
+    fn invalid_queue_size() {
+        let mut opts = default_options("test.img".to_string());
+        opts.queue_size = 30;
+        let mem = GuestMemoryAtomic::new(GuestMemoryMmap::new());
+        let block_device = Box::new(TestBlockDevice::new(SECTOR_SIZE as u64 * 8));
+        let result = UbiBlkBackend::new(&opts, mem, block_device);
+        assert!(matches!(result, Err(VhostUserBlockError::InvalidParameter { .. })));
+    }
+
+    /// Ensure a backend can be created with valid parameters and exposes expected features.
+    #[test]
+    fn backend_features_and_protocol() {
+        let opts = default_options("img".to_string());
+        let mem = GuestMemoryAtomic::new(GuestMemoryMmap::new());
+        let block_device = Box::new(TestBlockDevice::new(SECTOR_SIZE as u64 * 8));
+        let backend = UbiBlkBackend::new(&opts, mem, block_device).unwrap();
+        assert_eq!(backend.num_queues(), 1);
+        assert_eq!(backend.max_queue_size(), 32);
+
+        let features = backend.features();
+        assert!(features & (1 << VIRTIO_BLK_F_FLUSH) != 0);
+        let protocol = backend.protocol_features();
+        assert!(protocol.contains(VhostUserProtocolFeatures::CONFIG));
+    }
+
+    /// Updating event index should propagate to all worker threads.
+    #[test]
+    fn set_event_index() {
+        let opts = default_options("img".to_string());
+        let mem = GuestMemoryAtomic::new(GuestMemoryMmap::new());
+        let block_device = Box::new(TestBlockDevice::new(SECTOR_SIZE as u64 * 8));
+        let backend = UbiBlkBackend::new(&opts, mem, block_device).unwrap();
+        backend.set_event_idx(true);
+        for thread in backend.threads.iter() {
+            assert!(thread.lock().unwrap().event_idx);
+        }
+    }
+
+    /// handle_event should reject unexpected event sets.
+    #[test]
+    fn handle_event_invalid_eventset() {
+        let opts = default_options("img".to_string());
+        let mem = GuestMemoryAtomic::new(GuestMemoryMmap::new());
+        let block_device = Box::new(TestBlockDevice::new(SECTOR_SIZE as u64 * 8));
+        let backend = UbiBlkBackend::new(&opts, mem, block_device).unwrap();
+        let err = backend.handle_event(0, EventSet::OUT, &[], 0).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::Other);
+    }
+
+    /// handle_event should reject device events other than 0.
+    #[test]
+    fn handle_event_invalid_device() {
+        let opts = default_options("img".to_string());
+        let mem = GuestMemoryAtomic::new(GuestMemoryMmap::new());
+        let block_device = Box::new(TestBlockDevice::new(SECTOR_SIZE as u64 * 8));
+        let backend = UbiBlkBackend::new(&opts, mem, block_device).unwrap();
+        let err = backend.handle_event(1, EventSet::IN, &[], 0).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::Other);
+    }
+
+    /// start_block_backend should return an error when image_path is specified without metadata_path.
+    #[test]
+    fn start_backend_missing_metadata() {
+        let tmp = NamedTempFile::new().unwrap();
+        tmp.as_file().set_len(SECTOR_SIZE as u64 * 8).unwrap();
+        let mut opts = default_options(tmp.path().to_string_lossy().to_string());
+        opts.image_path = Some("img2".to_string());
+        let res = start_block_backend(&opts, KeyEncryptionCipher { method: CipherMethod::None, key: None, init_vector: None, auth_data: None });
+        assert!(res.is_err());
+    }
+
+    /// init_metadata should fail when metadata_path is missing.
+    #[test]
+    fn init_metadata_missing_path() {
+        let opts = default_options("img".to_string());
+        let res = init_metadata(&opts, KeyEncryptionCipher { method: CipherMethod::None, key: None, init_vector: None, auth_data: None }, 4);
+        assert!(res.is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- extract existing backend.rs tests to separate file
- add more unit tests for backend.rs

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684258d8c10083279a71cb35114b7b9a