### PR TITLE
Track writes if options.set_written is set.

### DIFF
--- a/src/block_device/bdev_lazy/bdev_lazy_tests.rs
+++ b/src/block_device/bdev_lazy/bdev_lazy_tests.rs
@@ -3,16 +3,91 @@ mod tests {
     use crate::block_device::SharedBuffer;
     use crate::block_device::{
         bdev_lazy::{init_metadata, BgWorker, LazyBlockDevice, SharedBgWorker, UbiMetadata},
-        bdev_test::TestBlockDevice,
+        bdev_test::{TestBlockDevice, TestDeviceMetrics},
         BlockDevice, IoChannel,
     };
     use crate::utils::aligned_buffer::AlignedBuf;
     use crate::vhost_backend::SECTOR_SIZE;
     use std::cell::RefCell;
     use std::rc::Rc;
-    use std::sync::{Arc, Mutex};
+    use std::sync::{Arc, Mutex, RwLock};
     use std::thread::sleep;
     use std::time::Duration;
+
+    const STRIPE_SHIFT: u8 = 12;
+    const STRIPE_COUNT: usize = 4;
+    const STRIPE_SECTORS: u64 = 1u64 << STRIPE_SHIFT;
+    const DEV_SIZE: u64 = STRIPE_SECTORS * SECTOR_SIZE as u64 * STRIPE_COUNT as u64;
+    const METADATA_SIZE: u64 = 8 * 1024 * 1024;
+
+    struct TestEnv {
+        lazy: Box<LazyBlockDevice>,
+        bgworker: SharedBgWorker,
+        stripe_sectors: u64,
+        target_mem: Arc<RwLock<Vec<u8>>>,
+        target_metrics: Arc<RwLock<TestDeviceMetrics>>,
+        image_metrics: Option<Arc<RwLock<TestDeviceMetrics>>>,
+    }
+
+    fn setup_env(with_image: bool, track_written: bool, data: &[u8]) -> TestEnv {
+        let target_dev = TestBlockDevice::new(DEV_SIZE);
+        let target_mem = target_dev.mem.clone();
+        let target_metrics = target_dev.metrics.clone();
+
+        let metadata_dev = TestBlockDevice::new(METADATA_SIZE);
+        let mut ch = metadata_dev.create_channel().unwrap();
+        let metadata = UbiMetadata::new(STRIPE_SHIFT, STRIPE_COUNT, STRIPE_COUNT);
+        init_metadata(&metadata, &mut ch).unwrap();
+
+        if with_image {
+            let image_dev = TestBlockDevice::new(DEV_SIZE);
+            if !data.is_empty() {
+                let mut tmp = vec![0u8; SECTOR_SIZE];
+                tmp[..data.len()].copy_from_slice(data);
+                image_dev.write(0, &tmp, SECTOR_SIZE);
+            }
+            let image_metrics = image_dev.metrics.clone();
+            let bgworker: SharedBgWorker = Arc::new(Mutex::new(
+                BgWorker::new(&image_dev, &target_dev, &metadata_dev, 512).unwrap(),
+            ));
+            let lazy = LazyBlockDevice::new(
+                Box::new(target_dev),
+                Some(Box::new(image_dev)),
+                bgworker.clone(),
+                track_written,
+            )
+            .unwrap();
+            TestEnv {
+                lazy,
+                bgworker,
+                stripe_sectors: STRIPE_SECTORS,
+                target_mem,
+                target_metrics,
+                image_metrics: Some(image_metrics),
+            }
+        } else {
+            let source_dev = TestBlockDevice::new(DEV_SIZE);
+            if !data.is_empty() {
+                let mut tmp = vec![0u8; SECTOR_SIZE];
+                tmp[..data.len()].copy_from_slice(data);
+                source_dev.write(0, &tmp, SECTOR_SIZE);
+            }
+            let bgworker: SharedBgWorker = Arc::new(Mutex::new(
+                BgWorker::new(&source_dev, &target_dev, &metadata_dev, 512).unwrap(),
+            ));
+            let lazy =
+                LazyBlockDevice::new(Box::new(target_dev), None, bgworker.clone(), track_written)
+                    .unwrap();
+            TestEnv {
+                lazy,
+                bgworker,
+                stripe_sectors: STRIPE_SECTORS,
+                target_mem,
+                target_metrics,
+                image_metrics: None,
+            }
+        }
+    }
 
     /// Poll the channel and the bgworker until all operations complete.
     fn drive(bgworker: &SharedBgWorker, chan: &mut Box<dyn IoChannel>) -> Vec<(usize, bool)> {
@@ -42,59 +117,40 @@ mod tests {
     /// and that queued writes are committed once the fetch completes.
     #[test]
     fn test_copy_on_read_true() {
-        let stripe_shift = 12u8;
-        let stripe_sectors = 1u64 << stripe_shift;
-        let stripe_count: usize = 4;
-        let dev_size = stripe_sectors * SECTOR_SIZE as u64 * stripe_count as u64;
-
-        let source_dev = TestBlockDevice::new(dev_size);
-        let target_dev = TestBlockDevice::new(dev_size);
-        let metadata_dev = TestBlockDevice::new(8 * 1024 * 1024);
-
-        let target_mem = target_dev.mem.clone();
-
-        let data = b"copy_on_read_data";
-        let mut tmp = vec![0u8; SECTOR_SIZE];
-        tmp[..data.len()].copy_from_slice(data);
-        source_dev.write(0, &tmp, SECTOR_SIZE);
-
-        let mut ch = metadata_dev.create_channel().unwrap();
-        let metadata = UbiMetadata::new(stripe_shift, stripe_count, stripe_count);
-        init_metadata(&metadata, &mut ch).unwrap();
-
-        let bgworker: SharedBgWorker = Arc::new(Mutex::new(
-            BgWorker::new(&source_dev, &target_dev, &metadata_dev, 512).unwrap(),
-        ));
-
-        let lazy =
-            LazyBlockDevice::new(Box::new(target_dev), None, bgworker.clone(), false).unwrap();
-        let mut chan = lazy.create_channel().unwrap();
+        let env = setup_env(false, false, b"copy_on_read_data");
+        let mut chan = env.lazy.create_channel().unwrap();
 
         let read_buf: SharedBuffer = Rc::new(RefCell::new(AlignedBuf::new(SECTOR_SIZE)));
         chan.add_read(0, 1, read_buf.clone(), 1);
         chan.submit().unwrap();
-        let results = drive(&bgworker, &mut chan);
+        let results = drive(&env.bgworker, &mut chan);
         assert_eq!(results, vec![(1, true)]);
-        assert_eq!(&read_buf.borrow().as_slice()[..data.len()], data);
-        assert_eq!(&target_mem.read().unwrap()[0..data.len()], data);
+        assert_eq!(
+            &read_buf.borrow().as_slice()[.."copy_on_read_data".len()],
+            b"copy_on_read_data"
+        );
+        assert_eq!(
+            &env.target_mem.read().unwrap()[0.."copy_on_read_data".len()],
+            b"copy_on_read_data"
+        );
 
         let write_data = b"queued_write";
         let write_buf: SharedBuffer = Rc::new(RefCell::new(AlignedBuf::new(SECTOR_SIZE)));
         write_buf.borrow_mut().as_mut_slice()[..write_data.len()].copy_from_slice(write_data);
-        chan.add_write(stripe_sectors, 1, write_buf.clone(), 2);
+        chan.add_write(env.stripe_sectors, 1, write_buf.clone(), 2);
         chan.submit().unwrap();
-        let results = drive(&bgworker, &mut chan);
+        let results = drive(&env.bgworker, &mut chan);
         assert_eq!(results, vec![(2, true)]);
-        let start = stripe_sectors as usize * SECTOR_SIZE;
+        let start = env.stripe_sectors as usize * SECTOR_SIZE;
         assert_eq!(
-            &target_mem.read().unwrap()[start..start + write_data.len()],
+            &env.target_mem.read().unwrap()[start..start + write_data.len()],
             write_data
         );
 
         let flush_id = 3;
         chan.add_flush(flush_id);
         chan.submit().unwrap();
-        let results = drive(&bgworker, &mut chan);
+        let results = drive(&env.bgworker, &mut chan);
         assert_eq!(results, vec![(flush_id, true)]);
     }
 
@@ -102,68 +158,100 @@ mod tests {
     /// disabled and that writes and flushes still operate on the target device.
     #[test]
     fn test_copy_on_read_false() {
-        let stripe_shift = 12u8;
-        let stripe_sectors = 1u64 << stripe_shift;
-        let stripe_count: usize = 4;
-        let dev_size = stripe_sectors * SECTOR_SIZE as u64 * stripe_count as u64;
-
-        let image_dev = TestBlockDevice::new(dev_size);
-        let target_dev = TestBlockDevice::new(dev_size);
-        let metadata_dev = TestBlockDevice::new(8 * 1024 * 1024);
-
-        let target_mem = target_dev.mem.clone();
-        let target_metrics = target_dev.metrics.clone();
-        let image_metrics = image_dev.metrics.clone();
-
-        let data = b"image_read";
-        let mut tmp = vec![0u8; SECTOR_SIZE];
-        tmp[..data.len()].copy_from_slice(data);
-        image_dev.write(0, &tmp, SECTOR_SIZE);
-
-        let mut ch = metadata_dev.create_channel().unwrap();
-        let metadata = UbiMetadata::new(stripe_shift, stripe_count, stripe_count);
-        init_metadata(&metadata, &mut ch).unwrap();
-
-        let bgworker: SharedBgWorker = Arc::new(Mutex::new(
-            BgWorker::new(&image_dev, &target_dev, &metadata_dev, 512).unwrap(),
-        ));
-
-        let lazy = LazyBlockDevice::new(
-            Box::new(target_dev),
-            Some(Box::new(image_dev)),
-            bgworker.clone(),
-            false,
-        )
-        .unwrap();
-        let mut chan = lazy.create_channel().unwrap();
+        let env = setup_env(true, false, b"image_read");
+        let mut chan = env.lazy.create_channel().unwrap();
 
         let read_buf: SharedBuffer = Rc::new(RefCell::new(AlignedBuf::new(SECTOR_SIZE)));
         chan.add_read(0, 1, read_buf.clone(), 1);
         chan.submit().unwrap();
-        let results = drive(&bgworker, &mut chan);
+        let results = drive(&env.bgworker, &mut chan);
         assert_eq!(results, vec![(1, true)]);
-        assert_eq!(&read_buf.borrow().as_slice()[..data.len()], data);
-        assert_ne!(&target_mem.read().unwrap()[0..data.len()], data);
-        assert_eq!(image_metrics.read().unwrap().reads, 1);
-        assert_eq!(target_metrics.read().unwrap().reads, 0);
+        assert_eq!(
+            &read_buf.borrow().as_slice()[.."image_read".len()],
+            b"image_read"
+        );
+        assert_ne!(
+            &env.target_mem.read().unwrap()[0.."image_read".len()],
+            b"image_read"
+        );
+        assert_eq!(env.image_metrics.as_ref().unwrap().read().unwrap().reads, 1);
+        assert_eq!(env.target_metrics.read().unwrap().reads, 0);
 
         let write_data = b"write_after_fetch";
         let write_buf: SharedBuffer = Rc::new(RefCell::new(AlignedBuf::new(SECTOR_SIZE)));
         write_buf.borrow_mut().as_mut_slice()[..write_data.len()].copy_from_slice(write_data);
-        chan.add_write(stripe_sectors, 1, write_buf.clone(), 2);
+        chan.add_write(env.stripe_sectors, 1, write_buf.clone(), 2);
         chan.submit().unwrap();
-        let results = drive(&bgworker, &mut chan);
+        let results = drive(&env.bgworker, &mut chan);
         assert_eq!(results, vec![(2, true)]);
-        let start = stripe_sectors as usize * SECTOR_SIZE;
+        let start = env.stripe_sectors as usize * SECTOR_SIZE;
         assert_eq!(
-            &target_mem.read().unwrap()[start..start + write_data.len()],
+            &env.target_mem.read().unwrap()[start..start + write_data.len()],
             write_data
         );
 
         let flush_id = 3;
         chan.add_flush(flush_id);
         chan.submit().unwrap();
-        let results = drive(&bgworker, &mut chan);
+        let results = drive(&env.bgworker, &mut chan);
+        assert_eq!(results, vec![(flush_id, true)]);
+    }
+
+    /// Verify that stripes are marked written when tracking is enabled.
+    #[test]
+    fn test_track_written_true() {
+        let env = setup_env(false, true, b"");
+        let mut chan = env.lazy.create_channel().unwrap();
+
+        let write_data = b"write_with_tracking";
+        let write_buf: SharedBuffer = Rc::new(RefCell::new(AlignedBuf::new(SECTOR_SIZE)));
+        write_buf.borrow_mut().as_mut_slice()[..write_data.len()].copy_from_slice(write_data);
+        chan.add_write(env.stripe_sectors, 1, write_buf.clone(), 1);
+        chan.submit().unwrap();
+        let results = drive(&env.bgworker, &mut chan);
+        assert_eq!(results, vec![(1, true)]);
+        let start = env.stripe_sectors as usize * SECTOR_SIZE;
+        assert_eq!(
+            &env.target_mem.read().unwrap()[start..start + write_data.len()],
+            write_data
+        );
+
+        let state = env.bgworker.lock().unwrap().shared_state();
+        assert!(state.stripe_written(1));
+
+        let flush_id = 2;
+        chan.add_flush(flush_id);
+        chan.submit().unwrap();
+        let results = drive(&env.bgworker, &mut chan);
+        assert_eq!(results, vec![(flush_id, true)]);
+    }
+
+    /// Verify tracking of written stripes when an image device is present.
+    #[test]
+    fn test_track_written_true_with_image() {
+        let env = setup_env(true, true, b"image_data");
+        let mut chan = env.lazy.create_channel().unwrap();
+
+        let write_data = b"track_image_write";
+        let write_buf: SharedBuffer = Rc::new(RefCell::new(AlignedBuf::new(SECTOR_SIZE)));
+        write_buf.borrow_mut().as_mut_slice()[..write_data.len()].copy_from_slice(write_data);
+        chan.add_write(env.stripe_sectors, 1, write_buf.clone(), 1);
+        chan.submit().unwrap();
+        let results = drive(&env.bgworker, &mut chan);
+        assert_eq!(results, vec![(1, true)]);
+        let start = env.stripe_sectors as usize * SECTOR_SIZE;
+        assert_eq!(
+            &env.target_mem.read().unwrap()[start..start + write_data.len()],
+            write_data
+        );
+
+        let state = env.bgworker.lock().unwrap().shared_state();
+        assert!(state.stripe_written(1));
+
+        let flush_id = 2;
+        chan.add_flush(flush_id);
+        chan.submit().unwrap();
+        let results = drive(&env.bgworker, &mut chan);
         assert_eq!(results, vec![(flush_id, true)]);
     }
 }

--- a/src/block_device/bdev_lazy/bgworker.rs
+++ b/src/block_device/bdev_lazy/bgworker.rs
@@ -10,7 +10,8 @@ use std::sync::{
 };
 
 pub enum BgWorkerRequest {
-    Fetch(usize),
+    Fetch { stripe_id: usize },
+    SetWritten { stripe_id: usize },
     Shutdown,
 }
 
@@ -60,7 +61,8 @@ impl BgWorker {
 
     pub fn process_request(&mut self, req: BgWorkerRequest) {
         match req {
-            BgWorkerRequest::Fetch(id) => self.stripe_fetcher.handle_fetch_request(id),
+            BgWorkerRequest::Fetch { stripe_id } => self.stripe_fetcher.handle_fetch_request(stripe_id),
+            BgWorkerRequest::SetWritten { stripe_id } => self.metadata_flusher.set_stripe_written(stripe_id),
             BgWorkerRequest::Shutdown => {
                 info!("Received shutdown request, stopping worker");
                 self.done = true;

--- a/src/block_device/bdev_lazy/bgworker.rs
+++ b/src/block_device/bdev_lazy/bgworker.rs
@@ -61,8 +61,12 @@ impl BgWorker {
 
     pub fn process_request(&mut self, req: BgWorkerRequest) {
         match req {
-            BgWorkerRequest::Fetch { stripe_id } => self.stripe_fetcher.handle_fetch_request(stripe_id),
-            BgWorkerRequest::SetWritten { stripe_id } => self.metadata_flusher.set_stripe_written(stripe_id),
+            BgWorkerRequest::Fetch { stripe_id } => {
+                self.stripe_fetcher.handle_fetch_request(stripe_id)
+            }
+            BgWorkerRequest::SetWritten { stripe_id } => {
+                self.metadata_flusher.set_stripe_written(stripe_id)
+            }
             BgWorkerRequest::Shutdown => {
                 info!("Received shutdown request, stopping worker");
                 self.done = true;

--- a/src/block_device/bdev_lazy/device.rs
+++ b/src/block_device/bdev_lazy/device.rs
@@ -70,7 +70,7 @@ impl LazyIoChannel {
                 && !self.stripe_fetches_requested.contains(&stripe_id)
             {
                 self.bgworker_ch
-                    .send(BgWorkerRequest::Fetch(stripe_id))
+                    .send(BgWorkerRequest::Fetch { stripe_id })
                     .map_err(|e| {
                         error!("Failed to send fetch request for stripe {stripe_id}: {e}");
                         VhostUserBlockError::ChannelError

--- a/src/block_device/bdev_lazy/metadata_flusher.rs
+++ b/src/block_device/bdev_lazy/metadata_flusher.rs
@@ -95,7 +95,6 @@ impl MetadataFlusher {
         });
     }
 
-    #[allow(dead_code)]
     pub fn set_stripe_written(&mut self, stripe_id: usize) {
         self.queued_requests.push_back(MetadataFlusherRequest {
             stripe_id,
@@ -163,7 +162,7 @@ impl MetadataFlusher {
             let (buf, index) = self.buffer_pool.get_buffer().unwrap();
             self.metadata.stripe_headers[req.stripe_id] |=
                 if req.kind == MetadataFlusherRequestKind::SetFetched {
-                    0b11
+                    0b01
                 } else {
                     0b10
                 };
@@ -232,7 +231,7 @@ mod tests {
 
         for stripe_id in 5..=6 {
             assert!(shared_state.stripe_fetched(stripe_id));
-            assert!(shared_state.stripe_written(stripe_id));
+            assert!(!shared_state.stripe_written(stripe_id));
         }
 
         metadata_flusher.set_stripe_written(7);


### PR DESCRIPTION
In the stripe headers section of metadata we track which stripes have been requested to be written. This can be used in the future to optimize cross-host disk moves.