### PR TITLE
Improve rust idioms

### DIFF
--- a/src/block_device/bdev_uring.rs
+++ b/src/block_device/bdev_uring.rs
@@ -72,11 +72,10 @@ impl IoChannel for UringIoChannel {
         let buf = buf.borrow();
         let fd = self.file.as_raw_fd();
         let len = sector_count * SECTOR_SIZE as u32;
-        let write_e =
-            io_uring::opcode::Write::new(io_uring::types::Fd(fd), buf.as_ptr(), len as u32)
-                .offset(sector_offset * SECTOR_SIZE as u64)
-                .build()
-                .user_data(id as u64);
+        let write_e = io_uring::opcode::Write::new(io_uring::types::Fd(fd), buf.as_ptr(), len)
+            .offset(sector_offset * SECTOR_SIZE as u64)
+            .build()
+            .user_data(id as u64);
         let push_result = unsafe { self.ring.submission().push(&write_e) };
         if push_result.is_err() {
             self.finished_requests.push((id, false));

--- a/src/utils/aligned_buffer.rs
+++ b/src/utils/aligned_buffer.rs
@@ -59,6 +59,11 @@ impl AlignedBuf {
     pub fn len(&self) -> usize {
         self.len
     }
+
+    /// Returns true if the buffer has a length of zero.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
 }
 
 impl Clone for AlignedBuf {

--- a/src/vhost_backend/backend.rs
+++ b/src/vhost_backend/backend.rs
@@ -52,7 +52,7 @@ impl UbiBlkBackend {
     }
 }
 
-impl<'a> UbiBlkBackend {
+impl UbiBlkBackend {
     pub fn new(
         options: &Options,
         mem: GuestMemoryAtomic<GuestMemoryMmap>,
@@ -124,7 +124,7 @@ impl<'a> UbiBlkBackend {
 //
 // You can find CloudHypervisor's code at
 // https://github.com/cloud-hypervisor/cloud-hypervisor
-impl<'a> VhostUserBackend for UbiBlkBackend {
+impl VhostUserBackend for UbiBlkBackend {
     type Bitmap = BitmapMmapRegion;
     type Vring = VringRwLock<GuestMemoryAtomic<GuestMemoryMmap>>;
 
@@ -199,10 +199,10 @@ impl<'a> VhostUserBackend for UbiBlkBackend {
         thread_id: usize,
     ) -> std::result::Result<(), std::io::Error> {
         if evset != EventSet::IN {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("Invalid event set: {:?}", evset),
-            ));
+            return Err(std::io::Error::other(format!(
+                "Invalid event set: {:?}",
+                evset
+            )));
         }
 
         let mut thread = self.threads[thread_id].lock().unwrap();
@@ -242,10 +242,10 @@ impl<'a> VhostUserBackend for UbiBlkBackend {
 
                 Ok(())
             }
-            _ => Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("Invalid device event: {}", device_event),
-            )),
+            _ => Err(std::io::Error::other(format!(
+                "Invalid device event: {}",
+                device_event
+            ))),
         }
     }
 
@@ -383,19 +383,19 @@ pub fn start_block_backend(
 
     let name = "ubiblk-backend";
     let mut daemon = VhostUserDaemon::new(name.to_string(), backend.clone(), mem).map_err(|e| {
-        Box::new(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            format!("VhostUserDaemon::new error: {:?}", e),
-        ))
+        Box::new(std::io::Error::other(format!(
+            "VhostUserDaemon::new error: {:?}",
+            e
+        )))
     })?;
 
     info!("Daemon is created!");
 
     if let Err(e) = daemon.serve(&options.socket) {
-        return Err(Box::new(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            format!("VhostUserDaemon::wait error: {:?}", e),
-        )));
+        return Err(Box::new(std::io::Error::other(format!(
+            "VhostUserDaemon::wait error: {:?}",
+            e
+        ))));
     };
 
     info!("Finished serving socket!");


### PR DESCRIPTION
## Summary
- add `is_empty` helper for `AlignedBuf`
- use `div_ceil` and remove unnecessary casts in lazy stripe metadata manager
- simplify `UringIoChannel` write
- clean up lifetimes and error helpers in backend implementation

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68817253da90832782226fb5472c873e