### PR TITLE
Add `IoChannel.stripe_has_data`.

### DIFF
--- a/src/block_device/mod.rs
+++ b/src/block_device/mod.rs
@@ -12,6 +12,10 @@ pub trait IoChannel {
 
     fn poll(&mut self) -> Vec<(usize, bool)>;
     fn busy(&self) -> bool;
+
+    fn stripe_has_data(&self, _stripe_id: u64) -> bool {
+        true
+    }
 }
 
 pub trait BlockDevice {


### PR DESCRIPTION
In future commits this will be used to do smarter copy-on-access: If a stripe at the base image doesn't have any data written to it, don't fetch it.

This method will have a meaningful implementation for remote bdev, in which fetching data over network is expensive.

Right now adding it to the interface so we can develop different components which rely on it.