### PR TITLE
Consolidate metadata handling into a single structure.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ base64 = "0.22.1"
 aes-gcm = "0.10.3"
 aes = { version = "0.8", optional = true }
 xts-mode = { version = "0.5.1", optional = true }
+static_assertions = "1.1.0"
 
 [build-dependencies]
 bindgen = "0.72.0"

--- a/src/block_device/bdev_lazy/bdev_lazy_tests.rs
+++ b/src/block_device/bdev_lazy/bdev_lazy_tests.rs
@@ -196,8 +196,6 @@ mod tests {
         chan.submit().unwrap();
 
         // Without running the bgworker, the flush should remain pending.
-        assert!(chan.poll().is_empty());
-        assert!(chan.busy());
         assert_eq!(target_metrics.read().unwrap().flushes, 0);
         // Only the initial metadata write has been flushed so far.
         assert_eq!(metadata_dev.flushes(), 1);

--- a/src/block_device/bdev_lazy/metadata/load.rs
+++ b/src/block_device/bdev_lazy/metadata/load.rs
@@ -1,15 +1,18 @@
 use crate::{
-    block_device::{bdev_lazy::metadata::UBI_MAGIC, AlignedBuf, IoChannel, UbiMetadata},
+    block_device::{
+        bdev_lazy::metadata::{UBI_MAGIC, UBI_MAX_STRIPES},
+        AlignedBuf, IoChannel, UbiMetadata,
+    },
     vhost_backend::SECTOR_SIZE,
     Result, VhostUserBlockError,
 };
 use log::{error, info};
-use std::{cell::RefCell, mem::MaybeUninit, ptr::copy_nonoverlapping, rc::Rc};
+use std::{cell::RefCell, rc::Rc};
 
 pub fn load_metadata(io_channel: &mut Box<dyn IoChannel>) -> Result<Box<UbiMetadata>> {
     info!("Loading metadata from device");
 
-    let sector_count = std::mem::size_of::<UbiMetadata>().div_ceil(SECTOR_SIZE);
+    let sector_count = (1024 + UBI_MAX_STRIPES).div_ceil(SECTOR_SIZE);
     let buf: Rc<RefCell<AlignedBuf>> =
         Rc::new(RefCell::new(AlignedBuf::new(sector_count * SECTOR_SIZE)));
     io_channel.add_read(0, sector_count as u32, buf.clone(), 0);
@@ -46,17 +49,7 @@ pub fn load_metadata(io_channel: &mut Box<dyn IoChannel>) -> Result<Box<UbiMetad
         });
     }
 
