### PR TITLE
Normalize permissions in release archives

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Package
         run: |
           cd target/${{ matrix.target }}/release
-          tar -czf vhost-backend-${{ matrix.arch }}.tar.gz vhost-backend init-metadata
+          tar --owner=0 --group=0 --numeric-owner --mode='a=rX,u+w' -czf vhost-backend-${{ matrix.arch }}.tar.gz vhost-backend init-metadata
           cd -
 
       - uses: ncipollo/release-action@v1


### PR DESCRIPTION
## Summary
- set explicit ownership and permissions when creating release tarballs

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo test --features disable-isal-crypto`


------
https://chatgpt.com/codex/tasks/task_e_68b2a095d18c8327bea5b1d704e74ec3