### PR TITLE
Modify print_features to return string

### DIFF
--- a/src/bin/vhost-frontend.rs
+++ b/src/bin/vhost-frontend.rs
@@ -8,7 +8,7 @@ use std::{
     path::{Path, PathBuf},
 };
 use ubiblk::utils::{
-    block::{print_features, VirtioBlockConfig},
+    block::{features_to_str, VirtioBlockConfig},
     memory::allocate_hugepage_memory,
 };
 use vhost::{
@@ -184,7 +184,7 @@ fn setup_frontend(socket: &Path) -> Result<Frontend, Box<dyn std::error::Error>>
     println!("Getting features");
     frontend.set_hdr_flags(VhostUserHeaderFlag::NEED_REPLY);
     let features = frontend.get_features()?;
-    print_features(features);
+    print!("{}", features_to_str(features));
 
     println!("Setting features");
     frontend.set_hdr_flags(VhostUserHeaderFlag::empty());

--- a/src/block_device/bdev_lazy/stripe_metadata_manager.rs
+++ b/src/block_device/bdev_lazy/stripe_metadata_manager.rs
@@ -182,7 +182,7 @@ impl StripeMetadataManager {
     }
 
     pub fn stripe_sector_count(&self) -> u64 {
-        (1 as u64) << self.metadata.stripe_sector_count_shift
+        1u64 << self.metadata.stripe_sector_count_shift
     }
 
     pub fn stripe_status(&self, stripe_id: usize) -> StripeStatus {

--- a/src/utils/block.rs
+++ b/src/utils/block.rs
@@ -37,7 +37,7 @@ pub struct VirtioBlockGeometry {
 // Ensure VirtioBlockConfig is safe for ByteValued
 unsafe impl ByteValued for VirtioBlockConfig {}
 
-pub fn print_features(features: u64) {
+pub fn features_to_str(features: u64) -> String {
     let all_features = [
         (VIRTIO_F_ACCESS_PLATFORM, "VIRTIO_F_ACCESS_PLATFORM"),
         (VIRTIO_F_ADMIN_VQ, "VIRTIO_F_ADMIN_VQ"),
@@ -73,22 +73,51 @@ pub fn print_features(features: u64) {
 
     let mut remaining_features = features;
     let mut first = true;
-    print!("Features (0x{:x}): ", features);
+    let mut output = format!("Features (0x{:x}): ", features);
     for (feature, name) in all_features.iter() {
         if remaining_features & ((1 as u64) << *feature) != 0 {
             if !first {
-                print!(" | ");
+                output.push_str(" | ");
             }
-            print!("{}", name);
+            output.push_str(name);
             first = false;
             remaining_features &= !((1 as u64) << *feature);
         }
     }
     if remaining_features != 0 {
         if !first {
-            print!(" | ");
+            output.push_str(" | ");
         }
-        print!("0x{:x}", remaining_features);
+        output.push_str(&format!("0x{:x}", remaining_features));
     }
-    println!();
+    output.push('\n');
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_features_to_str_none() {
+        assert_eq!(features_to_str(0), "Features (0x0): \n");
+    }
+
+    #[test]
+    fn test_features_to_str_known() {
+        let features = 1u64 << VIRTIO_BLK_F_FLUSH;
+        let expected = format!("Features (0x{:x}): VIRTIO_BLK_F_FLUSH\n", features);
+        assert_eq!(features_to_str(features), expected);
+    }
+
+    #[test]
+    fn test_features_to_str_mixed() {
+        let unknown = 1u64 << 63;
+        let features = (1u64 << VIRTIO_BLK_F_FLUSH) | (1u64 << VIRTIO_BLK_F_DISCARD) | unknown;
+        let expected = format!(
+            "Features (0x{:x}): VIRTIO_BLK_F_FLUSH | VIRTIO_BLK_F_DISCARD | 0x{:x}\n",
+            features, unknown
+        );
+        assert_eq!(features_to_str(features), expected);
+    }
 }

--- a/src/utils/block.rs
+++ b/src/utils/block.rs
@@ -75,13 +75,13 @@ pub fn features_to_str(features: u64) -> String {
     let mut first = true;
     let mut output = format!("Features (0x{:x}): ", features);
     for (feature, name) in all_features.iter() {
-        if remaining_features & ((1 as u64) << *feature) != 0 {
+        if remaining_features & (1u64 << *feature) != 0 {
             if !first {
                 output.push_str(" | ");
             }
             output.push_str(name);
             first = false;
-            remaining_features &= !((1 as u64) << *feature);
+            remaining_features &= !(1u64 << *feature);
         }
     }
     if remaining_features != 0 {

--- a/src/vhost_backend/backend.rs
+++ b/src/vhost_backend/backend.rs
@@ -7,7 +7,7 @@ use std::{
 
 use crate::{
     block_device::UringBlockDevice,
-    utils::block::{print_features, VirtioBlockConfig},
+    utils::block::{features_to_str, VirtioBlockConfig},
     VhostUserBlockError,
 };
 use crate::{
@@ -119,14 +119,12 @@ impl<'a> VhostUserBackend for UbiBlkBackend {
             | (1 << VIRTIO_RING_F_INDIRECT_DESC) // https://docs.oasis-open.org/virtio/virtio/v1.0/cs04/virtio-v1.0-cs04.html#x1-330003
             | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits();
 
-        print!("avail_features: ");
-        print_features(avail_features);
+        info!("avail_features: {}", features_to_str(avail_features).trim_end());
         avail_features
     }
 
     fn acked_features(&self, features: u64) {
-        info!("acked_features: 0x{:x}", features);
-        print_features(features);
+        info!("acked_features: 0x{:x} {}", features, features_to_str(features).trim_end());
     }
 
     fn protocol_features(&self) -> VhostUserProtocolFeatures {
@@ -418,5 +416,3 @@ pub fn init_metadata(
 
 #[cfg(test)]
 mod backend_tests;
-
-


### PR DESCRIPTION
## Summary
- rename `print_features` to `features_to_str`
- update frontend and backend callers
- adjust tests for the renamed helper
- log features in backend using `info!` instead of printing

## Testing
- `cargo check` *(fails: use of unstable `offset_of`)*
- `cargo test --quiet` *(fails: use of unstable `offset_of`)*

------
https://chatgpt.com/codex/tasks/task_e_684402eb5b688327a4111b25605cf9e1