### PR TITLE
Optimize encode_hex

### DIFF
--- a/src/utils/debug.rs
+++ b/src/utils/debug.rs
@@ -44,8 +44,7 @@ pub fn encode_hex(data: &[u8], len: usize) -> String {
     data[..len.min(data.len())]
         .iter()
         .map(|byte| format!("{:02x}", byte))
-        .collect::<Vec<String>>()
-        .join("")
+        .collect::<String>()
 }
 
 pub fn decode_hex(hex: &str) -> Result<Vec<u8>, String> {


### PR DESCRIPTION
## Summary
- reduce intermediate allocation in encode_hex

## Testing
- `cargo test -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_68780906c28483279fca8b1574ea8b07