### PR TITLE
Refactor metadata write function

### DIFF
--- a/src/block_device/bdev_lazy/bdev_lazy_tests.rs
+++ b/src/block_device/bdev_lazy/bdev_lazy_tests.rs
@@ -3,7 +3,8 @@ mod tests {
     use crate::block_device::SharedBuffer;
     use crate::block_device::{
         bdev_lazy::{
-            stripe_fetcher::SharedStripeFetcher, LazyBlockDevice, StripeFetcher, UbiMetadata,
+            init_metadata, stripe_fetcher::SharedStripeFetcher, LazyBlockDevice, StripeFetcher,
+            UbiMetadata,
         },
         bdev_test::TestBlockDevice,
         BlockDevice, IoChannel,
@@ -60,7 +61,8 @@ mod tests {
         source_dev.write(0, &tmp, SECTOR_SIZE);
 
         let mut ch = metadata_dev.create_channel().unwrap();
-        UbiMetadata::new(stripe_shift).write(&mut ch).unwrap();
+        let metadata = UbiMetadata::new(stripe_shift);
+        init_metadata(&metadata, &mut ch).unwrap();
 
         let killfd = EventFd::new(0).unwrap();
         let fetcher = Arc::new(Mutex::new(
@@ -121,7 +123,8 @@ mod tests {
         image_dev.write(0, &tmp, SECTOR_SIZE);
 
         let mut ch = metadata_dev.create_channel().unwrap();
-        UbiMetadata::new(stripe_shift).write(&mut ch).unwrap();
+        let metadata = UbiMetadata::new(stripe_shift);
+        init_metadata(&metadata, &mut ch).unwrap();
 
         let killfd = EventFd::new(0).unwrap();
         let fetcher = Arc::new(Mutex::new(
@@ -182,7 +185,8 @@ mod tests {
         let target_metrics = target_dev.metrics.clone();
 
         let mut ch = metadata_dev.create_channel().unwrap();
-        UbiMetadata::new(stripe_shift).write(&mut ch).unwrap();
+        let metadata = UbiMetadata::new(stripe_shift);
+        init_metadata(&metadata, &mut ch).unwrap();
 
         let killfd = EventFd::new(0).unwrap();
         let fetcher = Arc::new(Mutex::new(

--- a/src/block_device/bdev_lazy/metadata_init.rs
+++ b/src/block_device/bdev_lazy/metadata_init.rs
@@ -1,0 +1,70 @@
+use std::{cell::RefCell, ptr::copy_nonoverlapping, rc::Rc};
+
+use super::super::{IoChannel, UbiMetadata};
+use crate::utils::aligned_buffer::AlignedBuf;
+use crate::{vhost_backend::SECTOR_SIZE, Result, VhostUserBlockError};
+use log::{error, info};
+
+pub const METADATA_WRITE_ID: usize = 0;
+pub const METADATA_FLUSH_ID: usize = 1;
+
+fn wait_for_completion(ch: &mut Box<dyn IoChannel>, id: usize) -> Result<()> {
+    let timeout = std::time::Duration::from_secs(5);
+    let start = std::time::Instant::now();
+    let op = if id == METADATA_WRITE_ID {
+        "write"
+    } else {
+        "flush"
+    };
+    while start.elapsed() < timeout {
+        std::thread::sleep(std::time::Duration::from_millis(1));
+        if let Some((cid, success)) = ch.poll().into_iter().next() {
+            if cid != id {
+                error!("Unexpected completion ID: {}, expected {}", cid, id);
+                return Err(VhostUserBlockError::IoError {
+                    source: std::io::Error::other(format!("Unexpected ID: {}", cid)),
+                });
+            }
+            if !success {
+                error!("Failed to {} metadata", op);
+                return Err(VhostUserBlockError::IoError {
+                    source: std::io::Error::other(format!("Failed to {} metadata", op)),
+                });
+            }
+            if id == METADATA_WRITE_ID {
+                info!("Metadata written successfully, flushing...");
+            } else {
+                info!("Metadata flushed successfully");
+            }
+            return Ok(());
+        }
+    }
+    error!("Timeout while waiting for metadata {}", op);
+    Err(VhostUserBlockError::IoError {
+        source: std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            format!("Timeout while waiting for metadata {}", op),
+        ),
+    })
+}
+
+pub fn init_metadata(metadata: &UbiMetadata, ch: &mut Box<dyn IoChannel>) -> Result<()> {
+    let metadata_size = std::mem::size_of::<UbiMetadata>();
+    let sectors = metadata_size.div_ceil(SECTOR_SIZE);
+    let buf = Rc::new(RefCell::new(AlignedBuf::new(sectors * SECTOR_SIZE)));
+
+    unsafe {
+        let src = metadata as *const UbiMetadata as *const u8;
+        let dst = buf.borrow_mut().as_mut_ptr();
+        copy_nonoverlapping(src, dst, metadata_size);
+    }
+
+    ch.add_write(0, sectors as u32, buf.clone(), METADATA_WRITE_ID);
+    ch.submit()?;
+    wait_for_completion(ch, METADATA_WRITE_ID)?;
+
+    ch.add_flush(METADATA_FLUSH_ID);
+    ch.submit()?;
+    wait_for_completion(ch, METADATA_FLUSH_ID)?;
+    Ok(())
+}

--- a/src/block_device/bdev_lazy/mod.rs
+++ b/src/block_device/bdev_lazy/mod.rs
@@ -1,8 +1,10 @@
 mod bdev_lazy;
+mod metadata_init;
 mod stripe_fetcher;
 mod stripe_metadata_manager;
 
 pub use bdev_lazy::LazyBlockDevice;
+pub use metadata_init::init_metadata;
 pub use stripe_fetcher::StripeFetcher;
 pub use stripe_metadata_manager::UbiMetadata;
 

--- a/src/block_device/bdev_lazy/stripe_fetcher.rs
+++ b/src/block_device/bdev_lazy/stripe_fetcher.rs
@@ -316,7 +316,7 @@ unsafe impl Sync for StripeFetcher {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::block_device::bdev_lazy::stripe_metadata_manager::UbiMetadata;
+    use crate::block_device::bdev_lazy::{init_metadata, stripe_metadata_manager::UbiMetadata};
     use crate::block_device::bdev_test::TestBlockDevice;
     use crate::vhost_backend::SECTOR_SIZE;
     use crate::VhostUserBlockError;
@@ -331,9 +331,8 @@ mod tests {
         let mut ch = metadata_dev
             .create_channel()
             .expect("Failed to create channel");
-        UbiMetadata::new(stripe_sector_count_shift)
-            .write(&mut ch)
-            .unwrap();
+        let metadata = UbiMetadata::new(stripe_sector_count_shift);
+        init_metadata(&metadata, &mut ch).unwrap();
 
         let killfd = EventFd::new(0).unwrap();
         let mut stripe_fetcher =
@@ -426,9 +425,8 @@ mod tests {
         let mut ch = metadata_dev
             .create_channel()
             .expect("Failed to create channel");
-        UbiMetadata::new(stripe_sector_count_shift)
-            .write(&mut ch)
-            .unwrap();
+        let metadata = UbiMetadata::new(stripe_sector_count_shift);
+        init_metadata(&metadata, &mut ch).unwrap();
 
         let killfd = EventFd::new(0).unwrap();
         let res = StripeFetcher::new(&source_dev, &target_dev, &metadata_dev, killfd, 512);
@@ -451,7 +449,8 @@ mod tests {
         let mut ch = metadata_dev
             .create_channel()
             .expect("Failed to create channel");
-        UbiMetadata::new(stripe_shift).write(&mut ch).unwrap();
+        let metadata = UbiMetadata::new(stripe_shift);
+        init_metadata(&metadata, &mut ch).unwrap();
 
         let killfd = EventFd::new(0).unwrap();
         let mut stripe_fetcher =

--- a/src/block_device/mod.rs
+++ b/src/block_device/mod.rs
@@ -31,6 +31,7 @@ pub(crate) mod bdev_test;
 pub(crate) mod bdev_failing;
 
 pub use bdev_crypt::CryptBlockDevice;
+pub use bdev_lazy::init_metadata;
 pub use bdev_lazy::LazyBlockDevice;
 pub use bdev_lazy::StripeFetcher;
 pub use bdev_lazy::UbiMetadata;

--- a/src/vhost_backend/backend.rs
+++ b/src/vhost_backend/backend.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 use super::{backend_thread::UbiBlkBackendThread, KeyEncryptionCipher, Options};
-use crate::block_device::UbiMetadata;
+use crate::block_device::{init_metadata as init_metadata_file, UbiMetadata};
 use crate::utils::aligned_buffer::BUFFER_ALIGNMENT;
 use crate::Result;
 use log::{debug, error, info};
@@ -459,6 +459,6 @@ pub fn init_metadata(
     let metadata_bdev = build_block_device(&metadata_path, config, kek.clone())?;
     let mut ch = metadata_bdev.create_channel()?;
     let metadata = UbiMetadata::new(stripe_sector_count_shift);
-    metadata.write(&mut ch)?;
+    init_metadata_file(&metadata, &mut ch)?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- extract metadata writing logic into a new `metadata_init` module
- use `write_metadata` throughout the codebase
- expose the new function via public API

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6886a5e255288327b85dc867536105d3