### PR TITLE
Improve adherence to Rust idioms

### DIFF
--- a/src/block_device/bdev_crypt.rs
+++ b/src/block_device/bdev_crypt.rs
@@ -65,8 +65,7 @@ impl CryptIoChannel {
         for i in 0..sector_count as usize {
             let sector = sector_start + i as u64;
             let mut tweak = self.get_initial_tweak(sector);
-            let sector_data =
-                &mut buf[(i * SECTOR_SIZE) as usize..((i + 1) * SECTOR_SIZE) as usize];
+            let sector_data = &mut buf[i * SECTOR_SIZE..(i + 1) * SECTOR_SIZE];
             unsafe {
                 XTS_AES_256_dec(
                     self.key2.as_mut_ptr(),
@@ -84,8 +83,7 @@ impl CryptIoChannel {
         for i in 0..sector_count as usize {
             let sector = sector_start + i as u64;
             let mut tweak = self.get_initial_tweak(sector);
-            let sector_data =
-                &mut buf[((i * SECTOR_SIZE) as usize)..((i + 1) * SECTOR_SIZE) as usize];
+            let sector_data = &mut buf[i * SECTOR_SIZE..(i + 1) * SECTOR_SIZE];
             unsafe {
                 XTS_AES_256_enc(
                     self.key2.as_mut_ptr(),
@@ -165,7 +163,7 @@ pub struct CryptBlockDevice {
 impl BlockDevice for CryptBlockDevice {
     fn create_channel(&self) -> Result<Box<dyn IoChannel>> {
         let base_channel = self.base.create_channel()?;
-        let crypt_channel = CryptIoChannel::new(base_channel, self.key1.clone(), self.key2.clone());
+        let crypt_channel = CryptIoChannel::new(base_channel, self.key1, self.key2);
         Ok(Box::new(crypt_channel))
     }
 
@@ -182,11 +180,7 @@ impl CryptBlockDevice {
         kek: KeyEncryptionCipher,
     ) -> Result<Box<Self>> {
         let (key1, key2) = decrypt_keys(key1, key2, kek)?;
-        Ok(Box::new(CryptBlockDevice {
-            base,
-            key1: key1,
-            key2: key2,
-        }))
+        Ok(Box::new(CryptBlockDevice { base, key1, key2 }))
     }
 }
 

--- a/src/block_device/bdev_lazy/stripe_fetcher.rs
+++ b/src/block_device/bdev_lazy/stripe_fetcher.rs
@@ -85,7 +85,7 @@ impl StripeFetcher {
             metadata_manager,
             fetch_queue: VecDeque::new(),
             req_mpsc_pairs: vec![],
-            fetch_buffers: fetch_buffers,
+            fetch_buffers,
             stripes_fetched: 0,
             pending_flush_requests: vec![],
             inprogress_flush_requests: vec![],
@@ -186,7 +186,7 @@ impl StripeFetcher {
             .min(self.target_sector_count - stripe_sector_offset);
 
         self.fetch_target_channel.add_write(
-            stripe_sector_offset as u64,
+            stripe_sector_offset,
             stripe_sector_count as u32,
             buf,
             buffer_idx,
@@ -295,7 +295,7 @@ impl StripeFetcher {
             self.finish_flush(success);
         }
 
-        if self.pending_flush_requests.len() > 0 && self.inprogress_flush_requests.is_empty() {
+        if !self.pending_flush_requests.is_empty() && self.inprogress_flush_requests.is_empty() {
             self.inprogress_flush_requests = self.pending_flush_requests.clone();
             self.pending_flush_requests.clear();
 

--- a/src/block_device/bdev_lazy/stripe_metadata_manager.rs
+++ b/src/block_device/bdev_lazy/stripe_metadata_manager.rs
@@ -31,8 +31,7 @@ pub struct StripeStatusVec {
 
 impl StripeStatusVec {
     pub fn sector_to_stripe_id(&self, sector: u64) -> usize {
-        let stripe_id = (sector / self.stripe_sector_count) as usize;
-        stripe_id
+        (sector / self.stripe_sector_count) as usize
     }
 
     pub fn stripe_status(&self, stripe_id: usize) -> StripeStatus {
@@ -93,11 +92,11 @@ impl UbiMetadata {
 
     pub fn write(&self, ch: &mut Box<dyn IoChannel>) -> Result<()> {
         let metadata_size = std::mem::size_of::<UbiMetadata>();
-        let sectors = (metadata_size + SECTOR_SIZE - 1) / SECTOR_SIZE;
+        let sectors = metadata_size.div_ceil(SECTOR_SIZE);
         let buf = Rc::new(RefCell::new(AlignedBuf::new(sectors * SECTOR_SIZE)));
 
         unsafe {
-            let src = &*self as *const UbiMetadata as *const u8;
+            let src = self as *const UbiMetadata as *const u8;
             let dst = buf.borrow_mut().as_mut_ptr();
             copy_nonoverlapping(src, dst, metadata_size);
         }


### PR DESCRIPTION
## Summary
- remove unnecessary clones and casts
- collapse nested `else if` blocks
- use `div_ceil`, `is_empty`, and other tidy improvements
- fix debug file open options
- simplify optional logging writes

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6880323049b083279a79e0971fc205b9