### PR TITLE
Make IoChannel::busy immutable

### DIFF
--- a/src/block_device/bdev_crypt.rs
+++ b/src/block_device/bdev_crypt.rs
@@ -192,7 +192,7 @@ impl IoChannel for CryptIoChannel {
         results
     }
 
-    fn busy(&mut self) -> bool {
+    fn busy(&self) -> bool {
         self.base.busy()
     }
 }

--- a/src/block_device/bdev_failing.rs
+++ b/src/block_device/bdev_failing.rs
@@ -65,7 +65,7 @@ impl IoChannel for FailingIoChannel {
         results
     }
 
-    fn busy(&mut self) -> bool {
+    fn busy(&self) -> bool {
         self.inner.busy()
     }
 }

--- a/src/block_device/bdev_lazy/device.rs
+++ b/src/block_device/bdev_lazy/device.rs
@@ -269,8 +269,8 @@ impl IoChannel for LazyIoChannel {
         results
     }
 
-    fn busy(&mut self) -> bool {
-        let image_busy = if let Some(image_channel) = &mut self.image {
+    fn busy(&self) -> bool {
+        let image_busy = if let Some(image_channel) = self.image.as_ref() {
             image_channel.busy()
         } else {
             false

--- a/src/block_device/bdev_sync.rs
+++ b/src/block_device/bdev_sync.rs
@@ -111,7 +111,7 @@ impl IoChannel for SyncIoChannel {
         std::mem::take(&mut self.finished_requests)
     }
 
-    fn busy(&mut self) -> bool {
+    fn busy(&self) -> bool {
         false
     }
 }

--- a/src/block_device/bdev_test.rs
+++ b/src/block_device/bdev_test.rs
@@ -63,7 +63,7 @@ impl IoChannel for TestIoChannel {
         std::mem::take(&mut self.finished_requests)
     }
 
-    fn busy(&mut self) -> bool {
+    fn busy(&self) -> bool {
         false
     }
 }

--- a/src/block_device/bdev_uring.rs
+++ b/src/block_device/bdev_uring.rs
@@ -127,7 +127,7 @@ impl IoChannel for UringIoChannel {
         finished_requests
     }
 
-    fn busy(&mut self) -> bool {
+    fn busy(&self) -> bool {
         self.submissions > self.completions
     }
 }

--- a/src/block_device/mod.rs
+++ b/src/block_device/mod.rs
@@ -11,7 +11,7 @@ pub trait IoChannel {
     fn submit(&mut self) -> Result<()>;
 
     fn poll(&mut self) -> Vec<(usize, bool)>;
-    fn busy(&mut self) -> bool;
+    fn busy(&self) -> bool;
 }
 
 pub trait BlockDevice {


### PR DESCRIPTION
## Summary
- update IoChannel trait so busy does not require `&mut self`
- adjust all IoChannel implementations and users

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68893ff6ca508327bba63992ae373558