### PR TITLE
Persist fetch metadata right after fetch is completed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ perform the write operation. However, reads are handled differently based on
 - **`copy_on_read = true`** – A read from an unfetched stripe triggers a fetch
   and completes once the stripe has been copied to the base device.
 
-The metadata is created with `init-metadata` and stored at `metadata_path`.  It
-contains a magic header and a byte for each stripe indicating whether that
-stripe has been fetched.
+The metadata is created with `init-metadata` and stored at `metadata_path`. The
+first sector contains a magic header, and subsequent sectors store a byte for
+each stripe indicating whether that stripe has been fetched.
 
 ## Key Encryption Key (KEK) File
 The keys in the configuration file can be encrypted using a KEK file. The KEK file should contain the encryption key in base64 format. The backend will use this key to decrypt the block device keys at runtime.

--- a/src/block_device/bdev_failing.rs
+++ b/src/block_device/bdev_failing.rs
@@ -75,6 +75,7 @@ pub struct FailingBlockDevice {
     state: Arc<Mutex<FailState>>,
 }
 
+#[allow(dead_code)]
 impl FailingBlockDevice {
     pub fn new(size: u64) -> Self {
         FailingBlockDevice {

--- a/src/block_device/bdev_lazy/bdev_lazy_tests.rs
+++ b/src/block_device/bdev_lazy/bdev_lazy_tests.rs
@@ -52,7 +52,6 @@ mod tests {
         let metadata_dev = TestBlockDevice::new(8 * 1024 * 1024);
 
         let target_mem = target_dev.mem.clone();
-        let target_metrics = target_dev.metrics.clone();
 
         let data = b"copy_on_read_data";
         let mut tmp = vec![0u8; SECTOR_SIZE];
@@ -97,7 +96,6 @@ mod tests {
         chan.submit().unwrap();
         let results = drive(&bgworker, &mut chan);
         assert_eq!(results, vec![(flush_id, true)]);
-        assert_eq!(target_metrics.read().unwrap().flushes, 3);
     }
 
     /// Verify that reads are served from the image when copy-on-read is
@@ -167,94 +165,5 @@ mod tests {
         chan.submit().unwrap();
         let results = drive(&bgworker, &mut chan);
         assert_eq!(results, vec![(flush_id, true)]);
-        assert_eq!(target_metrics.read().unwrap().flushes, 2);
-    }
-
-    /// Ensure that flush requests are completed only after metadata has been
-    /// written and flushed.
-    #[test]
-    fn test_flush_waits_for_metadata_flush() {
-        let stripe_shift = 12u8;
-        let stripe_sectors = 1u64 << stripe_shift;
-        let stripe_count: usize = 4;
-        let dev_size = stripe_sectors * SECTOR_SIZE as u64 * stripe_count as u64;
-
-        let source_dev = TestBlockDevice::new(dev_size);
-        let target_dev = TestBlockDevice::new(dev_size);
-        let metadata_dev = TestBlockDevice::new(8 * 1024 * 1024);
-
-        let target_metrics = target_dev.metrics.clone();
-
-        let mut ch = metadata_dev.create_channel().unwrap();
-        let metadata = UbiMetadata::new(stripe_shift, stripe_count, stripe_count);
-        init_metadata(&metadata, &mut ch).unwrap();
-
-        let bgworker: SharedBgWorker = Arc::new(Mutex::new(
-            BgWorker::new(&source_dev, &target_dev, &metadata_dev, 512).unwrap(),
-        ));
-
-        let lazy =
-            LazyBlockDevice::new(Box::new(target_dev), None, bgworker.clone(), false).unwrap();
-        let mut chan = lazy.create_channel().unwrap();
-
-        let flush_id = 42;
-        chan.add_flush(flush_id);
-        chan.submit().unwrap();
-
-        // Without running the bgworker, the flush should remain pending.
-        assert_eq!(target_metrics.read().unwrap().flushes, 0);
-        // Only the initial metadata write has been flushed so far.
-        assert_eq!(metadata_dev.flushes(), 1);
-
-        // Drive the bgworker and channel to completion.
-        let results = drive(&bgworker, &mut chan);
-        assert_eq!(results, vec![(flush_id, true)]);
-        assert_eq!(target_metrics.read().unwrap().flushes, 1);
-        assert_eq!(metadata_dev.flushes(), 2);
-    }
-
-    #[test]
-    fn test_track_written() {
-        let stripe_shift = 12u8;
-        let stripe_sectors = 1u64 << stripe_shift;
-        let stripe_count: usize = 4;
-        let dev_size = stripe_sectors * SECTOR_SIZE as u64 * stripe_count as u64;
-
-        let source_dev = TestBlockDevice::new(dev_size);
-        let target_dev = TestBlockDevice::new(dev_size);
-        let metadata_dev = TestBlockDevice::new(8 * 1024 * 1024);
-
-        let mut ch = metadata_dev.create_channel().unwrap();
-        let metadata = UbiMetadata::new(stripe_shift, stripe_count, stripe_count);
-        init_metadata(&metadata, &mut ch).unwrap();
-
-        let bgworker: SharedBgWorker = Arc::new(Mutex::new(
-            BgWorker::new(&source_dev, &target_dev, &metadata_dev, 512).unwrap(),
-        ));
-        let metadata_state = bgworker.lock().unwrap().shared_state();
-
-        let lazy =
-            LazyBlockDevice::new(Box::new(target_dev), None, bgworker.clone(), true).unwrap();
-        let mut chan = lazy.create_channel().unwrap();
-
-        // before write, all stripes are marked as not written to.
-        for i in 0..stripe_count {
-            assert!(!metadata_state.stripe_written(i));
-        }
-
-        let write_buf: SharedBuffer = Rc::new(RefCell::new(AlignedBuf::new(SECTOR_SIZE)));
-        chan.add_write(stripe_sectors + 1, 1, write_buf.clone(), 1);
-        chan.submit().unwrap();
-        let _ = drive(&bgworker, &mut chan);
-
-        // after write, stripe 1 is marked as written to.
-        assert!(metadata_state.stripe_written(1));
-        for i in 0..stripe_count {
-            if i == 1 {
-                assert!(metadata_state.stripe_written(i));
-            } else {
-                assert!(!metadata_state.stripe_written(i));
-            }
-        }
     }
 }

--- a/src/block_device/bdev_lazy/metadata/mod.rs
+++ b/src/block_device/bdev_lazy/metadata/mod.rs
@@ -8,6 +8,3 @@ pub use load::load_metadata;
 pub use shared_state::SharedMetadataState;
 pub use types::UbiMetadata;
 pub use types::UBI_MAGIC;
-
-#[cfg(test)]
-pub use types::UBI_MAGIC_SIZE;

--- a/src/block_device/bdev_lazy/metadata/shared_state.rs
+++ b/src/block_device/bdev_lazy/metadata/shared_state.rs
@@ -1,28 +1,27 @@
 use super::UbiMetadata;
 use std::sync::{
-    atomic::{AtomicU64, AtomicU8, Ordering},
+    atomic::{AtomicU8, Ordering},
     Arc,
 };
 
 #[derive(Debug, Clone)]
 pub struct SharedMetadataState {
     stripe_headers: Arc<Vec<AtomicU8>>,
-    metadata_version: Arc<AtomicU64>,
-    metadata_version_flushed: Arc<AtomicU64>,
     stripe_sector_count_shift: u8,
 }
 
 impl SharedMetadataState {
     pub fn new(metadata: &UbiMetadata) -> Self {
-        let stripe_headers = metadata.stripe_headers.clone();
-        // Start at version 1 so initial state is not considered flushed.
-        let metadata_version = Arc::new(AtomicU64::new(1));
-        let metadata_version_flushed = Arc::new(AtomicU64::new(0));
+        let stripe_headers = Arc::new(
+            metadata
+                .stripe_headers
+                .iter()
+                .map(|h| AtomicU8::new(*h))
+                .collect::<Vec<_>>(),
+        );
 
         Self {
             stripe_headers,
-            metadata_version,
-            metadata_version_flushed,
             stripe_sector_count_shift: metadata.stripe_sector_count_shift,
         }
     }
@@ -35,29 +34,6 @@ impl SharedMetadataState {
         (sector >> self.stripe_sector_count_shift) as usize
     }
 
-    pub fn increment_version(&self) {
-        self.metadata_version.fetch_add(1, Ordering::AcqRel);
-    }
-
-    pub fn set_flushed_version(&self, version: u64) {
-        self.metadata_version_flushed
-            .store(version, Ordering::Release);
-    }
-
-    pub fn flushed_version(&self) -> u64 {
-        self.metadata_version_flushed.load(Ordering::Acquire)
-    }
-
-    pub fn current_version(&self) -> u64 {
-        self.metadata_version.load(Ordering::Acquire)
-    }
-
-    pub fn needs_flush(&self) -> bool {
-        let flushed = self.metadata_version_flushed.load(Ordering::Acquire);
-        let current = self.metadata_version.load(Ordering::Acquire);
-        current > flushed
-    }
-
     pub fn stripe_fetched(&self, stripe_id: usize) -> bool {
         let header = self.stripe_headers[stripe_id].load(Ordering::Acquire);
         header & (1 << 0) != 0
@@ -68,17 +44,7 @@ impl SharedMetadataState {
         header & (1 << 1) != 0
     }
 
-    pub fn set_stripe_fetched(&self, stripe_id: usize) {
-        let prev_header = self.stripe_headers[stripe_id].fetch_or(1 << 0, Ordering::AcqRel);
-        if prev_header & (1 << 0) == 0 {
-            self.increment_version();
-        }
-    }
-
-    pub fn set_stripe_written(&self, stripe_id: usize) {
-        let prev_header = self.stripe_headers[stripe_id].fetch_or(1 << 1, Ordering::AcqRel);
-        if prev_header & (1 << 1) == 0 {
-            self.increment_version();
-        }
+    pub fn set_stripe_header(&self, stripe_id: usize, header: u8) {
+        self.stripe_headers[stripe_id].store(header, Ordering::Release);
     }
 }

--- a/src/utils/aligned_buffer_pool.rs
+++ b/src/utils/aligned_buffer_pool.rs
@@ -1,0 +1,65 @@
+use std::{cell::RefCell, collections::VecDeque, rc::Rc};
+
+use crate::block_device::SharedBuffer;
+
+use super::aligned_buffer::AlignedBuf;
+
+pub struct AlignedBufferPool {
+    buffers: Vec<SharedBuffer>,
+    available_buffers: VecDeque<usize>,
+}
+
+impl AlignedBufferPool {
+    pub fn new(alignment: usize, count: usize, size: usize) -> Self {
+        let mut buffers = Vec::with_capacity(count);
+        let mut available_buffers = VecDeque::with_capacity(count);
+        for _ in 0..count {
+            buffers.push(Rc::new(RefCell::new(AlignedBuf::new_with_alignment(
+                size, alignment,
+            ))));
+            available_buffers.push_back(buffers.len() - 1);
+        }
+        Self {
+            buffers,
+            available_buffers,
+        }
+    }
+
+    pub fn get_buffer(&mut self) -> Option<(SharedBuffer, usize)> {
+        if let Some(index) = self.available_buffers.pop_front() {
+            let buffer = self.buffers[index].clone();
+            Some((buffer, index))
+        } else {
+            None
+        }
+    }
+
+    pub fn return_buffer(&mut self, index: usize) {
+        if index < self.buffers.len() {
+            self.available_buffers.push_back(index);
+        } else {
+            panic!(
+                "Invalid buffer index {} returned to pool (max: {})",
+                index,
+                self.buffers.len() - 1
+            );
+        }
+    }
+
+    pub fn has_available(&self) -> bool {
+        !self.available_buffers.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_aligned_buffer_pool() {
+        let mut pool = AlignedBufferPool::new(4096, 10, 8192);
+        let (buffer, index) = pool.get_buffer().unwrap();
+        assert_eq!(buffer.borrow().len(), 8192);
+        pool.return_buffer(index);
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,9 @@
 pub mod aligned_buffer;
+pub mod aligned_buffer_pool;
 pub mod block;
 pub mod debug;
 
 pub use debug::*;
+
+pub use aligned_buffer::AlignedBuf;
+pub use aligned_buffer_pool::AlignedBufferPool;

--- a/src/vhost_backend/backend.rs
+++ b/src/vhost_backend/backend.rs
@@ -353,7 +353,7 @@ pub fn start_block_backend(
         let bgworker_ch = match bgworker.lock() {
             Ok(b) => Some(b.req_sender()),
             Err(e) => {
-                error!("Failed to lock bgworker mutex: {}", e);
+                error!("Failed to lock bgworker mutex: {e}");
                 None
             }
         };


### PR DESCRIPTION
To support write through mode we shouldn't have any unpersisted metadata in memory. So, this change persist the fetch metadata right after the stripe fetch but before servicing the block device write requests.

This change temporarily removes the logic to track the written header bit. We'll readd it in future commits.