### PR TITLE
Add default KeyEncryptionCipher

### DIFF
--- a/src/bin/init-metadata.rs
+++ b/src/bin/init-metadata.rs
@@ -62,12 +62,7 @@ fn main() {
         }
     };
 
-    let mut kek = KeyEncryptionCipher {
-        method: CipherMethod::None,
-        key: None,
-        init_vector: None,
-        auth_data: None,
-    };
+    let mut kek = KeyEncryptionCipher::default();
 
     let stripe_sector_count_shift = cmd_arguments
         .get_one::<u8>("stripe-sector-count-shift")

--- a/src/bin/vhost-backend.rs
+++ b/src/bin/vhost-backend.rs
@@ -57,12 +57,7 @@ fn main() {
         process::exit(1);
     }
 
-    let mut kek = KeyEncryptionCipher {
-        method: CipherMethod::None,
-        key: None,
-        init_vector: None,
-        auth_data: None,
-    };
+    let mut kek = KeyEncryptionCipher::default();
 
     if let Some(kek_path) = cmd_arguments.get_one::<String>("kek") {
         let file = match File::open(kek_path) {

--- a/src/block_device/bdev_crypt.rs
+++ b/src/block_device/bdev_crypt.rs
@@ -297,12 +297,7 @@ mod tests {
 
     #[test]
     fn test_crypt_block_device() {
-        let kek = KeyEncryptionCipher {
-            method: CipherMethod::None,
-            key: None,
-            init_vector: None,
-            auth_data: None,
-        };
+        let kek = KeyEncryptionCipher::default();
         let base = TestBlockDevice::new(1024 * 1024);
         let metrics = base.metrics.clone();
         let mem = base.mem.clone();
@@ -386,12 +381,7 @@ mod tests {
 
     #[test]
     fn test_invalid_key_length() {
-        let kek = KeyEncryptionCipher {
-            method: CipherMethod::None,
-            key: None,
-            init_vector: None,
-            auth_data: None,
-        };
+        let kek = KeyEncryptionCipher::default();
         let base = TestBlockDevice::new(1024 * 1024);
         let key1 = [
             1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103,
@@ -475,9 +465,7 @@ mod tests {
     fn test_missing_kek_parameters() {
         let kek = KeyEncryptionCipher {
             method: CipherMethod::Aes256Gcm,
-            key: None,
-            init_vector: None,
-            auth_data: None,
+            ..Default::default()
         };
         let base = TestBlockDevice::new(1024 * 1024);
         let key1 = vec![0u8; 32];
@@ -544,12 +532,7 @@ mod tests {
             Box::new(base),
             vec![0u8; 32],
             vec![0u8; 32],
-            KeyEncryptionCipher {
-                method: CipherMethod::None,
-                key: None,
-                init_vector: None,
-                auth_data: None,
-            },
+            KeyEncryptionCipher::default(),
         )
         .unwrap();
 

--- a/src/vhost_backend/backend_tests.rs
+++ b/src/vhost_backend/backend_tests.rs
@@ -3,8 +3,8 @@ mod tests {
     use crate::block_device::bdev_test::TestBlockDevice;
     use crate::utils::aligned_buffer::BUFFER_ALIGNMENT;
     use crate::vhost_backend::{
-        init_metadata, start_block_backend, CipherMethod, KeyEncryptionCipher, Options,
-        UbiBlkBackend, SECTOR_SIZE,
+        init_metadata, start_block_backend, KeyEncryptionCipher, Options, UbiBlkBackend,
+        SECTOR_SIZE,
     };
     use crate::VhostUserBlockError;
     use tempfile::NamedTempFile;
@@ -106,15 +106,7 @@ mod tests {
         tmp.as_file().set_len(SECTOR_SIZE as u64 * 8).unwrap();
         let mut opts = default_options(tmp.path().to_string_lossy().to_string());
         opts.image_path = Some("img2".to_string());
-        let res = start_block_backend(
-            &opts,
-            KeyEncryptionCipher {
-                method: CipherMethod::None,
-                key: None,
-                init_vector: None,
-                auth_data: None,
-            },
-        );
+        let res = start_block_backend(&opts, KeyEncryptionCipher::default());
         assert!(res.is_err());
     }
 
@@ -122,16 +114,7 @@ mod tests {
     #[test]
     fn init_metadata_missing_path() {
         let opts = default_options("img".to_string());
-        let res = init_metadata(
-            &opts,
-            KeyEncryptionCipher {
-                method: CipherMethod::None,
-                key: None,
-                init_vector: None,
-                auth_data: None,
-            },
-            4,
-        );
+        let res = init_metadata(&opts, KeyEncryptionCipher::default(), 4);
         assert!(res.is_err());
     }
 }

--- a/src/vhost_backend/options.rs
+++ b/src/vhost_backend/options.rs
@@ -40,6 +40,17 @@ pub struct KeyEncryptionCipher {
     pub auth_data: Option<Vec<u8>>,
 }
 
+impl Default for KeyEncryptionCipher {
+    fn default() -> Self {
+        Self {
+            method: CipherMethod::None,
+            key: None,
+            init_vector: None,
+            auth_data: None,
+        }
+    }
+}
+
 fn default_poll_queue_timeout_us() -> u128 {
     1000
 }


### PR DESCRIPTION
## Summary
- add a `Default` implementation for `KeyEncryptionCipher`
- use the new default helper in CLI tools and tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6880323049b083279a79e0971fc205b9