### PR TITLE
Use clap derive for CLI tools

### DIFF
--- a/src/bin/vhost-backend.rs
+++ b/src/bin/vhost-backend.rs
@@ -1,40 +1,37 @@
-use clap::{Arg, Command};
+use clap::Parser;
 use log::error;
 use serde_yaml;
 use std::fs::File;
 use std::process;
 use ubiblk::vhost_backend::*;
 
+#[derive(Parser)]
+#[command(
+    name = "vhost-user-blk backend",
+    version,
+    author,
+    about = "Launch a vhost-user-blk backend using a config file."
+)]
+struct Args {
+    /// Path to the configuration YAML file.
+    #[arg(short = 'f', long = "config")]
+    config: String,
+
+    /// Path to the key encryption key file.
+    #[arg(short = 'k', long = "kek")]
+    kek: Option<String>,
+
+    /// Unlink the key encryption key file after use.
+    #[arg(short = 'u', long = "unlink-kek", default_value_t = false)]
+    unlink_kek: bool,
+}
+
 fn main() {
     env_logger::builder().format_timestamp(None).init();
 
-    let cmd_arguments = Command::new("vhost-user-blk backend")
-        .version(env!("CARGO_PKG_VERSION"))
-        .author(env!("CARGO_PKG_AUTHORS"))
-        .about("Launch a vhost-user-blk backend using a config file.")
-        .arg(
-            Arg::new("config")
-                .short('f')
-                .long("config")
-                .required(true)
-                .help("Path to the configuration YAML file."),
-        )
-        .arg(
-            Arg::new("kek")
-                .short('k')
-                .long("kek")
-                .help("Path to the key encryption key file."),
-        )
-        .arg(
-            Arg::new("unlink-kek")
-                .short('u')
-                .long("unlink-kek")
-                .action(clap::ArgAction::SetTrue)
-                .help("Unlink the key encryption key file after use."),
-        )
-        .get_matches();
+    let args = Args::parse();
 
-    let config_path = cmd_arguments.get_one::<String>("config").unwrap();
+    let config_path = &args.config;
 
     let file = match File::open(config_path) {
         Ok(file) => file,
@@ -59,7 +56,7 @@ fn main() {
 
     let mut kek = KeyEncryptionCipher::default();
 
-    if let Some(kek_path) = cmd_arguments.get_one::<String>("kek") {
+    if let Some(kek_path) = &args.kek {
         let file = match File::open(kek_path) {
             Ok(file) => file,
             Err(e) => {
@@ -76,12 +73,10 @@ fn main() {
             }
         };
 
-        if let Some(unlink_kek) = cmd_arguments.get_one::<bool>("unlink-kek") {
-            if *unlink_kek {
-                if let Err(e) = std::fs::remove_file(kek_path) {
-                    error!("Error unlinking KEK file {}: {}", kek_path, e);
-                    process::exit(1);
-                }
+        if args.unlink_kek {
+            if let Err(e) = std::fs::remove_file(kek_path) {
+                error!("Error unlinking KEK file {}: {}", kek_path, e);
+                process::exit(1);
             }
         }
     }


### PR DESCRIPTION
## Summary
- use clap derive macros for `vhost-backend` and `init-metadata`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68814538a16483279c6eddfd25f0d001