### PR TITLE
Improve io_uring and sync channel error handling

### DIFF
--- a/src/block_device/bdev_sync.rs
+++ b/src/block_device/bdev_sync.rs
@@ -71,11 +71,11 @@ impl IoChannel for SyncIoChannel {
 
     fn add_flush(&mut self, id: usize) {
         let mut file = self.file.lock().unwrap();
-        if let Err(_) = file.flush() {
+        if file.flush().is_err() {
             self.finished_requests.push((id, false));
             return;
         }
-        if let Err(_) = file.sync_all() {
+        if file.sync_all().is_err() {
             self.finished_requests.push((id, false));
             return;
         }

--- a/src/block_device/bdev_uring.rs
+++ b/src/block_device/bdev_uring.rs
@@ -61,7 +61,7 @@ impl IoChannel for UringIoChannel {
             .build()
             .user_data(id as u64);
         let push_result = unsafe { self.ring.submission().push(&read_e) };
-        if let Err(_) = push_result {
+        if push_result.is_err() {
             self.finished_requests.push((id, false));
             return;
         }
@@ -78,7 +78,7 @@ impl IoChannel for UringIoChannel {
                 .build()
                 .user_data(id as u64);
         let push_result = unsafe { self.ring.submission().push(&write_e) };
-        if let Err(_) = push_result {
+        if push_result.is_err() {
             self.finished_requests.push((id, false));
             return;
         }
@@ -91,7 +91,7 @@ impl IoChannel for UringIoChannel {
             .build()
             .user_data(id as u64);
         let push_result = unsafe { self.ring.submission().push(&flush_e) };
-        if let Err(_) = push_result {
+        if push_result.is_err() {
             self.finished_requests.push((id, false));
             return;
         }

--- a/src/vhost_backend/backend_thread.rs
+++ b/src/vhost_backend/backend_thread.rs
@@ -190,7 +190,7 @@ impl UbiBlkBackendThread {
             let desc_chain = req.desc_chain.clone().unwrap();
             let mut write_to_guest_failed = false;
             if req.request_type == RequestType::In && success {
-                if let Err(_) = self.write_to_guest(req) {
+                if self.write_to_guest(req).is_err() {
                     write_to_guest_failed = true;
                 }
                 finished_reads.push(request_id);


### PR DESCRIPTION
## Summary
- use `is_err()` for simple `Result` checks in `bdev_uring` and `bdev_sync`
- simplify `write_to_guest` error check in backend thread

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68803631e6248327aa999d31e7e9cf0b