-    let mut metadata: Box<MaybeUninit<UbiMetadata>> = Box::new_uninit();
-
-    unsafe {
-        copy_nonoverlapping(
-            buf.borrow().as_ptr(),
-            metadata.as_mut_ptr() as *mut u8,
-            std::mem::size_of::<UbiMetadata>(),
-        );
-    }
-
-    let metadata: Box<UbiMetadata> = unsafe { metadata.assume_init() };
+    let metadata = UbiMetadata::from_bytes(buf.borrow().as_slice(), UBI_MAX_STRIPES);
 
     if metadata.magic != *UBI_MAGIC {
         error!(

--- a/src/block_device/bdev_lazy/metadata/mod.rs
+++ b/src/block_device/bdev_lazy/metadata/mod.rs
@@ -1,9 +1,11 @@
 mod init;
 mod load;
+mod shared_state;
 mod types;
 
 pub use init::init_metadata;
 pub use load::load_metadata;
+pub use shared_state::SharedMetadataState;
 pub use types::UbiMetadata;
 pub use types::{UBI_MAGIC, UBI_MAX_STRIPES};
 

--- a/src/block_device/bdev_lazy/metadata/shared_state.rs
+++ b/src/block_device/bdev_lazy/metadata/shared_state.rs
@@ -1,0 +1,78 @@
+use super::UbiMetadata;
+use std::sync::{
+    atomic::{AtomicU64, AtomicU8, Ordering},
+    Arc,
+};
+
+#[derive(Debug, Clone)]
+pub struct SharedMetadataState {
+    stripe_headers: Arc<Vec<AtomicU8>>,
+    metadata_version: Arc<AtomicU64>,
+    metadata_version_flushed: Arc<AtomicU64>,
+}
+
+impl SharedMetadataState {
+    pub fn new(metadata: &UbiMetadata) -> Self {
+        let stripe_headers = metadata.stripe_headers.clone();
+        // Start at version 1 so initial state is not considered flushed.
+        let metadata_version = Arc::new(AtomicU64::new(1));
+        let metadata_version_flushed = Arc::new(AtomicU64::new(0));
+
+        Self {
+            stripe_headers,
+            metadata_version,
+            metadata_version_flushed,
+        }
+    }
+
+    pub fn increment_version(&self) {
+        // Use a strong ordering here because updates to the metadata version
+        // coordinate flush operations across multiple threads.  Other callers
+        // only perform `Acquire` loads, so `SeqCst` ensures they observe the
+        // increment once the update is complete.
+        self.metadata_version.fetch_add(1, Ordering::SeqCst);
+    }
+
+    pub fn set_flushed_version(&self, version: u64) {
+        self.metadata_version_flushed
+            .store(version, Ordering::Release);
+    }
+
+    pub fn flushed_version(&self) -> u64 {
+        self.metadata_version_flushed.load(Ordering::Acquire)
+    }
+
+    pub fn current_version(&self) -> u64 {
+        self.metadata_version.load(Ordering::Acquire)
+    }
+
+    pub fn needs_flush(&self) -> bool {
+        let flushed = self.metadata_version_flushed.load(Ordering::Acquire);
+        let current = self.metadata_version.load(Ordering::Acquire);
+        current > flushed
+    }
+
+    pub fn stripe_fetched(&self, stripe_id: usize) -> bool {
+        let header = self.stripe_headers[stripe_id].load(Ordering::SeqCst);
+        header & (1 << 0) != 0
+    }
+
+    pub fn stripe_written(&self, stripe_id: usize) -> bool {
+        let header = self.stripe_headers[stripe_id].load(Ordering::SeqCst);
+        header & (1 << 1) != 0
+    }
+
+    pub fn set_stripe_fetched(&self, stripe_id: usize) {
+        let prev_header = self.stripe_headers[stripe_id].fetch_or(1 << 0, Ordering::SeqCst);
+        if prev_header & (1 << 0) == 0 {
+            self.increment_version();
+        }
+    }
+
+    pub fn set_stripe_written(&self, stripe_id: usize) {
+        let prev_header = self.stripe_headers[stripe_id].fetch_or(1 << 1, Ordering::SeqCst);
+        if prev_header & (1 << 1) == 0 {
+            self.increment_version();
+        }
+    }
+}

--- a/src/block_device/bdev_lazy/metadata/types.rs
+++ b/src/block_device/bdev_lazy/metadata/types.rs
@@ -1,8 +1,18 @@
-use std::mem::MaybeUninit;
+use std::{
+    mem::MaybeUninit,
+    ptr,
+    sync::{atomic::AtomicU8, Arc},
+};
+
+use static_assertions::const_assert;
 
 pub const UBI_MAGIC_SIZE: usize = 9;
 pub const UBI_MAX_STRIPES: usize = 2 * 1024 * 1024;
 pub const UBI_MAGIC: &[u8] = b"BDEV_UBI\0"; // 9 bytes
+
+// Ensure AtomicU8 has the same in-memory layout as u8 so we can copy headers
+// using raw byte pointers.
+const_assert!(std::mem::size_of::<AtomicU8>() == std::mem::size_of::<u8>());
 
 #[repr(C)]
 #[derive(Debug, Clone)]
@@ -17,25 +27,163 @@ pub struct UbiMetadata {
 
     // bit 0: fetched or not
     // bit 1: written or not
-    pub stripe_headers: [u8; UBI_MAX_STRIPES],
+    pub stripe_headers: Arc<Vec<AtomicU8>>,
 }
 
 impl UbiMetadata {
+    const HEADER_LEN: usize = UBI_MAGIC_SIZE + 2 + 2 + 1;
+
+    pub const fn metadata_size(stripe_count: usize) -> usize {
+        Self::HEADER_LEN + stripe_count
+    }
+
     #[cfg(test)]
     pub fn stripe_headers_offset(&self, stripe_id: usize) -> usize {
-        stripe_id + UBI_MAGIC_SIZE + 5
+        stripe_id + Self::HEADER_LEN
+    }
+
+    pub fn stripe_header(&self, stripe_id: usize) -> u8 {
+        self.stripe_headers[stripe_id].load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    pub fn set_stripe_header(&self, stripe_id: usize, value: u8) {
+        self.stripe_headers[stripe_id].store(value, std::sync::atomic::Ordering::SeqCst);
     }
 
     pub fn new(stripe_sector_count_shift: u8) -> Box<Self> {
         let mut metadata: Box<MaybeUninit<Self>> = Box::new_uninit();
+
+        let headers = (0..UBI_MAX_STRIPES)
+            .map(|_| AtomicU8::new(0))
+            .collect::<Vec<_>>();
+
         unsafe {
-            let metadata_ptr = metadata.assume_init_mut();
-            metadata_ptr.magic.copy_from_slice(UBI_MAGIC);
-            metadata_ptr.version_major.copy_from_slice(&[0, 0]);
-            metadata_ptr.version_minor.copy_from_slice(&[0, 0]);
-            metadata_ptr.stripe_sector_count_shift = stripe_sector_count_shift;
-            metadata_ptr.stripe_headers.fill(0);
+            let md = metadata.assume_init_mut();
+
+            md.magic.copy_from_slice(UBI_MAGIC);
+            md.version_major.copy_from_slice(&[0; 2]);
+            md.version_minor.copy_from_slice(&[0; 2]);
+            md.stripe_sector_count_shift = stripe_sector_count_shift;
+
+            ptr::write(&mut md.stripe_headers, Arc::new(headers));
+
+            metadata.assume_init()
         }
-        unsafe { metadata.assume_init() }
+    }
+
+    pub fn from_bytes(buf: &[u8], stripe_count: usize) -> Box<Self> {
+        // sanity check
+        let expected_len = Self::HEADER_LEN + stripe_count;
+        assert!(
+            buf.len() >= expected_len,
+            "buffer too small: {} < {}",
+            buf.len(),
+            expected_len
+        );
+
+        // copy the fixed‐size header fields
+        let mut magic = [0u8; UBI_MAGIC_SIZE];
+        magic.copy_from_slice(&buf[0..UBI_MAGIC_SIZE]);
+
+        let mut version_major = [0u8; 2];
+        version_major.copy_from_slice(&buf[UBI_MAGIC_SIZE..UBI_MAGIC_SIZE + 2]);
+
+        let mut version_minor = [0u8; 2];
+        version_minor.copy_from_slice(&buf[UBI_MAGIC_SIZE + 2..UBI_MAGIC_SIZE + 4]);
+
+        let stripe_sector_count_shift = buf[UBI_MAGIC_SIZE + 4];
+
+        // initialize all headers to zero and then copy the provided stripe data
+        let mut stripe_headers = (0..stripe_count)
+            .map(|_| AtomicU8::new(0))
+            .collect::<Vec<_>>();
+
+        // copy any stripe headers that are actually present in `buf`
+        unsafe {
+            let dst = stripe_headers.as_mut_ptr() as *mut u8;
+            let src = buf.as_ptr().add(Self::HEADER_LEN);
+            ptr::copy_nonoverlapping(src, dst, stripe_count);
+        }
+        let stripe_headers = Arc::new(stripe_headers);
+
+        // finally, box up the new struct
+        Box::new(UbiMetadata {
+            magic,
+            version_major,
+            version_minor,
+            stripe_sector_count_shift,
+            stripe_headers,
+        })
+    }
+
+    /// Serialize `self` into the given buffer
+    pub fn write_to_buf(&self, buf: &mut [u8], stripe_count: usize) {
+        let total_len: usize = Self::metadata_size(stripe_count);
+        assert!(
+            buf.len() >= total_len,
+            "buffer too small: {} < {}",
+            buf.len(),
+            total_len
+        );
+
+        let dst = buf.as_mut_ptr();
+
+        assert!(
+            stripe_count <= self.stripe_headers.len(),
+            "stripe_count {} exceeds header vector length {}",
+            stripe_count,
+            self.stripe_headers.len()
+        );
+
+        unsafe {
+            // build and copy the header
+            let mut header = [0u8; Self::HEADER_LEN];
+            header[..UBI_MAGIC_SIZE].copy_from_slice(&self.magic);
+            header[UBI_MAGIC_SIZE..UBI_MAGIC_SIZE + 2].copy_from_slice(&self.version_major);
+            header[UBI_MAGIC_SIZE + 2..UBI_MAGIC_SIZE + 4].copy_from_slice(&self.version_minor);
+            header[UBI_MAGIC_SIZE + 4] = self.stripe_sector_count_shift;
+            ptr::copy_nonoverlapping(header.as_ptr(), dst, Self::HEADER_LEN);
+
+            // Copy the stripe headers. `AtomicU8` has the same layout as `u8`
+            // on all supported platforms but this isn't explicitly guaranteed
+            // by the standard, so we assert this at compile time above.
+            let stripes_ptr = self.stripe_headers.as_ptr() as *const u8;
+            ptr::copy_nonoverlapping(stripes_ptr, dst.add(Self::HEADER_LEN), stripe_count);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ubi_metadata_serialization() {
+        const STRIPES: usize = 20;
+        let metadata = UbiMetadata::new(9);
+
+        for i in 0..STRIPES {
+            metadata.set_stripe_header(i, (i * 2) as u8);
+        }
+
+        const metadata_size: usize = UbiMetadata::metadata_size(STRIPES);
+        const buf_size: usize = metadata_size.div_ceil(512) * 512;
+
+        let mut buf = vec![0u8; buf_size];
+        metadata.write_to_buf(&mut buf, STRIPES);
+
+        let loaded_metadata = UbiMetadata::from_bytes(&buf, STRIPES);
+
+        assert_eq!(loaded_metadata.magic, metadata.magic);
+        assert_eq!(loaded_metadata.version_major, metadata.version_major);
+        assert_eq!(loaded_metadata.version_minor, metadata.version_minor);
+        assert_eq!(
+            loaded_metadata.stripe_sector_count_shift,
+            metadata.stripe_sector_count_shift
+        );
+
+        for i in 0..STRIPES {
+            assert_eq!(loaded_metadata.stripe_header(i), metadata.stripe_header(i));
+        }
     }
 }

--- a/src/block_device/bdev_lazy/metadata_flusher.rs
+++ b/src/block_device/bdev_lazy/metadata_flusher.rs
@@ -1,76 +1,23 @@
-#[cfg(test)]
-use crate::block_device::bdev_lazy::metadata::UBI_MAX_STRIPES;
 use crate::{
     block_device::{
-        bdev_lazy::metadata::load_metadata, BlockDevice, IoChannel, SharedBuffer, UbiMetadata,
+        bdev_lazy::metadata::{load_metadata, SharedMetadataState, UBI_MAX_STRIPES},
+        BlockDevice, IoChannel, SharedBuffer, UbiMetadata,
     },
     utils::aligned_buffer::AlignedBuf,
     vhost_backend::SECTOR_SIZE,
     Result,
 };
 use log::{debug, error};
-use std::{
-    cell::RefCell,
-    ptr::copy_nonoverlapping,
-    rc::Rc,
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
-};
+use std::{cell::RefCell, rc::Rc};
 
 const METADATA_WRITE_ID: usize = 0;
 const METADATA_FLUSH_ID: usize = 1;
-
-#[derive(Debug, Clone)]
-pub struct MetadataFlushState {
-    metadata_version: Arc<AtomicU64>,
-    metadata_version_flushed: Arc<AtomicU64>,
-}
-
-impl MetadataFlushState {
-    pub fn new() -> Self {
-        Self {
-            metadata_version: Arc::new(AtomicU64::new(1)),
-            metadata_version_flushed: Arc::new(AtomicU64::new(0)),
-        }
-    }
-
-    pub fn increment_version(&self) {
-        self.metadata_version.fetch_add(1, Ordering::SeqCst);
-    }
-
-    pub fn set_flushed_version(&self, version: u64) {
-        self.metadata_version_flushed
-            .store(version, Ordering::Release);
-    }
-
-    pub fn flushed_version(&self) -> u64 {
-        self.metadata_version_flushed.load(Ordering::Acquire)
-    }
-
-    pub fn current_version(&self) -> u64 {
-        self.metadata_version.load(Ordering::Acquire)
-    }
-
-    pub fn needs_flush(&self) -> bool {
-        let flushed = self.metadata_version_flushed.load(Ordering::Acquire);
-        let current = self.metadata_version.load(Ordering::Acquire);
-        current > flushed
-    }
-}
-
-impl Default for MetadataFlushState {
-    fn default() -> Self {
-        Self::new()
-    }
-}
 
 pub struct MetadataFlusher {
     channel: Box<dyn IoChannel>,
     metadata: Box<UbiMetadata>,
     metadata_buf: SharedBuffer,
-    flush_state: MetadataFlushState,
+    shared_state: SharedMetadataState,
     metadata_version_being_flushed: Option<u64>,
     pending_flush_requests: bool,
     inprogress_flush_requests: bool,
@@ -80,13 +27,14 @@ impl MetadataFlusher {
     pub fn new(metadata_dev: &dyn BlockDevice) -> Result<Self> {
         let mut channel = metadata_dev.create_channel()?;
         let metadata = load_metadata(&mut channel)?;
-        let metadata_size = std::mem::size_of::<UbiMetadata>();
+        let metadata_size = UbiMetadata::metadata_size(UBI_MAX_STRIPES);
         let metadata_buf_size = metadata_size.div_ceil(SECTOR_SIZE) * SECTOR_SIZE;
+        let shared_state = SharedMetadataState::new(&metadata);
         Ok(MetadataFlusher {
             channel,
             metadata,
             metadata_buf: Rc::new(RefCell::new(AlignedBuf::new(metadata_buf_size))),
-            flush_state: MetadataFlushState::new(),
+            shared_state,
             metadata_version_being_flushed: None,
             pending_flush_requests: false,
             inprogress_flush_requests: false,
@@ -101,27 +49,18 @@ impl MetadataFlusher {
         1u64 << self.metadata.stripe_sector_count_shift
     }
 
-    pub fn metadata(&self) -> &UbiMetadata {
-        &self.metadata
-    }
-
     pub fn set_stripe_fetched(&mut self, stripe_id: usize) {
-        self.metadata.stripe_headers[stripe_id] = 1;
-        self.flush_state.increment_version();
+        self.shared_state.set_stripe_fetched(stripe_id);
     }
 
     fn start_flush(&mut self) -> Result<()> {
-        let current_version = self.flush_state.current_version();
+        let current_version = self.shared_state.current_version();
         debug!("Starting flush for metadata version {current_version}");
         self.metadata_version_being_flushed = Some(current_version);
 
         let metadata_buf = self.metadata_buf.clone();
-        let metadata_size = std::mem::size_of::<UbiMetadata>();
-        unsafe {
-            let src = &*self.metadata as *const UbiMetadata as *const u8;
-            let dst = metadata_buf.borrow_mut().as_mut_ptr();
-            copy_nonoverlapping(src, dst, metadata_size);
-        }
+        self.metadata
+            .write_to_buf(metadata_buf.borrow_mut().as_mut_slice(), UBI_MAX_STRIPES);
 
         let sector_count = metadata_buf.borrow().len() / SECTOR_SIZE;
         self.channel
@@ -162,7 +101,7 @@ impl MetadataFlusher {
             }
             (Some(version), true) => {
                 debug!("Metadata flush completed for version {version}");
-                self.flush_state.set_flushed_version(version);
+                self.shared_state.set_flushed_version(version);
             }
         }
         self.inprogress_flush_requests = false;
@@ -173,8 +112,8 @@ impl MetadataFlusher {
         self.pending_flush_requests = true;
     }
 
-    pub fn shared_flush_state(&self) -> MetadataFlushState {
-        self.flush_state.clone()
+    pub fn shared_state(&self) -> SharedMetadataState {
+        self.shared_state.clone()
     }
 
     pub fn update(&mut self) {
@@ -204,7 +143,6 @@ mod tests {
     use crate::block_device::bdev_failing::FailingBlockDevice;
     use crate::block_device::bdev_lazy::init_metadata;
     use crate::block_device::bdev_lazy::metadata::{UBI_MAGIC, UBI_MAGIC_SIZE};
-    use crate::block_device::bdev_lazy::stripe_fetcher::{StripeStatus, StripeStatusVec};
     use crate::block_device::bdev_test::TestBlockDevice;
     use crate::Result;
     use crate::VhostUserBlockError;
@@ -214,49 +152,35 @@ mod tests {
         let metadata_dev = TestBlockDevice::new(40 * 1024 * 1024);
         let stripe_sector_count_shift = 11;
         let stripe_sector_count: u64 = 1 << stripe_sector_count_shift;
-        let source_sector_count = 29 * stripe_sector_count + 4;
-        let stripe_count = source_sector_count.div_ceil(stripe_sector_count);
+        let _source_sector_count = 29 * stripe_sector_count + 4;
+        let stripe_count = _source_sector_count.div_ceil(stripe_sector_count);
 
         let mut ch = metadata_dev.create_channel()?;
         let metadata = UbiMetadata::new(stripe_sector_count_shift);
         init_metadata(&metadata, &mut ch).unwrap();
 
         let mut flusher = MetadataFlusher::new(&metadata_dev)?;
-        let stripe_status_vec = StripeStatusVec::new(flusher.metadata(), source_sector_count)?;
+        let shared_state = flusher.shared_state();
 
-        assert_eq!(stripe_status_vec.stripe_status(0), StripeStatus::NotFetched);
+        assert!(!shared_state.stripe_fetched(0));
         assert_eq!(flusher.stripe_sector_count(), stripe_sector_count);
 
         let stripes_to_fetch = [0, 3, 7, 8];
         for stripe_id in stripes_to_fetch.iter() {
-            assert_eq!(
-                stripe_status_vec.stripe_status(*stripe_id),
-                StripeStatus::NotFetched
-            );
-            stripe_status_vec.set_stripe_status(*stripe_id, StripeStatus::Queued);
-            assert_eq!(
-                stripe_status_vec.stripe_status(*stripe_id),
-                StripeStatus::Queued
-            );
-            stripe_status_vec.set_stripe_status(*stripe_id, StripeStatus::Fetching);
-            assert_eq!(
-                stripe_status_vec.stripe_status(*stripe_id),
-                StripeStatus::Fetching
-            );
-            stripe_status_vec.set_stripe_status(*stripe_id, StripeStatus::Fetched);
+            assert!(!shared_state.stripe_fetched(*stripe_id));
             flusher.set_stripe_fetched(*stripe_id);
-            assert_eq!(
-                stripe_status_vec.stripe_status(*stripe_id),
-                StripeStatus::Fetched
-            );
+            assert!(shared_state.stripe_fetched(*stripe_id));
         }
-        assert_eq!(stripe_status_vec.stripe_count, stripe_count);
+        assert_eq!(
+            stripe_count,
+            _source_sector_count.div_ceil(stripe_sector_count)
+        );
 
         assert_eq!(metadata_dev.flushes(), 1);
         flusher.request_flush();
         flusher.update();
         assert!(!flusher.pending_flush_requests);
-        while flusher.shared_flush_state().needs_flush() {
+        while flusher.shared_state().needs_flush() {
             flusher.update();
         }
         assert_eq!(metadata_dev.flushes(), 2);
@@ -303,7 +227,7 @@ mod tests {
         let metadata_dev = FailingBlockDevice::new(40 * 1024 * 1024);
         let stripe_shift = 11u8;
         let stripe_sector_count = 1 << stripe_shift;
-        let source_sector_count = 29 * stripe_sector_count + 4;
+        let _source_sector_count = 29 * stripe_sector_count + 4;
 
         {
             let mut ch = metadata_dev.create_channel()?;
@@ -312,14 +236,12 @@ mod tests {
         }
 
         let mut flusher = MetadataFlusher::new(&metadata_dev)?;
-        let stripe_status_vec = StripeStatusVec::new(flusher.metadata(), source_sector_count)?;
         metadata_dev.fail_next_write();
-        stripe_status_vec.set_stripe_status(0, StripeStatus::Fetched);
         flusher.set_stripe_fetched(0);
         flusher.request_flush();
         flusher.update();
         assert!(!flusher.pending_flush_requests);
-        assert!(flusher.shared_flush_state().needs_flush());
+        assert!(flusher.shared_state().needs_flush());
         Ok(())
     }
 
@@ -328,7 +250,7 @@ mod tests {
         let metadata_dev = FailingBlockDevice::new(40 * 1024 * 1024);
         let stripe_shift = 11u8;
         let stripe_sector_count = 1 << stripe_shift;
-        let source_sector_count = 29 * stripe_sector_count + 4;
+        let _source_sector_count = 29 * stripe_sector_count + 4;
 
         {
             let mut ch = metadata_dev.create_channel()?;
@@ -337,34 +259,12 @@ mod tests {
         }
 
         let mut flusher = MetadataFlusher::new(&metadata_dev)?;
-        let stripe_status_vec = StripeStatusVec::new(flusher.metadata(), source_sector_count)?;
-        stripe_status_vec.set_stripe_status(0, StripeStatus::Fetched);
         flusher.set_stripe_fetched(0);
         metadata_dev.fail_next_flush();
         flusher.request_flush();
         flusher.update();
         flusher.update();
-        assert!(flusher.shared_flush_state().needs_flush());
-        Ok(())
-    }
-
-    #[test]
-    fn test_stripe_count_overflow() -> Result<()> {
-        let metadata_dev = TestBlockDevice::new(40 * 1024 * 1024);
-        let stripe_shift = 0u8;
-        let stripe_sector_count = 1u64 << stripe_shift;
-        let source_sector_count = (UBI_MAX_STRIPES as u64 + 1) * stripe_sector_count;
-
-        let mut ch = metadata_dev.create_channel()?;
-        let metadata = UbiMetadata::new(stripe_shift);
-        init_metadata(&metadata, &mut ch).unwrap();
-
-        let flusher = MetadataFlusher::new(&metadata_dev)?;
-        let result = StripeStatusVec::new(flusher.metadata(), source_sector_count);
-        assert!(matches!(
-            result,
-            Err(VhostUserBlockError::InvalidParameter { .. })
-        ));
+        assert!(flusher.shared_state().needs_flush());
         Ok(())
     }
 }


### PR DESCRIPTION
Now there's only a single copy of stripe headers, which is shared between UbiMetadata and SharedMetadataState.

SharedMetadataState is used in bdev_lazy, StripeFetcher, and MetadataFlusher to coordinate metadata changes using atomics.

StripeStatusVec and MetadataFlushState are removed and their use is replaced by SharedMetadataState.