### PR TITLE
Ensure vhost-backend logs always dump in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,4 +82,5 @@ jobs:
           make test-e2e
 
       - name: Dump vhost-backend logs
+        if: ${{ always() }}
         run: cat target/tests/blkio/vhost-backend.log


### PR DESCRIPTION
## Summary
- ensure the vhost-backend log dumping step always runs in CI by adding an explicit condition

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e457766bf8832798340b1d70a68769