### PR TITLE
Simplify stripe_fetcher

### DIFF
--- a/src/block_device/bdev_lazy/stripe_fetcher.rs
+++ b/src/block_device/bdev_lazy/stripe_fetcher.rs
@@ -117,7 +117,6 @@ pub struct StripeFetcher {
     stripe_sector_count: u64,
     fetch_queue: VecDeque<usize>,
     fetch_buffers: Vec<FetchBuffer>,
-    stripes_fetched: usize,
     stripe_status_vec: StripeStatusVec,
 }
 
@@ -163,7 +162,6 @@ impl StripeFetcher {
             stripe_sector_count,
             fetch_queue: VecDeque::new(),
             fetch_buffers,
-            stripes_fetched: 0,
             stripe_status_vec,
         })
     }
@@ -210,7 +208,6 @@ impl StripeFetcher {
         if success {
             self.stripe_status_vec
                 .set_stripe_status(stripe_id, StripeStatus::Fetched);
-            self.stripes_fetched += 1;
         } else {
             self.stripe_status_vec
                 .set_stripe_status(stripe_id, StripeStatus::Failed);


### PR DESCRIPTION
## Summary
- remove unused `stripes_fetched` field from `StripeFetcher`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo test --features disable-isal-crypto`

------
https://chatgpt.com/codex/tasks/task_e_6889d3d9475883279df07688f411cd5e