### PR TITLE
Bump ubiblk crate version to v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,7 +1180,7 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "ubiblk"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ubiblk"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [profile.release]


### PR DESCRIPTION
## Summary
- update the crate version in `Cargo.toml` to v0.3.0
- refresh the `Cargo.lock` entry for `ubiblk` to match the new version

## Testing
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo test --features disable-isal-crypto

------
https://chatgpt.com/codex/tasks/task_e_68c9c4d532f48327820042ae11cf3962