### PR TITLE
Add `Options.write_through`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ The configuration YAML must define:
 - `skip_sync`: (Optional) Skip flush handling for faster operation.
 - `copy_on_read`: (Optional) Copy stripes from the image only when accessed.
 - `track_written`: (Optional) Track stripes that have been written.
-- `direct_io`: (Optional) Use direct I/O (O_DIRECT) when accessing files. When enabled, request buffers are aligned to the larger of 4096 bytes or the host filesystem block size.
-- `sync_io`: (Optional) Open files with O_SYNC.
+- `write_through`: (Optional) Enable the write-through mode.
 - `encryption_key`: (Optional) AES-XTS keys provided as base64 encoded strings.
 - `io_debug_path`: (Optional) Path for I/O debug log.
 - `device_id`: (Optional) Identifier returned to the guest for GET_ID.
@@ -95,8 +94,7 @@ io_debug_path: "/tmp/io_debug.log"       # Optional: path for I/O debug log
 skip_sync: false                         # Optional: skip flush handling
 copy_on_read: false                      # Optional: copy stripes on first read
 track_written: false                     # Optional: track written stripes
-direct_io: true                          # Optional: use O_DIRECT
-sync_io: false                           # Optional: use O_SYNC
+write_through: false                     # Optional: enable write-through mode
 device_id: "ubiblk"                      # Optional: device identifier
 encryption_key:                          # Optional: AES‐XTS keys (base64 encoded)
   - "x74Yhe/ovgxY4BrBaM6Wm/9firf9k/N+ayvGsskBo+hjQtrL+nslCDC5oR/HpSDL"

--- a/src/vhost_backend/backend_tests.rs
+++ b/src/vhost_backend/backend_tests.rs
@@ -31,8 +31,7 @@ mod tests {
             skip_sync: false,
             copy_on_read: false,
             track_written: false,
-            direct_io: false,
-            sync_io: false,
+            write_through: true,
             encryption_key: None,
             device_id: "ubiblk".to_string(),
         }

--- a/src/vhost_backend/backend_thread_tests.rs
+++ b/src/vhost_backend/backend_thread_tests.rs
@@ -54,8 +54,7 @@ mod tests {
             skip_sync: false,
             copy_on_read: false,
             track_written: false,
-            direct_io: false,
-            sync_io: false,
+            write_through: true,
             encryption_key: None,
             device_id: "ubiblk".to_string(),
         }

--- a/src/vhost_backend/options.rs
+++ b/src/vhost_backend/options.rs
@@ -85,11 +85,7 @@ fn default_track_written() -> bool {
     false
 }
 
-fn default_direct_io() -> bool {
-    true
-}
-
-fn default_sync_io() -> bool {
+fn default_write_through() -> bool {
     false
 }
 
@@ -145,11 +141,8 @@ pub struct Options {
     #[serde(default = "default_track_written")]
     pub track_written: bool,
 
-    #[serde(default = "default_direct_io")]
-    pub direct_io: bool,
-
-    #[serde(default = "default_sync_io")]
-    pub sync_io: bool,
+    #[serde(default = "default_write_through")]
+    pub write_through: bool,
 
     #[serde(default, deserialize_with = "decode_encryption_keys")]
     pub encryption_key: Option<(Vec<u8>, Vec<u8>)>,
@@ -247,8 +240,7 @@ mod tests {
         let options: Options = from_str(yaml).unwrap();
         assert!(!options.copy_on_read);
         assert!(!options.track_written);
-        assert!(options.direct_io);
-        assert!(!options.sync_io);
+        assert!(!options.write_through);
         assert_eq!(options.device_id, "ubiblk".to_string());
     }
 
@@ -271,25 +263,14 @@ mod tests {
     }
 
     #[test]
-    fn test_direct_io_enabled() {
+    fn test_write_through_enabled() {
         let yaml = r#"
         path: "/path/to/image"
         socket: "/path/to/socket"
-        direct_io: true
+        write_through: true
         "#;
         let options: Options = from_str(yaml).unwrap();
-        assert!(options.direct_io);
-    }
-
-    #[test]
-    fn test_sync_enabled() {
-        let yaml = r#"
-        path: "/path/to/image"
-        socket: "/path/to/socket"
-        sync_io: true
-        "#;
-        let options: Options = from_str(yaml).unwrap();
-        assert!(options.sync_io);
+        assert!(options.write_through);
     }
 
     #[test]

--- a/tests/blkio/run-tests.sh
+++ b/tests/blkio/run-tests.sh
@@ -37,7 +37,6 @@ seg_size_max: 4096
 seg_count_max: 1
 poll_queue_timeout_us: 500
 device_id: "vm123456"
-direct_io: true
 encryption_key:
 - $key1
 - $key2


### PR DESCRIPTION
To enable the write through mode we need to several other things besides doing sync IO. So, this PR replaces the sync_io option with a more meaningful write_through.

This also removes the direct_io option since we use it always anyway.