### PR TITLE
Switch stripe state tracking to roaring bitmaps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ tempfile = "3.20.0"
 serde_with = { version = "3.14.0", features = ["base64"] }
 base64 = "0.22.1"
 aes-gcm = "0.10.3"
+roaring = "0.11.1"
 
 [build-dependencies]
 bindgen = "0.72.0"


### PR DESCRIPTION
## Summary
- keep track of fetched/unfetched stripes using `roaring` bitmap
- maintain queued and fetching stripes with `HashSet`
- update `StripeStatusVec` APIs

## Testing
- `cargo test -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_6877e49fe07c83279c48e7129a4322ef