### PR TITLE
Enable native CPU optimizations

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-C", "target-cpu=native"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,8 @@ vm-memory = { version = "0.16.2", features = ["backend-mmap", "backend-atomic"] 
 [features]
 default = []
 disable-isal-crypto = ["aes", "xts-mode"]
+
+[profile.release]
+lto = "fat"
+codegen-units = 1
+panic = "abort"


### PR DESCRIPTION
## Summary
- optimize release profile with LTO, a single codegen unit, and abort-on-panic
- compile with `target-cpu=native` to take advantage of CPU-specific features

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo test --features disable-isal-crypto`


------
https://chatgpt.com/codex/tasks/task_e_68900332e30083278819d7b4081e2158