### PR TITLE
Ensure vhost backend logs always dump in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,4 +82,10 @@ jobs:
           make test-e2e
 
       - name: Dump vhost-backend logs
-        run: cat target/tests/blkio/vhost-backend.log
+        if: ${{ always() }}
+        run: |
+          if [ -f target/tests/blkio/vhost-backend.log ]; then
+            cat target/tests/blkio/vhost-backend.log
+          else
+            echo "No vhost-backend log found"
+          fi


### PR DESCRIPTION
## Summary
- ensure the vhost-backend log dumping step always runs in CI by using the `always()` condition
- guard the log dumping command so the workflow continues even if the log file was not created

## Testing
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo test --features disable-isal-crypto

------
https://chatgpt.com/codex/tasks/task_e_68e457766bf8832798340b1d70a68769