### PR TITLE
Skip decryption on failed reads

### DIFF
--- a/src/block_device/bdev_crypt.rs
+++ b/src/block_device/bdev_crypt.rs
@@ -178,11 +178,13 @@ impl IoChannel for CryptIoChannel {
         for (id, result) in self.base.poll() {
             if id < self.read_requests.len() {
                 if let Some(req) = self.read_requests[id].take() {
-                    self.decrypt(
-                        req.buf.borrow_mut().as_mut_slice(),
-                        req.sector_offset,
-                        req.sector_count as u64,
-                    );
+                    if result {
+                        self.decrypt(
+                            req.buf.borrow_mut().as_mut_slice(),
+                            req.sector_offset,
+                            req.sector_count as u64,
+                        );
+                    }
                     results.push((id, result));
                     continue;
                 }


### PR DESCRIPTION
## Summary
- Skip decrypting read buffers when the underlying read fails

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo test --features disable-isal-crypto`


------
https://chatgpt.com/codex/tasks/task_e_68a63cfc1f788327ab08f14504310221