### PR TITLE
Decouple the bgworker thread from connections.

### DIFF
--- a/src/bin/vhost-backend.rs
+++ b/src/bin/vhost-backend.rs
@@ -80,5 +80,8 @@ fn main() {
         }
     }
 
-    block_backend_loop(&options, kek);
+    if let Err(e) = block_backend_loop(&options, kek) {
+        error!("Backend exited with error: {e}");
+        process::exit(1);
+    }
 }

--- a/src/block_device/bdev_crypt.rs
+++ b/src/block_device/bdev_crypt.rs
@@ -215,6 +215,14 @@ impl BlockDevice for CryptBlockDevice {
     fn sector_count(&self) -> u64 {
         self.base.sector_count()
     }
+
+    fn clone(&self) -> Box<dyn BlockDevice> {
+        Box::new(CryptBlockDevice {
+            base: self.base.clone(),
+            key1: self.key1,
+            key2: self.key2,
+        })
+    }
 }
 
 impl CryptBlockDevice {

--- a/src/block_device/bdev_null.rs
+++ b/src/block_device/bdev_null.rs
@@ -76,6 +76,10 @@ impl BlockDevice for NullBlockDevice {
     fn sector_count(&self) -> u64 {
         0
     }
+
+    fn clone(&self) -> Box<dyn BlockDevice> {
+        Box::new(NullBlockDevice)
+    }
 }
 
 #[cfg(test)]

--- a/src/block_device/bdev_sync.rs
+++ b/src/block_device/bdev_sync.rs
@@ -131,6 +131,14 @@ impl BlockDevice for SyncBlockDevice {
     fn sector_count(&self) -> u64 {
         self.sector_count
     }
+
+    fn clone(&self) -> Box<dyn BlockDevice> {
+        Box::new(SyncBlockDevice {
+            path: self.path.clone(),
+            sector_count: self.sector_count,
+            readonly: self.readonly,
+        })
+    }
 }
 
 impl SyncBlockDevice {

--- a/src/block_device/bdev_test.rs
+++ b/src/block_device/bdev_test.rs
@@ -123,6 +123,14 @@ impl BlockDevice for TestBlockDevice {
     fn sector_count(&self) -> u64 {
         self.sector_count
     }
+
+    fn clone(&self) -> Box<dyn BlockDevice> {
+        Box::new(TestBlockDevice {
+            sector_count: self.sector_count,
+            mem: self.mem.clone(),
+            metrics: self.metrics.clone(),
+        })
+    }
 }
 
 #[cfg(test)]

--- a/src/block_device/bdev_uring.rs
+++ b/src/block_device/bdev_uring.rs
@@ -184,6 +184,17 @@ impl BlockDevice for UringBlockDevice {
     fn sector_count(&self) -> u64 {
         self.sector_count
     }
+
+    fn clone(&self) -> Box<dyn BlockDevice> {
+        Box::new(UringBlockDevice {
+            path: self.path.clone(),
+            sector_count: self.sector_count,
+            queue_size: self.queue_size,
+            readonly: self.readonly,
+            direct_io: self.direct_io,
+            sync: self.sync,
+        })
+    }
 }
 
 impl UringBlockDevice {

--- a/src/block_device/mod.rs
+++ b/src/block_device/mod.rs
@@ -17,6 +17,13 @@ pub trait IoChannel {
 pub trait BlockDevice {
     fn create_channel(&self) -> Result<Box<dyn IoChannel>>;
     fn sector_count(&self) -> u64;
+    fn clone(&self) -> Box<dyn BlockDevice>;
+}
+
+impl Clone for Box<dyn BlockDevice> {
+    fn clone(&self) -> Box<dyn BlockDevice> {
+        self.as_ref().clone()
+    }
 }
 
 mod bdev_crypt;

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,8 @@ pub enum VhostUserBlockError {
     InvalidParameter { description: String },
     #[error("Metadata error: {description}")]
     MetadataError { description: String },
+    #[error("Other error: {description}")]
+    Other { description: String },
 }
 
 pub type Result<T> = std::result::Result<T, VhostUserBlockError>;

--- a/src/vhost_backend/backend_tests.rs
+++ b/src/vhost_backend/backend_tests.rs
@@ -4,11 +4,9 @@ mod tests {
     use crate::utils::aligned_buffer::BUFFER_ALIGNMENT;
     use crate::utils::block::VirtioBlockConfig;
     use crate::vhost_backend::{
-        init_metadata, start_block_backend, KeyEncryptionCipher, Options, UbiBlkBackend,
-        SECTOR_SIZE,
+        init_metadata, KeyEncryptionCipher, Options, UbiBlkBackend, SECTOR_SIZE,
     };
     use crate::VhostUserBlockError;
-    use tempfile::NamedTempFile;
     use vhost::vhost_user::message::VhostUserProtocolFeatures;
     use vhost_user_backend::VhostUserBackend;
     use virtio_bindings::virtio_blk::VIRTIO_BLK_F_FLUSH;
@@ -100,17 +98,6 @@ mod tests {
         let backend = UbiBlkBackend::new(&opts, mem, block_device, BUFFER_ALIGNMENT).unwrap();
         let err = backend.handle_event(1, EventSet::IN, &[], 0).unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::Other);
-    }
-
-    /// start_block_backend should return an error when image_path is specified without metadata_path.
-    #[test]
-    fn start_backend_missing_metadata() {
-        let tmp = NamedTempFile::new().unwrap();
-        tmp.as_file().set_len(SECTOR_SIZE as u64 * 8).unwrap();
-        let mut opts = default_options(tmp.path().to_string_lossy().to_string());
-        opts.image_path = Some("img2".to_string());
-        let res = start_block_backend(&opts, KeyEncryptionCipher::default());
-        assert!(res.is_err());
     }
 
     /// init_metadata should fail when metadata_path is missing.

--- a/src/vhost_backend/mod.rs
+++ b/src/vhost_backend/mod.rs
@@ -14,4 +14,4 @@ mod backend_tests;
 mod backend_thread_tests;
 
 #[cfg(test)]
-pub use backend::{start_block_backend, UbiBlkBackend};
+pub use backend::UbiBlkBackend;


### PR DESCRIPTION
Previously, we started the bgworker thread whenever a vhost connection was made. In future we'll add other tasks to the bgworker thread that should continue running independent of vhost connections. For example, when a disk with a remote base image is catching up with the remote base image.

For this reason, this commit starts a single bgworker thread as soon as the program starts running and reuses it for each vhost connection.