### PR TITLE
Minor poll loop refactor

### DIFF
--- a/src/block_device/bdev_lazy/stripe_metadata_manager.rs
+++ b/src/block_device/bdev_lazy/stripe_metadata_manager.rs
@@ -333,9 +333,7 @@ impl StripeMetadataManager {
         let mut results = io_channel.poll();
         while io_channel.busy() {
             std::thread::sleep(std::time::Duration::from_millis(1));
-            for result in io_channel.poll() {
-                results.push(result);
-            }
+            results.extend(io_channel.poll());
         }
 
         if results.len() != 1 {


### PR DESCRIPTION
## Summary
- simplify metadata polling loop by using `extend`

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68815664968c8327aacdbe04c10d0f99