### PR TITLE
Improve polling performance

### DIFF
--- a/src/block_device/bdev_lazy/bdev_lazy.rs
+++ b/src/block_device/bdev_lazy/bdev_lazy.rs
@@ -246,7 +246,7 @@ impl IoChannel for LazyIoChannel {
         self.poll_stripe_fetcher();
         self.process_queued_requests();
 
-        let mut results = self.finished_requests.clone();
+        let mut results = std::mem::take(&mut self.finished_requests);
         results.extend(self.base.poll());
         if let Some(image_channel) = &mut self.image {
             results.extend(image_channel.poll());

--- a/src/block_device/bdev_sync.rs
+++ b/src/block_device/bdev_sync.rs
@@ -87,9 +87,7 @@ impl IoChannel for SyncIoChannel {
     }
 
     fn poll(&mut self) -> Vec<(usize, bool)> {
-        let finished_requests = self.finished_requests.clone();
-        self.finished_requests.clear();
-        finished_requests
+        std::mem::take(&mut self.finished_requests)
     }
 
     fn busy(&mut self) -> bool {

--- a/src/block_device/bdev_test.rs
+++ b/src/block_device/bdev_test.rs
@@ -60,9 +60,7 @@ impl IoChannel for TestIoChannel {
     }
 
     fn poll(&mut self) -> Vec<(usize, bool)> {
-        let finished_requests = self.finished_requests.clone();
-        self.finished_requests.clear();
-        finished_requests
+        std::mem::take(&mut self.finished_requests)
     }
 
     fn busy(&mut self) -> bool {

--- a/src/block_device/bdev_uring.rs
+++ b/src/block_device/bdev_uring.rs
@@ -107,8 +107,7 @@ impl IoChannel for UringIoChannel {
     }
 
     fn poll(&mut self) -> Vec<(usize, bool)> {
-        let mut finished_requests = self.finished_requests.clone();
-        self.finished_requests.clear();
+        let mut finished_requests = std::mem::take(&mut self.finished_requests);
         loop {
             let maybe_entry = { self.ring.completion().next() };
             match maybe_entry {


### PR DESCRIPTION
## Summary
- use `mem::take` to avoid cloning finished request vectors

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68817253da90832782226fb5472c873e