### PR TITLE
Allow building without isa-l_crypto

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,6 +57,9 @@ jobs:
       - name: Run tests with coverage
         run: cargo llvm-cov --fail-under-lines 78 --ignore-filename-regex src/bin/
 
+      - name: Run tests without isa-l_crypto
+        run: cargo test --features disable-isal-crypto
+
       - name: Build project
         if: github.event_name == 'workflow_dispatch' && github.ref_type == 'tag'
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ tempfile = "3.20.0"
 serde_with = { version = "3.14.0", features = ["base64"] }
 base64 = "0.22.1"
 aes-gcm = "0.10.3"
+aes = { version = "0.8", optional = true }
+xts-mode = { version = "0.5.1", optional = true }
 
 [build-dependencies]
 bindgen = "0.72.0"
@@ -35,3 +37,7 @@ bindgen = "0.72.0"
 [dev-dependencies]
 virtio-queue = { version = "0.16.0", features = ["test-utils"] }
 vm-memory = { version = "0.16.2", features = ["backend-mmap", "backend-atomic"] }
+
+[features]
+default = []
+disable-isal-crypto = ["aes", "xts-mode"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A block device utilities collection for virtualized environments.
 
 1. Install Rust and Cargo:
    - Follow the instructions at [rustup.rs](https://rustup.rs/).
-2. Install `isa-l_crypto`:
+2. Install `isa-l_crypto` (Optional. Recommended for higher performance):
 
 ```bash
 sudo apt-get install autoconf libtool nasm clang
@@ -16,6 +16,12 @@ cd isa-l_crypto/
 ./configure --prefix=/usr --libdir=/usr/lib
 make -j32
 sudo make install
+```
+
+If `isa-l_crypto` is not available, build using the `disable-isal-crypto` feature:
+
+```bash
+cargo build --release --features disable-isal-crypto
 ```
 
 3. Build the project:

--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,10 @@ use std::env;
 use std::path::{Path, PathBuf};
 
 fn main() {
+    if env::var_os("CARGO_FEATURE_DISABLE_ISAL_CRYPTO").is_some() {
+        return;
+    }
+
     // Link to the static version of isa-l_crypto
     println!("cargo:rustc-link-lib=static=isal_crypto");
     println!("cargo:rustc-link-search=native=/usr/lib");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
+#[cfg(not(feature = "disable-isal-crypto"))]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 pub mod block_device;


### PR DESCRIPTION
Added optional dependencies and a feature named “disable-isal-crypto” to allow using the pure Rust xts-mode implementation instead of isa-l_crypto. This is useful for developer environments which don't support isa-l_crypto.