### PR TITLE
Add e2e tests for interacting with vhost-backend

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,20 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y autoconf libtool nasm clang build-essential
+          sudo apt-get install -y autoconf libtool nasm clang build-essential clang-format meson docutils
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Clone and build libblkio
+        run: |
+          git clone https://gitlab.com/libblkio/libblkio.git
+          cd libblkio
+          meson setup build --prefix=/usr/local
+          meson compile -C build
+          sudo --preserve-env=PATH,RUSTUP_HOME,CARGO_HOME,HOME meson install -C build
 
       - name: Clone and build isa-l_crypto
         run: |
@@ -34,15 +47,13 @@ jobs:
           make -j$(nproc)
           sudo make install
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-            toolchain: stable
-            override: true
-            components: rustfmt, clippy
-
-      - name: Check formatting
+      - name: Check formatting (rust)
         run: cargo fmt --all -- --check
+
+      - name: Check formatting (e2e tests)
+        run: |
+          make format-tests
+          git diff --stat --exit-code
 
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
@@ -61,3 +72,11 @@ jobs:
 
       - name: Run tests without isa-l_crypto
         run: cargo test --features disable-isal-crypto
+
+      - name: Build project
+        run: cargo build
+
+      - name: Run e2e tests
+        run: |
+          mkdir -p target/tests/blkio/
+          make test-e2e

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+CC = gcc
+CFLAGS = -I/usr/local/include
+LDFLAGS = -L/usr/local/lib/x86_64-linux-gnu -lblkio
+
+TESTS_DIR = tests/blkio
+TARGET_TESTS_DIR = target/tests/blkio
+
+all: test-client create-base-image
+
+test-client: $(TESTS_DIR)/client.c
+	$(CC) -o $(TARGET_TESTS_DIR)/client $(TESTS_DIR)/client.c $(CFLAGS) $(LDFLAGS)
+
+create-base-image: $(TESTS_DIR)/create_base_image.c
+	$(CC) -o $(TARGET_TESTS_DIR)/create_base_image $(TESTS_DIR)/create_base_image.c $(CFLAGS)
+
+build-ubiblk:
+	cargo build
+
+populate-base-image: create-base-image
+	./$(TARGET_TESTS_DIR)/create_base_image $(TARGET_TESTS_DIR)/base.raw 2097152
+
+test-write-read: test-client
+	TEST_MODE=write_read ./$(TARGET_TESTS_DIR)/client
+
+test-lazy-read: test-client
+	TEST_MODE=lazy_read ./$(TARGET_TESTS_DIR)/client
+
+test-write-encrypted-data: test-client
+	TEST_MODE=write_encrypted_data ./$(TARGET_TESTS_DIR)/client
+
+test-e2e: test-client build-ubiblk
+	./$(TESTS_DIR)/run-tests.sh
+
+test-e2e-verbose: test-client build-ubiblk
+	RUST_LOG=debug RUST_BACKTRACE=full DEBUG=1 ./$(TESTS_DIR)/run-tests.sh
+
+format-tests:
+	clang-format -i $(TESTS_DIR)/*.c
+
+.PHONY: all test-client test-verbose test-write-read format-tests build-ubiblk

--- a/tests/blkio/client.c
+++ b/tests/blkio/client.c
@@ -1,0 +1,294 @@
+#include <blkio.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static bool debug_enabled = false;
+const char *driver = "virtio-blk-vhost-user";
+const char *socket_path = "target/tests/blkio/vhost.sock";
+
+typedef void (*blkioq_fn)(struct blkioq *, uint64_t, void *, size_t, void *,
+                          uint32_t);
+
+struct context {
+  struct blkio *bio;
+  struct blkioq *q;
+  struct blkio_mem_region write_region;
+  struct blkio_mem_region read_region;
+};
+
+void cleanup(struct context *ctx) {
+  if (ctx->bio)
+    blkio_destroy(&ctx->bio);
+}
+
+int handle_error(struct context *ctx, const char *msg, int ret) {
+  printf("%s: %d (%s), error_msg=%s\n", msg, ret, strerror(-ret),
+         blkio_get_error_msg());
+  cleanup(ctx);
+  return 1;
+}
+
+int init_context(struct context *ctx, const char *driver, const char *path) {
+  if (access(path, F_OK) != 0)
+    return handle_error(ctx, "Ubiblk socket file does not exist", -ENOENT);
+
+  int ret = blkio_create(driver, &ctx->bio);
+  if (ret < 0)
+    return handle_error(ctx, "Failed to create blkio driver", ret);
+
+  ret = blkio_set_str(ctx->bio, "path", path);
+  if (ret < 0)
+    return handle_error(ctx, "Error setting path", ret);
+
+  ret = blkio_connect(ctx->bio);
+  if (ret < 0)
+    return handle_error(ctx, "Error connecting", ret);
+
+  ret = blkio_start(ctx->bio);
+  if (ret < 0)
+    return handle_error(ctx, "Error starting", ret);
+
+  ctx->q = blkio_get_queue(ctx->bio, 0);
+  if (!ctx->q)
+    return handle_error(ctx, "Error getting queue", -ENOMEM);
+
+  return 0;
+}
+
+int setup_mem_region(struct context *ctx, struct blkio_mem_region *region,
+                     size_t size, const char *name) {
+  int ret = blkio_alloc_mem_region(ctx->bio, region, size);
+  if (ret < 0)
+    return handle_error(ctx, "Error allocating memory region", ret);
+  printf("Allocated %s memory region: addr=%p, len=%zu, fd=%d, fd_offset=%ld\n",
+         name, region->addr, region->len, region->fd, region->fd_offset);
+
+  ret = blkio_map_mem_region(ctx->bio, region);
+  if (ret < 0)
+    return handle_error(ctx, "Error mapping memory region", ret);
+  printf("Successfully mapped %s memory region of %zu bytes\n", name, size);
+  return 0;
+}
+
+int do_io(struct context *ctx, blkioq_fn io_func, uint64_t offset, void *buf,
+          size_t size, const char *op) {
+  struct blkio_completion completion = {0};
+  io_func(ctx->q, offset, buf, size, NULL, 0);
+  int ret = blkioq_do_io(ctx->q, &completion, 1, 1, NULL);
+  if (ret != 1)
+    return handle_error(ctx, "Error in blkioq_do_io", ret);
+  if (completion.ret != 0) {
+    printf("%s failed: ret=%d (%s), error_msg=%s\n", op, completion.ret,
+           strerror(-completion.ret),
+           completion.error_msg ? completion.error_msg : "none");
+    cleanup(ctx);
+    return 1;
+  }
+  if (debug_enabled)
+    printf("Successfully %s %zu bytes to/from offset 0x%lx\n", op, size,
+           offset);
+  return 0;
+}
+
+int write_read_test_with_block_size(size_t block_size) {
+  struct context ctx = {0};
+  size_t total_size = 4 * 1024 * 1024;
+  uint64_t offset = 0;
+
+  printf("Running write-read test with block size: %zu bytes\n", block_size);
+
+  if (init_context(&ctx, driver, socket_path))
+    return 1;
+
+  if (setup_mem_region(&ctx, &ctx.write_region, block_size, "write"))
+    return 1;
+
+  if (setup_mem_region(&ctx, &ctx.read_region, block_size, "read"))
+    return 1;
+
+  unsigned char *random_data = malloc(block_size);
+  if (!random_data) {
+    printf("Error allocating memory for random data\n");
+    cleanup(&ctx);
+    return 1;
+  }
+  FILE *urandom = fopen("/dev/urandom", "r");
+  if (!urandom) {
+    printf("Error opening /dev/urandom\n");
+    free(random_data);
+    cleanup(&ctx);
+    return 1;
+  }
+  fread(random_data, 1, block_size, urandom);
+  fclose(urandom);
+
+  while (offset < total_size) {
+    memcpy(ctx.write_region.addr, random_data, block_size);
+
+    if (do_io(&ctx, (blkioq_fn)blkioq_write, offset, ctx.write_region.addr,
+              block_size, "write"))
+      return 1;
+
+    if (do_io(&ctx, blkioq_read, offset, ctx.read_region.addr, block_size,
+              "read"))
+      return 1;
+
+    if (memcmp(ctx.read_region.addr, random_data, block_size) == 0) {
+      if (debug_enabled)
+        printf("Validation successful: read data matches written data at "
+               "offset 0x%lx\n",
+               offset);
+    } else {
+      printf("Validation failed: read data does not match written data at "
+             "offset 0x%lx\n",
+             offset);
+      printf("First 16 bytes read: ");
+      for (size_t i = 0; i < 16; i++)
+        printf("%02x ", ((unsigned char *)ctx.read_region.addr)[i]);
+      printf("\nExpected: ");
+      for (size_t i = 0; i < 16; i++)
+        printf("%02x ", random_data[i]);
+      printf("\n");
+      free(random_data);
+      cleanup(&ctx);
+      return 1;
+    }
+    offset += block_size;
+  }
+
+  if (!debug_enabled)
+    printf("All write blocks tested successfully with block size: %zu bytes\n",
+           block_size);
+
+  free(random_data);
+  cleanup(&ctx);
+  return 0;
+}
+
+int write_read_test() {
+  // Test with different block sizes: 4KB, 16KB, and 64KB
+  size_t block_sizes[] = {4096, 16384, 65536};
+  size_t num_block_sizes = sizeof(block_sizes) / sizeof(block_sizes[0]);
+
+  for (size_t i = 0; i < num_block_sizes; i++) {
+    if (write_read_test_with_block_size(block_sizes[i]) != 0) {
+      return 1;
+    }
+    // everytime we do a blkio_destroy, the vhost-backend restarts
+    // so we would wait for a second for it to become running again
+    sleep(1);
+  }
+
+  printf("All write-read tests completed successfully with all block sizes\n");
+  return 0;
+}
+
+int lazy_read_test() {
+  struct context ctx = {0};
+  size_t block_size = 4 * 1024;
+  size_t total_size = 2 * 1024 * 1024;
+  uint64_t offset = 0;
+
+  printf("Running lazy read test\n");
+
+  if (init_context(&ctx, driver, socket_path))
+    return 1;
+
+  if (setup_mem_region(&ctx, &ctx.read_region, block_size, "read"))
+    return 1;
+
+  while (offset < total_size) {
+    if (do_io(&ctx, blkioq_read, offset, ctx.read_region.addr, block_size,
+              "read"))
+      return 1;
+
+    // Validate the data read matches the expected pattern: (byte_offset * 111)
+    // & 0xff
+    unsigned char *data = (unsigned char *)ctx.read_region.addr;
+    int valid = 1;
+    for (size_t i = 0; i < block_size; i++) {
+      unsigned char expected = ((offset + i) * 111) & 0xff;
+      if (data[i] != expected) {
+        valid = 0;
+        printf(
+            "Validation failed at offset 0x%lx: expected 0x%02x, got 0x%02x\n",
+            offset + i, expected, data[i]);
+        break;
+      }
+    }
+
+    if (!valid) {
+      cleanup(&ctx);
+      return 1;
+    }
+
+    if (debug_enabled && (offset % (1024 * 1024) == 0))
+      printf("Validated %lu MB of lazy reads\n", offset / (1024 * 1024));
+
+    offset += block_size;
+  }
+
+  printf("Lazy read test completed successfully\n");
+
+  cleanup(&ctx);
+  return 0;
+}
+
+int encryption_test() {
+  struct context ctx = {0};
+  size_t block_size = 4 * 1024;
+  uint64_t offset = 3 * 1024 * 1024;
+
+  printf("Running encryption test\n");
+
+  if (init_context(&ctx, driver, socket_path))
+    return 1;
+
+  if (setup_mem_region(&ctx, &ctx.write_region, block_size, "write"))
+    return 1;
+
+  // Fill buffer with 'A' characters
+  memset(ctx.write_region.addr, 'A', block_size);
+
+  // Write the 'A's to the 3MB offset
+  if (do_io(&ctx, (blkioq_fn)blkioq_write, offset, ctx.write_region.addr,
+            block_size, "write"))
+    return 1;
+
+  printf("Successfully wrote 'A' characters to offset 3MB (0x%lx)\n", offset);
+
+  cleanup(&ctx);
+  return 0;
+}
+
+int main(int argc, char *argv[]) {
+  const char *test_mode = getenv("TEST_MODE");
+  const char *debug_env = getenv("DEBUG");
+
+  if (debug_env &&
+      (strcmp(debug_env, "true") == 0 || strcmp(debug_env, "1") == 0)) {
+    debug_enabled = true;
+  }
+
+  if (test_mode == NULL) {
+    test_mode = "write_read";
+  }
+
+  if (strcmp(test_mode, "write_read") == 0) {
+    return write_read_test();
+  } else if (strcmp(test_mode, "lazy_read") == 0) {
+    return lazy_read_test();
+  } else if (strcmp(test_mode, "write_encrypted_data") == 0) {
+    return encryption_test();
+  } else {
+    printf("Invalid TEST_MODE value: %s\n", test_mode);
+    printf("Valid options are: 'write_read' (default), 'lazy_read', or "
+           "'write_encrypted_data'\n");
+    return 1;
+  }
+}

--- a/tests/blkio/create_base_image.c
+++ b/tests/blkio/create_base_image.c
@@ -1,0 +1,54 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char *argv[]) {
+  if (argc != 3) {
+    fprintf(stderr, "Usage: %s <filename> <size_in_bytes>\n", argv[0]);
+    return 1;
+  }
+
+  const char *filename = argv[1];
+  size_t size = strtoull(argv[2], NULL, 10);
+
+  FILE *file = fopen(filename, "wb");
+  if (!file) {
+    perror("Error opening file");
+    return 1;
+  }
+
+  const size_t buffer_size = 64 * 1024;
+  uint8_t *buffer = malloc(buffer_size);
+  if (!buffer) {
+    fprintf(stderr, "Error allocating buffer\n");
+    fclose(file);
+    return 1;
+  }
+
+  size_t written = 0;
+  while (written < size) {
+    size_t to_write =
+        (size - written < buffer_size) ? (size - written) : buffer_size;
+
+    // Fill buffer with the pattern: (byte_offset * 111) & 0xff
+    for (size_t i = 0; i < to_write; i++) {
+      buffer[i] = ((written + i) * 111) & 0xff;
+    }
+
+    size_t result = fwrite(buffer, 1, to_write, file);
+    if (result != to_write) {
+      perror("Error writing to file");
+      free(buffer);
+      fclose(file);
+      return 1;
+    }
+
+    written += to_write;
+  }
+
+  free(buffer);
+  fclose(file);
+
+  printf("Successfully created %s with size %zu bytes\n", filename, size);
+  return 0;
+}

--- a/tests/blkio/run-tests.sh
+++ b/tests/blkio/run-tests.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+set -e
+
+exit_code=0
+PROJECT_ROOT=$(pwd)
+# To find the vhost-backend and init-metadata binaries
+export PATH=$(pwd)/target/debug:$PATH
+cd target/tests/blkio
+
+echo "Setting up disk..."
+# Always create/recreate these files
+rm -f disk.raw disk.metadata base.raw
+echo "Creating disk files (always recreated)..."
+truncate --size 4M disk.raw
+truncate --size 8K disk.metadata
+
+echo "Creating base image with pattern..."
+make -C $PROJECT_ROOT populate-base-image
+
+# Generate AES-XTS keys for disk encryption
+echo "Generating AES-XTS keys for disk encryption..."
+raw_key=$(openssl rand 64)
+key1=$(echo -n "$raw_key" | head -c 32 | base64 -w 0)
+key2=$(echo -n "$raw_key" | tail -c 32 | base64 -w 0)
+
+CONFIG_FILE="ubiblk-config.yaml"
+echo "Creating $CONFIG_FILE..."
+cat > "$CONFIG_FILE" << EOF
+path: "disk.raw"
+image_path: "base.raw"
+metadata_path: "disk.metadata"
+socket: "vhost.sock"
+num_queues: 4
+queue_size: 256
+seg_size_max: 4096
+seg_count_max: 1
+poll_queue_timeout_us: 500
+device_id: "vm123456"
+direct_io: true
+encryption_key:
+- $key1
+- $key2
+EOF
+
+STRIPE_SECTOR_COUNT_SHIFT=${STRIPE_SECTOR_COUNT_SHIFT:-11}
+if ! [[ "$STRIPE_SECTOR_COUNT_SHIFT" =~ ^[0-9]+$ ]] || [ "$STRIPE_SECTOR_COUNT_SHIFT" -lt 1 ] || \
+    [ "$STRIPE_SECTOR_COUNT_SHIFT" -gt 18 ]; then
+    echo "Error: STRIPE_SECTOR_COUNT_SHIFT must be a positive integer between 1 and 18"
+    exit 1
+fi
+echo "Initializing metadata with stripe sector count shift: $STRIPE_SECTOR_COUNT_SHIFT"
+init-metadata --config "$CONFIG_FILE" --stripe-sector-count-shift "$STRIPE_SECTOR_COUNT_SHIFT"
+
+echo "Starting vhost-backend in background..."
+vhost-backend --config "$CONFIG_FILE" &
+VHOST_PID=$!
+echo "vhost-backend started with PID: $VHOST_PID"
+
+echo $VHOST_PID > vhost-backend.pid
+echo "PID stored in vhost-backend.pid"
+
+sleep 1
+
+echo "Running lazy-read test..."
+make -C $PROJECT_ROOT test-lazy-read
+
+echo "Running write-read test..."
+make -C $PROJECT_ROOT test-write-read
+
+echo "Running encryption test..."
+make -C $PROJECT_ROOT test-write-encrypted-data
+echo "Checking encryption by reading raw disk data..."
+# Read 4KB from 3MB offset in the raw disk file
+dd if=disk.raw of=test_read.bin bs=4096 count=1 skip=768 2>/dev/null
+# Check if the data contains 'A's (it shouldn't if encryption is working)
+# 'A' in hex is 41, so we're looking for a sequence of 41s
+if hexdump -C test_read.bin | grep -q "41 41 41 41"; then
+    echo "ERROR: Encryption test failed - raw disk data contains 'A's"
+    exit_code=1
+else
+    echo "SUCCESS: Encryption test passed - raw disk data does not contain 'A's"
+fi
+
+echo "Stopping vhost-backend (PID: $VHOST_PID)..."
+kill $VHOST_PID
+wait $VHOST_PID 2>/dev/null || true
+rm -f vhost-backend.pid
+echo "Tests complete."
+exit $exit_code


### PR DESCRIPTION
New tests are added which tests the almost full functionality of ubiblk in production.

There are 3 set of tests:
- lazy-read tests: In these tests we make sure we are getting the data from the base image and testing its lazy read functionality
- write-read tests: fully writes all the blocks in a 4MB disk with random data in block sizes 4KB, 16KB and 64KB, then reading the block validating the right value stored in the disk.
- write-encrypted-data: makes sure the data written on the disk is actually encrypted.

There is a run-tests.sh script (located in tests/blkio) which sets up everything, including the base and disk images, running the init-metadata command and running a vhost-backend instance in background.

During the test, it makes sure to run cargo build and use the newly generated binaries located in target/debug to run the tests with.

Tests are written in C using the blkio library.

There are 2 files, one very simple with the name create_base_image.c which creates a base image with the formula (byte_offset * 111) & 0xff which is used in the lazy-read tests.

The other file is client.c which connects to the vhost-backend socket sending many read/write IO commands and testing e2e functionalities.

Debug feature is also added and you can run the tests with the command make test-verbose which logs the commands and their output which hopefully will come handy when debugging issues in the code.

The added Makefile is mostly used for test purposes and is not used for the ubiblk main operations.