### PR TITLE
Handle backend errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,8 @@ pub enum VhostUserBlockError {
     InvalidParameter { description: String },
     #[error("Metadata error: {description}")]
     MetadataError { description: String },
+    #[error("Backend thread failure")]
+    BackendThreadFailure,
 }
 
 pub type Result<T> = std::result::Result<T, VhostUserBlockError>;


### PR DESCRIPTION
## Summary
- add `BackendThreadFailure` error variant
- stop unwrapping backend thread locks
- handle errors when enabling notifications or cloning kill event
- return errors on stripe fetcher join failures

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687808e2b274832786cc12b6351b31f8