### PR TITLE
Consolidate metadata handling into a single structure.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1050,6 +1050,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,6 +1198,7 @@ dependencies = [
  "serde_with",
  "serde_yaml",
  "smallvec",
+ "static_assertions",
  "tempfile",
  "thiserror 2.0.12",
  "vhost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ base64 = "0.22.1"
 aes-gcm = "0.10.3"
 aes = { version = "0.8", optional = true }
 xts-mode = { version = "0.5.1", optional = true }
+static_assertions = "1.1.0"
 
 [build-dependencies]
 bindgen = "0.72.0"

--- a/src/block_device/bdev_lazy/bgworker.rs
+++ b/src/block_device/bdev_lazy/bgworker.rs
@@ -1,6 +1,5 @@
 use super::{
-    metadata_flusher::{MetadataFlushState, MetadataFlusher},
-    stripe_fetcher::{StripeFetcher, StripeStatusVec},
+    metadata::SharedMetadataState, metadata_flusher::MetadataFlusher, stripe_fetcher::StripeFetcher,
 };
 use crate::block_device::BlockDevice;
 use crate::Result;
@@ -19,6 +18,7 @@ pub enum BgWorkerRequest {
 pub struct BgWorker {
     stripe_fetcher: StripeFetcher,
     metadata_flusher: MetadataFlusher,
+    stripe_sector_count: u64,
     req_receiver: Receiver<BgWorkerRequest>,
     req_sender: Sender<BgWorkerRequest>,
     done: bool,
@@ -33,37 +33,38 @@ impl BgWorker {
         metadata_dev: &dyn BlockDevice,
         alignment: usize,
     ) -> Result<Self> {
-        let metadata_flusher = MetadataFlusher::new(metadata_dev)?;
+        let source_sector_count = source_dev.sector_count();
+        let metadata_flusher = MetadataFlusher::new(metadata_dev, source_sector_count)?;
         let stripe_sector_count = metadata_flusher.stripe_sector_count();
-        let stripe_status_vec =
-            StripeStatusVec::new(metadata_flusher.metadata(), source_dev.sector_count())?;
+        let shared_state = metadata_flusher.shared_state();
         let stripe_fetcher = StripeFetcher::new(
             source_dev,
             target_dev,
             stripe_sector_count,
-            stripe_status_vec,
+            shared_state,
             alignment,
         )?;
         let (tx, rx) = std::sync::mpsc::channel();
         Ok(BgWorker {
             stripe_fetcher,
             metadata_flusher,
+            stripe_sector_count,
             req_receiver: rx,
             req_sender: tx,
             done: false,
         })
     }
 
+    pub fn stripe_sector_count(&self) -> u64 {
+        self.stripe_sector_count
+    }
+
     pub fn req_sender(&self) -> Sender<BgWorkerRequest> {
         self.req_sender.clone()
     }
 
-    pub fn stripe_status_vec(&self) -> StripeStatusVec {
-        self.stripe_fetcher.stripe_status_vec()
-    }
-
-    pub fn shared_flush_state(&self) -> MetadataFlushState {
-        self.metadata_flusher.shared_flush_state()
+    pub fn shared_state(&self) -> SharedMetadataState {
+        self.metadata_flusher.shared_state()
     }
 
     pub fn process_request(&mut self, req: BgWorkerRequest) {
@@ -103,12 +104,7 @@ impl BgWorker {
     }
 
     pub fn update(&mut self) {
-        let completed = self.stripe_fetcher.update();
-        for (stripe_id, success) in completed {
-            if success {
-                self.metadata_flusher.set_stripe_fetched(stripe_id);
-            }
-        }
+        self.stripe_fetcher.update();
         self.metadata_flusher.update();
     }
 

--- a/src/block_device/bdev_lazy/metadata/mod.rs
+++ b/src/block_device/bdev_lazy/metadata/mod.rs
@@ -1,11 +1,13 @@
 mod init;
 mod load;
+mod shared_state;
 mod types;
 
 pub use init::init_metadata;
 pub use load::load_metadata;
+pub use shared_state::SharedMetadataState;
 pub use types::UbiMetadata;
-pub use types::{UBI_MAGIC, UBI_MAX_STRIPES};
+pub use types::UBI_MAGIC;
 
 #[cfg(test)]
 pub use types::UBI_MAGIC_SIZE;

--- a/src/block_device/bdev_lazy/metadata/shared_state.rs
+++ b/src/block_device/bdev_lazy/metadata/shared_state.rs
@@ -1,0 +1,74 @@
+use super::UbiMetadata;
+use std::sync::{
+    atomic::{AtomicU64, AtomicU8, Ordering},
+    Arc,
+};
+
+#[derive(Debug, Clone)]
+pub struct SharedMetadataState {
+    stripe_headers: Arc<Vec<AtomicU8>>,
+    metadata_version: Arc<AtomicU64>,
+    metadata_version_flushed: Arc<AtomicU64>,
+}
+
+impl SharedMetadataState {
+    pub fn new(metadata: &UbiMetadata) -> Self {
+        let stripe_headers = metadata.stripe_headers.clone();
+        // Start at version 1 so initial state is not considered flushed.
+        let metadata_version = Arc::new(AtomicU64::new(1));
+        let metadata_version_flushed = Arc::new(AtomicU64::new(0));
+
+        Self {
+            stripe_headers,
+            metadata_version,
+            metadata_version_flushed,
+        }
+    }
+
+    pub fn increment_version(&self) {
+        self.metadata_version.fetch_add(1, Ordering::AcqRel);
+    }
+
+    pub fn set_flushed_version(&self, version: u64) {
+        self.metadata_version_flushed
+            .store(version, Ordering::Release);
+    }
+
+    pub fn flushed_version(&self) -> u64 {
+        self.metadata_version_flushed.load(Ordering::Acquire)
+    }
+
+    pub fn current_version(&self) -> u64 {
+        self.metadata_version.load(Ordering::Acquire)
+    }
+
+    pub fn needs_flush(&self) -> bool {
+        let flushed = self.metadata_version_flushed.load(Ordering::Acquire);
+        let current = self.metadata_version.load(Ordering::Acquire);
+        current > flushed
+    }
+
+    pub fn stripe_fetched(&self, stripe_id: usize) -> bool {
+        let header = self.stripe_headers[stripe_id].load(Ordering::Acquire);
+        header & (1 << 0) != 0
+    }
+
+    pub fn stripe_written(&self, stripe_id: usize) -> bool {
+        let header = self.stripe_headers[stripe_id].load(Ordering::Acquire);
+        header & (1 << 1) != 0
+    }
+
+    pub fn set_stripe_fetched(&self, stripe_id: usize) {
+        let prev_header = self.stripe_headers[stripe_id].fetch_or(1 << 0, Ordering::AcqRel);
+        if prev_header & (1 << 0) == 0 {
+            self.increment_version();
+        }
+    }
+
+    pub fn set_stripe_written(&self, stripe_id: usize) {
+        let prev_header = self.stripe_headers[stripe_id].fetch_or(1 << 1, Ordering::AcqRel);
+        if prev_header & (1 << 1) == 0 {
+            self.increment_version();
+        }
+    }
+}

--- a/src/block_device/bdev_lazy/metadata/types.rs
+++ b/src/block_device/bdev_lazy/metadata/types.rs
@@ -1,8 +1,20 @@
-use std::mem::MaybeUninit;
+use std::{
+    mem::MaybeUninit,
+    ptr,
+    sync::{atomic::AtomicU8, Arc},
+};
+
+#[cfg(test)]
+use std::sync::atomic::Ordering;
+
+use static_assertions::const_assert;
 
 pub const UBI_MAGIC_SIZE: usize = 9;
-pub const UBI_MAX_STRIPES: usize = 2 * 1024 * 1024;
 pub const UBI_MAGIC: &[u8] = b"BDEV_UBI\0"; // 9 bytes
+
+// Ensure AtomicU8 has the same in-memory layout as u8 so we can copy headers
+// using raw byte pointers.
+const_assert!(std::mem::size_of::<AtomicU8>() == std::mem::size_of::<u8>());
 
 #[repr(C)]
 #[derive(Debug, Clone)]
@@ -17,25 +29,158 @@ pub struct UbiMetadata {
 
     // bit 0: fetched or not
     // bit 1: written or not
-    pub stripe_headers: [u8; UBI_MAX_STRIPES],
+    pub stripe_headers: Arc<Vec<AtomicU8>>,
 }
 
 impl UbiMetadata {
-    #[cfg(test)]
-    pub fn stripe_headers_offset(&self, stripe_id: usize) -> usize {
-        stripe_id + UBI_MAGIC_SIZE + 5
+    pub const HEADER_SIZE: usize = UBI_MAGIC_SIZE + 2 + 2 + 1;
+
+    pub fn metadata_size(&self) -> usize {
+        Self::HEADER_SIZE + self.stripe_headers.len()
     }
 
-    pub fn new(stripe_sector_count_shift: u8) -> Box<Self> {
+    pub fn stripe_size(&self) -> u64 {
+        1u64 << self.stripe_sector_count_shift
+    }
+
+    pub fn stripe_count(&self) -> u64 {
+        self.stripe_headers.len() as u64
+    }
+
+    #[cfg(test)]
+    pub fn stripe_headers_offset(&self, stripe_id: usize) -> usize {
+        stripe_id + Self::HEADER_SIZE
+    }
+
+    #[cfg(test)]
+    pub fn stripe_header(&self, stripe_id: usize) -> u8 {
+        self.stripe_headers[stripe_id].load(Ordering::SeqCst)
+    }
+
+    #[cfg(test)]
+    pub fn set_stripe_header(&self, stripe_id: usize, value: u8) {
+        self.stripe_headers[stripe_id].store(value, Ordering::SeqCst);
+    }
+
+    pub fn new(stripe_sector_count_shift: u8, stripe_count: usize) -> Box<Self> {
         let mut metadata: Box<MaybeUninit<Self>> = Box::new_uninit();
+
+        let headers = (0..stripe_count)
+            .map(|_| AtomicU8::new(0))
+            .collect::<Vec<_>>();
+
         unsafe {
-            let metadata_ptr = metadata.assume_init_mut();
-            metadata_ptr.magic.copy_from_slice(UBI_MAGIC);
-            metadata_ptr.version_major.copy_from_slice(&[0, 0]);
-            metadata_ptr.version_minor.copy_from_slice(&[0, 0]);
-            metadata_ptr.stripe_sector_count_shift = stripe_sector_count_shift;
-            metadata_ptr.stripe_headers.fill(0);
+            let md = metadata.assume_init_mut();
+
+            md.magic.copy_from_slice(UBI_MAGIC);
+            md.version_major.copy_from_slice(&[0; 2]);
+            md.version_minor.copy_from_slice(&[0; 2]);
+            md.stripe_sector_count_shift = stripe_sector_count_shift;
+
+            ptr::write(&mut md.stripe_headers, Arc::new(headers));
+
+            metadata.assume_init()
         }
-        unsafe { metadata.assume_init() }
+    }
+
+    pub fn from_bytes(buf: &[u8]) -> Box<Self> {
+        // copy the fixed‐size header fields
+        let mut magic = [0u8; UBI_MAGIC_SIZE];
+        magic.copy_from_slice(&buf[0..UBI_MAGIC_SIZE]);
+
+        let mut version_major = [0u8; 2];
+        version_major.copy_from_slice(&buf[UBI_MAGIC_SIZE..UBI_MAGIC_SIZE + 2]);
+
+        let mut version_minor = [0u8; 2];
+        version_minor.copy_from_slice(&buf[UBI_MAGIC_SIZE + 2..UBI_MAGIC_SIZE + 4]);
+
+        let stripe_sector_count_shift = buf[UBI_MAGIC_SIZE + 4];
+
+        let stripe_count = buf.len() - Self::HEADER_SIZE;
+
+        // initialize all headers to zero and then copy the provided stripe data
+        let mut stripe_headers = (0..stripe_count)
+            .map(|_| AtomicU8::new(0))
+            .collect::<Vec<_>>();
+
+        // copy any stripe headers that are actually present in `buf`
+        unsafe {
+            let dst = stripe_headers.as_mut_ptr() as *mut u8;
+            let src = buf.as_ptr().add(Self::HEADER_SIZE);
+            ptr::copy_nonoverlapping(src, dst, stripe_count);
+        }
+        let stripe_headers = Arc::new(stripe_headers);
+
+        // finally, box up the new struct
+        Box::new(UbiMetadata {
+            magic,
+            version_major,
+            version_minor,
+            stripe_sector_count_shift,
+            stripe_headers,
+        })
+    }
+
+    /// Serialize `self` into the given buffer
+    pub fn write_to_buf(&self, buf: &mut [u8]) {
+        let total_len: usize = self.metadata_size();
+        assert!(
+            buf.len() >= total_len,
+            "buffer too small: {} < {}",
+            buf.len(),
+            total_len
+        );
+
+        let dst = buf.as_mut_ptr();
+        let stripe_count = self.stripe_headers.len();
+
+        unsafe {
+            // build and copy the header
+            let mut header = [0u8; Self::HEADER_SIZE];
+            header[..UBI_MAGIC_SIZE].copy_from_slice(&self.magic);
+            header[UBI_MAGIC_SIZE..UBI_MAGIC_SIZE + 2].copy_from_slice(&self.version_major);
+            header[UBI_MAGIC_SIZE + 2..UBI_MAGIC_SIZE + 4].copy_from_slice(&self.version_minor);
+            header[UBI_MAGIC_SIZE + 4] = self.stripe_sector_count_shift;
+            ptr::copy_nonoverlapping(header.as_ptr(), dst, Self::HEADER_SIZE);
+
+            // Copy the stripe headers.
+            let stripes_ptr = self.stripe_headers.as_ptr() as *const u8;
+            ptr::copy_nonoverlapping(stripes_ptr, dst.add(Self::HEADER_SIZE), stripe_count);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ubi_metadata_serialization() {
+        const STRIPES: usize = 20;
+        let metadata = UbiMetadata::new(9, STRIPES);
+
+        for i in 0..STRIPES {
+            metadata.set_stripe_header(i, (i * 2) as u8);
+        }
+
+        let metadata_size: usize = metadata.metadata_size();
+        let buf_size: usize = metadata_size.div_ceil(512) * 512;
+
+        let mut buf = vec![0u8; buf_size];
+        metadata.write_to_buf(&mut buf);
+
+        let loaded_metadata = UbiMetadata::from_bytes(&buf);
+
+        assert_eq!(loaded_metadata.magic, metadata.magic);
+        assert_eq!(loaded_metadata.version_major, metadata.version_major);
+        assert_eq!(loaded_metadata.version_minor, metadata.version_minor);
+        assert_eq!(
+            loaded_metadata.stripe_sector_count_shift,
+            metadata.stripe_sector_count_shift
+        );
+
+        for i in 0..STRIPES {
+            assert_eq!(loaded_metadata.stripe_header(i), metadata.stripe_header(i));
+        }
     }
 }

--- a/src/block_device/bdev_lazy/metadata_flusher.rs
+++ b/src/block_device/bdev_lazy/metadata_flusher.rs
@@ -1,92 +1,52 @@
-#[cfg(test)]
-use crate::block_device::bdev_lazy::metadata::UBI_MAX_STRIPES;
 use crate::{
     block_device::{
-        bdev_lazy::metadata::load_metadata, BlockDevice, IoChannel, SharedBuffer, UbiMetadata,
+        bdev_lazy::metadata::{load_metadata, SharedMetadataState},
+        BlockDevice, IoChannel, SharedBuffer, UbiMetadata,
     },
     utils::aligned_buffer::AlignedBuf,
     vhost_backend::SECTOR_SIZE,
-    Result,
+    Result, VhostUserBlockError,
 };
 use log::{debug, error};
-use std::{
-    cell::RefCell,
-    ptr::copy_nonoverlapping,
-    rc::Rc,
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
-};
+use std::{cell::RefCell, rc::Rc};
 
 const METADATA_WRITE_ID: usize = 0;
 const METADATA_FLUSH_ID: usize = 1;
-
-#[derive(Debug, Clone)]
-pub struct MetadataFlushState {
-    metadata_version: Arc<AtomicU64>,
-    metadata_version_flushed: Arc<AtomicU64>,
-}
-
-impl MetadataFlushState {
-    pub fn new() -> Self {
-        Self {
-            metadata_version: Arc::new(AtomicU64::new(1)),
-            metadata_version_flushed: Arc::new(AtomicU64::new(0)),
-        }
-    }
-
-    pub fn increment_version(&self) {
-        self.metadata_version.fetch_add(1, Ordering::SeqCst);
-    }
-
-    pub fn set_flushed_version(&self, version: u64) {
-        self.metadata_version_flushed
-            .store(version, Ordering::Release);
-    }
-
-    pub fn flushed_version(&self) -> u64 {
-        self.metadata_version_flushed.load(Ordering::Acquire)
-    }
-
-    pub fn current_version(&self) -> u64 {
-        self.metadata_version.load(Ordering::Acquire)
-    }
-
-    pub fn needs_flush(&self) -> bool {
-        let flushed = self.metadata_version_flushed.load(Ordering::Acquire);
-        let current = self.metadata_version.load(Ordering::Acquire);
-        current > flushed
-    }
-}
-
-impl Default for MetadataFlushState {
-    fn default() -> Self {
-        Self::new()
-    }
-}
 
 pub struct MetadataFlusher {
     channel: Box<dyn IoChannel>,
     metadata: Box<UbiMetadata>,
     metadata_buf: SharedBuffer,
-    flush_state: MetadataFlushState,
+    shared_state: SharedMetadataState,
     metadata_version_being_flushed: Option<u64>,
     pending_flush_requests: bool,
     inprogress_flush_requests: bool,
 }
 
 impl MetadataFlusher {
-    pub fn new(metadata_dev: &dyn BlockDevice) -> Result<Self> {
+    pub fn new(metadata_dev: &dyn BlockDevice, source_sector_count: u64) -> Result<Self> {
         let mut channel = metadata_dev.create_channel()?;
-        let metadata = load_metadata(&mut channel)?;
-        let metadata_size = std::mem::size_of::<UbiMetadata>();
+        let metadata = load_metadata(&mut channel, metadata_dev.sector_count())?;
+
+        let source_stripe_count = source_sector_count.div_ceil(metadata.stripe_size());
+        if source_stripe_count > metadata.stripe_count() {
+            return Err(VhostUserBlockError::InvalidParameter {
+                description: format!(
+                    "Source stripe count {} exceeds metadata stripe count {}",
+                    source_stripe_count,
+                    metadata.stripe_count()
+                ),
+            });
+        }
+
+        let metadata_size = metadata.metadata_size();
         let metadata_buf_size = metadata_size.div_ceil(SECTOR_SIZE) * SECTOR_SIZE;
+        let shared_state = SharedMetadataState::new(&metadata);
         Ok(MetadataFlusher {
             channel,
             metadata,
             metadata_buf: Rc::new(RefCell::new(AlignedBuf::new(metadata_buf_size))),
-            flush_state: MetadataFlushState::new(),
+            shared_state,
             metadata_version_being_flushed: None,
             pending_flush_requests: false,
             inprogress_flush_requests: false,
@@ -101,27 +61,19 @@ impl MetadataFlusher {
         1u64 << self.metadata.stripe_sector_count_shift
     }
 
-    pub fn metadata(&self) -> &UbiMetadata {
-        &self.metadata
-    }
-
+    #[cfg(test)]
     pub fn set_stripe_fetched(&mut self, stripe_id: usize) {
-        self.metadata.stripe_headers[stripe_id] = 1;
-        self.flush_state.increment_version();
+        self.shared_state.set_stripe_fetched(stripe_id);
     }
 
     fn start_flush(&mut self) -> Result<()> {
-        let current_version = self.flush_state.current_version();
+        let current_version = self.shared_state.current_version();
         debug!("Starting flush for metadata version {current_version}");
         self.metadata_version_being_flushed = Some(current_version);
 
         let metadata_buf = self.metadata_buf.clone();
-        let metadata_size = std::mem::size_of::<UbiMetadata>();
-        unsafe {
-            let src = &*self.metadata as *const UbiMetadata as *const u8;
-            let dst = metadata_buf.borrow_mut().as_mut_ptr();
-            copy_nonoverlapping(src, dst, metadata_size);
-        }
+        self.metadata
+            .write_to_buf(metadata_buf.borrow_mut().as_mut_slice());
 
         let sector_count = metadata_buf.borrow().len() / SECTOR_SIZE;
         self.channel
@@ -162,7 +114,7 @@ impl MetadataFlusher {
             }
             (Some(version), true) => {
                 debug!("Metadata flush completed for version {version}");
-                self.flush_state.set_flushed_version(version);
+                self.shared_state.set_flushed_version(version);
             }
         }
         self.inprogress_flush_requests = false;
@@ -173,8 +125,8 @@ impl MetadataFlusher {
         self.pending_flush_requests = true;
     }
 
-    pub fn shared_flush_state(&self) -> MetadataFlushState {
-        self.flush_state.clone()
+    pub fn shared_state(&self) -> SharedMetadataState {
+        self.shared_state.clone()
     }
 
     pub fn update(&mut self) {
@@ -204,7 +156,6 @@ mod tests {
     use crate::block_device::bdev_failing::FailingBlockDevice;
     use crate::block_device::bdev_lazy::init_metadata;
     use crate::block_device::bdev_lazy::metadata::{UBI_MAGIC, UBI_MAGIC_SIZE};
-    use crate::block_device::bdev_lazy::stripe_fetcher::{StripeStatus, StripeStatusVec};
     use crate::block_device::bdev_test::TestBlockDevice;
     use crate::Result;
     use crate::VhostUserBlockError;
@@ -215,53 +166,39 @@ mod tests {
         let stripe_sector_count_shift = 11;
         let stripe_sector_count: u64 = 1 << stripe_sector_count_shift;
         let source_sector_count = 29 * stripe_sector_count + 4;
-        let stripe_count = source_sector_count.div_ceil(stripe_sector_count);
+        let stripe_count = source_sector_count.div_ceil(stripe_sector_count) as usize;
 
         let mut ch = metadata_dev.create_channel()?;
-        let metadata = UbiMetadata::new(stripe_sector_count_shift);
+        let metadata = UbiMetadata::new(stripe_sector_count_shift, stripe_count);
         init_metadata(&metadata, &mut ch).unwrap();
 
-        let mut flusher = MetadataFlusher::new(&metadata_dev)?;
-        let stripe_status_vec = StripeStatusVec::new(flusher.metadata(), source_sector_count)?;
+        let mut flusher = MetadataFlusher::new(&metadata_dev, source_sector_count)?;
+        let shared_state = flusher.shared_state();
 
-        assert_eq!(stripe_status_vec.stripe_status(0), StripeStatus::NotFetched);
+        assert!(!shared_state.stripe_fetched(0));
         assert_eq!(flusher.stripe_sector_count(), stripe_sector_count);
 
         let stripes_to_fetch = [0, 3, 7, 8];
         for stripe_id in stripes_to_fetch.iter() {
-            assert_eq!(
-                stripe_status_vec.stripe_status(*stripe_id),
-                StripeStatus::NotFetched
-            );
-            stripe_status_vec.set_stripe_status(*stripe_id, StripeStatus::Queued);
-            assert_eq!(
-                stripe_status_vec.stripe_status(*stripe_id),
-                StripeStatus::Queued
-            );
-            stripe_status_vec.set_stripe_status(*stripe_id, StripeStatus::Fetching);
-            assert_eq!(
-                stripe_status_vec.stripe_status(*stripe_id),
-                StripeStatus::Fetching
-            );
-            stripe_status_vec.set_stripe_status(*stripe_id, StripeStatus::Fetched);
+            assert!(!shared_state.stripe_fetched(*stripe_id));
             flusher.set_stripe_fetched(*stripe_id);
-            assert_eq!(
-                stripe_status_vec.stripe_status(*stripe_id),
-                StripeStatus::Fetched
-            );
+            assert!(shared_state.stripe_fetched(*stripe_id));
         }
-        assert_eq!(stripe_status_vec.stripe_count, stripe_count);
+        assert_eq!(
+            stripe_count,
+            source_sector_count.div_ceil(stripe_sector_count) as usize
+        );
 
         assert_eq!(metadata_dev.flushes(), 1);
         flusher.request_flush();
         flusher.update();
         assert!(!flusher.pending_flush_requests);
-        while flusher.shared_flush_state().needs_flush() {
+        while flusher.shared_state().needs_flush() {
             flusher.update();
         }
         assert_eq!(metadata_dev.flushes(), 2);
 
-        for i in 0..UBI_MAX_STRIPES {
+        for i in 0..stripe_count {
             let offset = metadata.stripe_headers_offset(i);
             let mut header_buf = [0u8; 1];
             metadata_dev.read(offset, &mut header_buf, 1);
@@ -285,12 +222,12 @@ mod tests {
         let stripe_shift = 11u8;
 
         let mut ch = metadata_dev.create_channel()?;
-        let metadata = UbiMetadata::new(stripe_shift);
+        let metadata = UbiMetadata::new(stripe_shift, 40);
         init_metadata(&metadata, &mut ch).unwrap();
         let bad_magic = [0u8; UBI_MAGIC_SIZE];
         metadata_dev.write(0, &bad_magic, UBI_MAGIC_SIZE);
 
-        let result = MetadataFlusher::new(&metadata_dev);
+        let result = MetadataFlusher::new(&metadata_dev, 1024);
         assert!(matches!(
             result,
             Err(VhostUserBlockError::MetadataError { .. })
@@ -302,24 +239,20 @@ mod tests {
     fn test_poll_flush_failed_write() -> Result<()> {
         let metadata_dev = FailingBlockDevice::new(40 * 1024 * 1024);
         let stripe_shift = 11u8;
-        let stripe_sector_count = 1 << stripe_shift;
-        let source_sector_count = 29 * stripe_sector_count + 4;
 
         {
             let mut ch = metadata_dev.create_channel()?;
-            let metadata = UbiMetadata::new(stripe_shift);
+            let metadata = UbiMetadata::new(stripe_shift, 40);
             init_metadata(&metadata, &mut ch).unwrap();
         }
 
-        let mut flusher = MetadataFlusher::new(&metadata_dev)?;
-        let stripe_status_vec = StripeStatusVec::new(flusher.metadata(), source_sector_count)?;
+        let mut flusher = MetadataFlusher::new(&metadata_dev, 1024)?;
         metadata_dev.fail_next_write();
-        stripe_status_vec.set_stripe_status(0, StripeStatus::Fetched);
         flusher.set_stripe_fetched(0);
         flusher.request_flush();
         flusher.update();
         assert!(!flusher.pending_flush_requests);
-        assert!(flusher.shared_flush_state().needs_flush());
+        assert!(flusher.shared_state().needs_flush());
         Ok(())
     }
 
@@ -327,44 +260,20 @@ mod tests {
     fn test_poll_flush_failed_flush() -> Result<()> {
         let metadata_dev = FailingBlockDevice::new(40 * 1024 * 1024);
         let stripe_shift = 11u8;
-        let stripe_sector_count = 1 << stripe_shift;
-        let source_sector_count = 29 * stripe_sector_count + 4;
 
         {
             let mut ch = metadata_dev.create_channel()?;
-            let metadata = UbiMetadata::new(stripe_shift);
+            let metadata = UbiMetadata::new(stripe_shift, 40);
             init_metadata(&metadata, &mut ch).unwrap();
         }
 
-        let mut flusher = MetadataFlusher::new(&metadata_dev)?;
-        let stripe_status_vec = StripeStatusVec::new(flusher.metadata(), source_sector_count)?;
-        stripe_status_vec.set_stripe_status(0, StripeStatus::Fetched);
+        let mut flusher = MetadataFlusher::new(&metadata_dev, 1024)?;
         flusher.set_stripe_fetched(0);
         metadata_dev.fail_next_flush();
         flusher.request_flush();
         flusher.update();
         flusher.update();
-        assert!(flusher.shared_flush_state().needs_flush());
-        Ok(())
-    }
-
-    #[test]
-    fn test_stripe_count_overflow() -> Result<()> {
-        let metadata_dev = TestBlockDevice::new(40 * 1024 * 1024);
-        let stripe_shift = 0u8;
-        let stripe_sector_count = 1u64 << stripe_shift;
-        let source_sector_count = (UBI_MAX_STRIPES as u64 + 1) * stripe_sector_count;
-
-        let mut ch = metadata_dev.create_channel()?;
-        let metadata = UbiMetadata::new(stripe_shift);
-        init_metadata(&metadata, &mut ch).unwrap();
-
-        let flusher = MetadataFlusher::new(&metadata_dev)?;
-        let result = StripeStatusVec::new(flusher.metadata(), source_sector_count);
-        assert!(matches!(
-            result,
-            Err(VhostUserBlockError::InvalidParameter { .. })
-        ));
+        assert!(flusher.shared_state().needs_flush());
         Ok(())
     }
 }

--- a/src/block_device/bdev_lazy/stripe_fetcher.rs
+++ b/src/block_device/bdev_lazy/stripe_fetcher.rs
@@ -1,114 +1,19 @@
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::{cell::RefCell, rc::Rc};
 
 use super::super::*;
-use super::metadata::UBI_MAX_STRIPES;
+use super::metadata::SharedMetadataState;
 use crate::utils::aligned_buffer::AlignedBuf;
 use crate::{vhost_backend::SECTOR_SIZE, Result, VhostUserBlockError};
 use log::{debug, error};
-use std::sync::{
-    atomic::{AtomicU8, Ordering},
-    Arc,
-};
 
 const MAX_CONCURRENT_FETCHES: usize = 16;
 
-#[repr(u8)]
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub enum StripeStatus {
-    NotFetched,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FetchState {
     Queued,
     Fetching,
     Flushing,
-    Fetched,
-    Failed,
-}
-
-#[derive(Debug, Clone)]
-pub struct StripeStatusVec {
-    pub data: Arc<Vec<AtomicU8>>,
-    pub stripe_sector_count: u64,
-    pub source_sector_count: u64,
-    pub stripe_count: u64,
-}
-
-impl StripeStatusVec {
-    pub fn sector_to_stripe_id(&self, sector: u64) -> usize {
-        (sector / self.stripe_sector_count) as usize
-    }
-
-    pub fn stripe_status(&self, stripe_id: usize) -> StripeStatus {
-        if (stripe_id as u64) < self.stripe_count {
-            match self.data[stripe_id].load(Ordering::Acquire) {
-                0 => StripeStatus::NotFetched,
-                1 => StripeStatus::Queued,
-                2 => StripeStatus::Fetching,
-                3 => StripeStatus::Flushing,
-                4 => StripeStatus::Fetched,
-                5 => StripeStatus::Failed,
-                other => {
-                    error!(
-                        "Invalid stripe status value: {other} for stripe_id: {stripe_id}. Defaulting to Failed."
-                    );
-                    StripeStatus::Failed
-                }
-            }
-        } else {
-            StripeStatus::Fetched
-        }
-    }
-
-    pub fn set_stripe_status(&self, stripe_id: usize, status: StripeStatus) {
-        if (stripe_id as u64) >= self.stripe_count {
-            error!(
-                "Invalid stripe_id: {}. Must be less than stripe_count: {}",
-                stripe_id, self.stripe_count
-            );
-            return;
-        }
-        self.data[stripe_id].store(status as u8, Ordering::Release);
-    }
-
-    pub fn stripe_sector_count(&self, stripe_id: usize) -> u32 {
-        let stripe_sector_count = self
-            .stripe_sector_count
-            .min(self.source_sector_count - (stripe_id as u64 * self.stripe_sector_count))
-            as usize;
-        stripe_sector_count as u32
-    }
-
-    pub fn new(metadata: &UbiMetadata, source_sector_count: u64) -> Result<Self> {
-        let v = metadata
-            .stripe_headers
-            .iter()
-            .map(|header| {
-                if *header == 0 {
-                    AtomicU8::new(StripeStatus::NotFetched as u8)
-                } else {
-                    AtomicU8::new(StripeStatus::Fetched as u8)
-                }
-            })
-            .collect::<Vec<AtomicU8>>();
-        let stripe_sector_count = 1u64 << metadata.stripe_sector_count_shift;
-        let stripe_count = source_sector_count.div_ceil(stripe_sector_count);
-        if stripe_count as usize > UBI_MAX_STRIPES {
-            return Err(VhostUserBlockError::InvalidParameter {
-                description: "source sector count exceeds maximum stripe count".to_string(),
-            });
-        }
-        Ok(StripeStatusVec {
-            data: Arc::new(v),
-            stripe_sector_count,
-            source_sector_count,
-            stripe_count,
-        })
-    }
-}
-
-#[derive(Clone)]
-struct FetchBuffer {
-    used_for: Option<usize>,
-    buf: SharedBuffer,
 }
 
 pub struct StripeFetcher {
@@ -118,8 +23,11 @@ pub struct StripeFetcher {
     target_sector_count: u64,
     stripe_sector_count: u64,
     fetch_queue: VecDeque<usize>,
-    fetch_buffers: Vec<FetchBuffer>,
-    stripe_status_vec: StripeStatusVec,
+    fetch_buffers: Vec<SharedBuffer>,
+    shared_state: SharedMetadataState,
+    stripe_states: HashMap<usize, FetchState>,
+    allocated_buffers: HashMap<usize, usize>,
+    available_buffers: VecDeque<usize>,
 }
 
 impl StripeFetcher {
@@ -127,7 +35,7 @@ impl StripeFetcher {
         source_dev: &dyn BlockDevice,
         target_dev: &dyn BlockDevice,
         stripe_sector_count: u64,
-        stripe_status_vec: StripeStatusVec,
+        shared_state: SharedMetadataState,
         alignment: usize,
     ) -> Result<Self> {
         let fetch_source_channel = source_dev.create_channel()?;
@@ -141,12 +49,11 @@ impl StripeFetcher {
         let stripe_size = stripe_size_u64 as usize;
 
         let fetch_buffers = (0..MAX_CONCURRENT_FETCHES)
-            .map(|_| FetchBuffer {
-                used_for: None,
-                buf: Rc::new(RefCell::new(AlignedBuf::new_with_alignment(
+            .map(|_| {
+                Rc::new(RefCell::new(AlignedBuf::new_with_alignment(
                     stripe_size,
                     alignment,
-                ))),
+                )))
             })
             .collect();
         let source_sector_count = source_dev.sector_count();
@@ -164,7 +71,10 @@ impl StripeFetcher {
             stripe_sector_count,
             fetch_queue: VecDeque::new(),
             fetch_buffers,
-            stripe_status_vec,
+            shared_state,
+            stripe_states: HashMap::new(),
+            allocated_buffers: HashMap::new(),
+            available_buffers: (0..MAX_CONCURRENT_FETCHES).collect(),
         })
     }
 
@@ -174,59 +84,112 @@ impl StripeFetcher {
             || self.fetch_target_channel.busy()
     }
 
-    pub fn stripe_status_vec(&self) -> StripeStatusVec {
-        self.stripe_status_vec.clone()
-    }
-
     pub fn handle_fetch_request(&mut self, stripe_id: usize) {
-        match self.stripe_status_vec.stripe_status(stripe_id) {
-            StripeStatus::NotFetched | StripeStatus::Failed => {
-                debug!("Enqueueing stripe {stripe_id} for fetch");
-                self.fetch_queue.push_back(stripe_id);
-                self.stripe_status_vec
-                    .set_stripe_status(stripe_id, StripeStatus::Queued);
+        if self.shared_state.stripe_fetched(stripe_id) {
+            debug!("Stripe {stripe_id} already fetched");
+            return;
+        }
+
+        if self.stripe_states.contains_key(&stripe_id) {
+            debug!("Stripe {stripe_id} is already queued or fetching");
+            return;
+        }
+
+        debug!("Enqueueing stripe {stripe_id} for fetch");
+        self.fetch_queue.push_back(stripe_id);
+        self.stripe_states.insert(stripe_id, FetchState::Queued);
+    }
+
+    pub fn update(&mut self) {
+        self.start_fetches();
+        self.poll_fetches();
+    }
+
+    fn start_fetches(&mut self) {
+        while !self.fetch_queue.is_empty() && !self.available_buffers.is_empty() {
+            let stripe_id = self.fetch_queue.pop_front().unwrap();
+            let buffer_idx = self.available_buffers.pop_front().unwrap();
+            let fetch_buffer = &mut self.fetch_buffers[buffer_idx];
+            self.allocated_buffers.insert(stripe_id, buffer_idx);
+
+            let buf = fetch_buffer.clone();
+            let stripe_sector_offset = stripe_id as u64 * self.stripe_sector_count;
+            let stripe_sector_count = self
+                .stripe_sector_count
+                .min(self.source_sector_count - stripe_sector_offset);
+
+            self.fetch_source_channel.add_read(
+                stripe_sector_offset,
+                stripe_sector_count as u32,
+                buf.clone(),
+                stripe_id,
+            );
+
+            if let Err(e) = self.fetch_source_channel.submit() {
+                error!("Failed to submit read for stripe {stripe_id}: {e:?}");
+                self.fetch_completed(stripe_id, false);
+                continue;
             }
-            StripeStatus::Fetched => {
-                debug!("Stripe {stripe_id} already fetched");
+
+            self.stripe_states.insert(stripe_id, FetchState::Fetching);
+        }
+    }
+
+    fn poll_fetches(&mut self) {
+        // Overall fetching logic (assuming things go well):
+        // 1. Read from the source channel.
+        // 2. Write to the target channel.
+        // 3. Flush the target channel.
+        // 4. Mark the stripe as fetched in the shared state.
+
+        // Handle completions from the source channel. Did any fetches from the
+        // source complete? Start writing the successful ones to the target.
+        for (stripe_id, success) in self.fetch_source_channel.poll() {
+            let buffer_idx = match self.allocated_buffers.get(&stripe_id) {
+                Some(idx) => *idx,
+                None => {
+                    error!("Received completion for unknown stripe {stripe_id}");
+                    continue;
+                }
+            };
+
+            if !success || !self.start_write(buffer_idx, stripe_id) {
+                self.fetch_completed(stripe_id, false);
             }
-            StripeStatus::Queued | StripeStatus::Fetching | StripeStatus::Flushing => {
-                debug!("Stripe {stripe_id} is already queued or fetching");
+        }
+
+        // Handle completions from the target channel. We'll start flushing the
+        // ones that were successfully written to the target.
+        for (stripe_id, success) in self.fetch_target_channel.poll() {
+            if !success {
+                self.fetch_completed(stripe_id, false);
+                continue;
+            }
+
+            match self.stripe_states.get(&stripe_id) {
+                Some(FetchState::Fetching) => {
+                    debug!("Stripe {stripe_id} write completed, flushing...");
+                    if self.start_flush(stripe_id) {
+                        self.stripe_states.insert(stripe_id, FetchState::Flushing);
+                    } else {
+                        self.fetch_completed(stripe_id, false);
+                        continue;
+                    }
+                }
+                Some(FetchState::Flushing) => {
+                    self.fetch_completed(stripe_id, success);
+                }
+                _ => {
+                    error!("Unexpected state for stripe {stripe_id} after write");
+                }
             }
         }
     }
 
-    fn fetch_completed(&mut self, buffer_idx: usize, success: bool) -> (usize, bool) {
+    fn start_write(&mut self, buffer_idx: usize, stripe_id: usize) -> bool {
         let fetch_buffer = &mut self.fetch_buffers[buffer_idx];
-        let stripe_id = match fetch_buffer.used_for.take() {
-            Some(id) => id,
-            None => {
-                error!("fetch_completed called with unused buffer {buffer_idx}");
-                return (0, false);
-            }
-        };
+        let buf = fetch_buffer.clone();
 
-        debug!("Fetch completed for stripe {stripe_id}, success={success}");
-
-        if success {
-            self.stripe_status_vec
-                .set_stripe_status(stripe_id, StripeStatus::Fetched);
-        } else {
-            self.stripe_status_vec
-                .set_stripe_status(stripe_id, StripeStatus::Failed);
-        }
-        (stripe_id, success)
-    }
-
-    fn start_write(&mut self, buffer_idx: usize) -> bool {
-        let fetch_buffer = &mut self.fetch_buffers[buffer_idx];
-        let stripe_id = match fetch_buffer.used_for {
-            Some(id) => id,
-            None => {
-                error!("start_write called with unused buffer {buffer_idx}");
-                return false;
-            }
-        };
-        let buf = fetch_buffer.buf.clone();
         let stripe_sector_offset = stripe_id as u64 * self.stripe_sector_count;
         let stripe_sector_count = self
             .stripe_sector_count
@@ -236,7 +199,7 @@ impl StripeFetcher {
             stripe_sector_offset,
             stripe_sector_count as u32,
             buf,
-            buffer_idx,
+            stripe_id,
         );
 
         if let Err(e) = self.fetch_target_channel.submit() {
@@ -247,10 +210,8 @@ impl StripeFetcher {
         }
     }
 
-    fn start_flush(&mut self, buffer_idx: usize, stripe_id: usize) -> bool {
-        self.stripe_status_vec
-            .set_stripe_status(stripe_id, StripeStatus::Flushing);
-        self.fetch_target_channel.add_flush(buffer_idx);
+    fn start_flush(&mut self, stripe_id: usize) -> bool {
+        self.fetch_target_channel.add_flush(stripe_id);
 
         if let Err(e) = self.fetch_target_channel.submit() {
             error!("Failed to submit flush for stripe {stripe_id}: {e:?}");
@@ -260,97 +221,19 @@ impl StripeFetcher {
         }
     }
 
-    fn poll_fetches(&mut self) -> Vec<(usize, bool)> {
-        let mut result = Vec::new();
-        for (buffer_idx, success) in self.fetch_source_channel.poll() {
-            if !success || !self.start_write(buffer_idx) {
-                result.push(self.fetch_completed(buffer_idx, false));
-            }
+    fn fetch_completed(&mut self, stripe_id: usize, success: bool) {
+        debug!("Fetch completed for stripe {stripe_id}, success={success}");
+
+        self.stripe_states.remove(&stripe_id);
+        if success {
+            self.shared_state.set_stripe_fetched(stripe_id);
         }
 
-        for (buffer_idx, success) in self.fetch_target_channel.poll() {
-            if !success {
-                result.push(self.fetch_completed(buffer_idx, false));
-                continue;
-            }
-            let stripe_id = match self.fetch_buffers[buffer_idx].used_for {
-                Some(id) => id,
-                None => {
-                    error!("poll_fetches called with unused buffer {buffer_idx}");
-                    continue;
-                }
-            };
-            let status = self.stripe_status_vec.stripe_status(stripe_id);
-            match status {
-                StripeStatus::Fetching => {
-                    debug!("Stripe {stripe_id} write completed, flushing...");
-                    if !self.start_flush(buffer_idx, stripe_id) {
-                        result.push(self.fetch_completed(buffer_idx, false));
-                        continue;
-                    }
-                }
-                StripeStatus::Flushing => {
-                    self.stripe_status_vec
-                        .set_stripe_status(stripe_id, StripeStatus::Fetched);
-                    result.push(self.fetch_completed(buffer_idx, success));
-                }
-                _ => {
-                    error!("Unexpected status for stripe {stripe_id} after write: {status:?}");
-                }
-            }
+        if let Some(buffer_idx) = self.allocated_buffers.remove(&stripe_id) {
+            self.available_buffers.push_back(buffer_idx);
+        } else {
+            error!("No buffer allocated for stripe {stripe_id} on completion");
         }
-
-        result
-    }
-
-    fn start_fetches(&mut self) -> Vec<(usize, bool)> {
-        let mut result = Vec::new();
-
-        while let Some(stripe_id) = self.fetch_queue.pop_front() {
-            let maybe_buffer_idx = self
-                .fetch_buffers
-                .iter()
-                .position(|buf| buf.used_for.is_none());
-            let buffer_idx = match maybe_buffer_idx {
-                Some(idx) => idx,
-                None => {
-                    self.fetch_queue.push_front(stripe_id);
-                    break;
-                }
-            };
-            let fetch_buffer = &mut self.fetch_buffers[buffer_idx];
-            fetch_buffer.used_for = Some(stripe_id);
-
-            let buf = fetch_buffer.buf.clone();
-            let stripe_sector_offset = stripe_id as u64 * self.stripe_sector_count;
-            let stripe_sector_count = self
-                .stripe_sector_count
-                .min(self.source_sector_count - stripe_sector_offset);
-
-            self.fetch_source_channel.add_read(
-                stripe_sector_offset,
-                stripe_sector_count as u32,
-                buf.clone(),
-                buffer_idx,
-            );
-
-            if let Err(e) = self.fetch_source_channel.submit() {
-                error!("Failed to submit read for stripe {stripe_id}: {e:?}");
-                result.push(self.fetch_completed(buffer_idx, false));
-                continue;
-            }
-
-            self.stripe_status_vec
-                .set_stripe_status(stripe_id, StripeStatus::Fetching);
-        }
-
-        result
-    }
-
-    pub fn update(&mut self) -> Vec<(usize, bool)> {
-        let mut completed_fetches = self.start_fetches();
-        completed_fetches.append(&mut self.poll_fetches());
-        completed_fetches
     }
 }
 

--- a/src/vhost_backend/backend.rs
+++ b/src/vhost_backend/backend.rs
@@ -490,9 +490,13 @@ pub fn init_metadata(
             .ok_or_else(|| VhostUserBlockError::InvalidParameter {
                 description: "metadata_path is none".to_string(),
             })?;
+    let base_bdev = build_block_device(&config.path, config, kek.clone())?;
+    let stripe_sector_count = 1u64 << stripe_sector_count_shift;
+    let stripe_count = base_bdev.sector_count().div_ceil(stripe_sector_count) as usize;
+
     let metadata_bdev = build_block_device(metadata_path, config, kek.clone())?;
     let mut ch = metadata_bdev.create_channel()?;
-    let metadata = UbiMetadata::new(stripe_sector_count_shift);
+    let metadata = UbiMetadata::new(stripe_sector_count_shift, stripe_count);
     init_metadata_file(&metadata, &mut ch)?;
     Ok(())
 }


### PR DESCRIPTION
Now there's only a single copy of stripe headers, which is shared between UbiMetadata and SharedMetadataState.

SharedMetadataState is used in bdev_lazy, StripeFetcher, and MetadataFlusher to coordinate metadata changes using atomics.

StripeStatusVec and MetadataFlushState are removed and their use is replaced by SharedMetadataState.