### PR TITLE
Prevent double return of pooled buffers

### DIFF
--- a/src/utils/aligned_buffer_pool.rs
+++ b/src/utils/aligned_buffer_pool.rs
@@ -7,43 +7,52 @@ use super::aligned_buffer::AlignedBuf;
 pub struct AlignedBufferPool {
     buffers: Vec<SharedBuffer>,
     available_buffers: VecDeque<usize>,
+    in_use: Vec<bool>,
 }
 
 impl AlignedBufferPool {
     pub fn new(alignment: usize, count: usize, size: usize) -> Self {
         let mut buffers = Vec::with_capacity(count);
         let mut available_buffers = VecDeque::with_capacity(count);
+        let mut in_use = Vec::with_capacity(count);
         for _ in 0..count {
             buffers.push(Rc::new(RefCell::new(AlignedBuf::new_with_alignment(
                 size, alignment,
             ))));
             available_buffers.push_back(buffers.len() - 1);
+            in_use.push(false);
         }
         Self {
             buffers,
             available_buffers,
+            in_use,
         }
     }
 
     pub fn get_buffer(&mut self) -> Option<(SharedBuffer, usize)> {
-        if let Some(index) = self.available_buffers.pop_front() {
-            let buffer = self.buffers[index].clone();
-            Some((buffer, index))
-        } else {
-            None
-        }
+        self.available_buffers.pop_front().map(|index| {
+            self.in_use[index] = true;
+            (self.buffers[index].clone(), index)
+        })
     }
 
     pub fn return_buffer(&mut self, index: usize) {
-        if index < self.buffers.len() {
-            self.available_buffers.push_back(index);
-        } else {
+        assert!(
+            index < self.buffers.len(),
+            "Invalid buffer index {} returned to pool (max: {})",
+            index,
+            self.buffers.len() - 1
+        );
+
+        if !self.in_use[index] {
             panic!(
-                "Invalid buffer index {} returned to pool (max: {})",
-                index,
-                self.buffers.len() - 1
+                "Buffer index {} was returned to the pool but is not currently in use",
+                index
             );
         }
+
+        self.in_use[index] = false;
+        self.available_buffers.push_back(index);
     }
 
     pub fn has_available(&self) -> bool {
@@ -78,6 +87,15 @@ mod tests {
         let mut pool = AlignedBufferPool::new(4096, 1, 512);
         // Only index 0 is valid
         pool.return_buffer(1);
+    }
+
+    #[test]
+    #[should_panic(expected = "not currently in use")]
+    fn test_returning_same_index_twice_panics() {
+        let mut pool = AlignedBufferPool::new(4096, 1, 512);
+        let (_, index) = pool.get_buffer().unwrap();
+        pool.return_buffer(index);
+        pool.return_buffer(index);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- track usage state for each buffer in the aligned buffer pool
- prevent returning buffers that are already available and add a regression test

## Testing
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo test --features disable-isal-crypto

------
https://chatgpt.com/codex/tasks/task_e_68c88f71a24083279c0b5117269e6a52