### PR TITLE
Improve CI with cargo cache

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,6 +45,17 @@ jobs:
             override: true
             components: rustfmt, clippy
 
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ matrix.target }}-
+
       - name: Add musl target
         run: rustup target add ${{ matrix.target }}
 


### PR DESCRIPTION
## Summary
- cache dependencies in GitHub Actions to reduce build time

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo test --features disable-isal-crypto`


------
https://chatgpt.com/codex/tasks/task_e_688ad4d22dd88327b61fc877e3ddf043