### PR TITLE
chore: update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,12 @@ lto = true
 strip = true
 
 [dependencies]
-clap = { version = "4.5.40", features = ["cargo", "wrap_help", "derive"] }
+clap = { version = "4.5.45", features = ["cargo", "wrap_help", "derive"] }
 serde = { version = "1.0", features = ["derive"] }
 bincode = { version = "2.0.1", features = ["serde"] }
 libc = "0.2"
 smallvec = "1.15.1"
-thiserror = "2.0.12"
+thiserror = "2.0.16"
 nix = { version = "0.30.1", features = ["event", "fs"] }
 # vhost = { path = "../vhost/vhost", features = ["vhost-user-frontend"] }
 # vhost-user-backend = { path = "../vhost/vhost-user-backend" }
@@ -24,12 +24,12 @@ vmm-sys-util = "0.14.0"
 vm-memory = "0.16.2"
 virtio-bindings = "0.2.6"
 virtio-queue = "0.16.0"
-io-uring = "0.7.8"
+io-uring = "0.7.10"
 serde_yaml = "0.9.34"
 hex = "0.4.3"
 log = "0.4.27"
 env_logger = "0.11.8"
-tempfile = "3.20.0"
+tempfile = "3.21.0"
 serde_with = { version = "3.14.0", features = ["base64"] }
 base64 = "0.22.1"
 aes-gcm = "0.10.3"


### PR DESCRIPTION
## Summary
- bump clap to 4.5.45
- update thiserror to 2.0.16
- refresh io-uring and tempfile to latest releases

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo test --features disable-isal-crypto`


------
https://chatgpt.com/codex/tasks/task_e_68a94e7db3548327827d7712edad2261