### PR TITLE
Req/response mpsc channel refactor.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,7 +55,7 @@ jobs:
         run: cargo install cargo-llvm-cov --locked
 
       - name: Run tests with coverage
-        run: cargo llvm-cov --fail-under-lines 77 --ignore-filename-regex src/bin/
+        run: cargo llvm-cov --fail-under-lines 78 --ignore-filename-regex src/bin/
 
       - name: Build project
         if: github.event_name == 'workflow_dispatch' && github.ref_type == 'tag'


### PR DESCRIPTION
Now bdev_lazy doesn't receive responses. Queued requests wait until the desired state is achieved. In future we might add a timeout.