### PR TITLE
docs: add RPC command reference and README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,16 +113,10 @@ echo "ublk_drv" | sudo tee /etc/modules-load.d/ublk.conf
 ## RPC Interface
 
 When `rpc_socket` is provided, the backend listens for newline-delimited
-JSON commands on the specified Unix socket. The following commands are
-supported:
+JSON commands on the specified Unix socket.
 
-- `{"command": "version"}` – returns the backend version string.
-- `{"command": "status"}` – returns the background worker status report or
-  `null` when no background worker is active.
-- `{"command": "queues"}` – returns an array of I/O activity snapshots for
-  each queue.
-- `{"command": "stats"}` – returns cumulative bytes and operation counts per
-  queue.
+For the full RPC command reference (including output specs and examples for
+all commands), see [docs/rpc.md](docs/rpc.md).
 
 Example using `nc` to query the status and pretty-print the response:
 

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -1,0 +1,150 @@
+# RPC Commands
+
+When `rpc_socket` is configured, the backend accepts newline-delimited JSON
+requests on the Unix socket and returns one JSON object per line.
+
+## Request format
+
+All requests use the same shape:
+
+```json
+{"command": "<name>"}
+```
+
+## `version`
+
+Returns the backend version.
+
+**Request**
+
+```json
+{"command": "version"}
+```
+
+**Output spec**
+
+- Top-level object with:
+  - `version` (string): backend version string.
+
+**Example response**
+
+```json
+{"version":"0.1.0"}
+```
+
+## `status`
+
+Returns the background worker status report.
+
+**Request**
+
+```json
+{"command": "status"}
+```
+
+**Output spec**
+
+- Top-level object with:
+  - `status` (object or `null`):
+    - `null` when no background worker is active.
+    - Otherwise, a status object from the backend reporter.
+
+**Example response**
+
+```json
+{
+  "status": {
+    "stripes": {
+      "fetched": 265,
+      "source": 3584,
+      "total": 40960
+    }
+  }
+}
+```
+
+## `queues`
+
+Returns a per-queue snapshot of recently observed I/O activity.
+
+**Request**
+
+```json
+{"command": "queues"}
+```
+
+**Output spec**
+
+- Top-level object with:
+  - `queues` (array): one entry per queue.
+    - Each queue entry is an array of I/O events.
+    - Event shapes:
+      - `["read", offset, length]`
+      - `["write", offset, length]`
+      - `["flush"]`
+
+**Example response**
+
+```json
+{
+  "queues": [
+    [
+      ["read", 0, 4096],
+      ["write", 8192, 4096],
+      ["flush"]
+    ],
+    [
+      ["read", 16384, 4096]
+    ]
+  ]
+}
+```
+
+## `stats`
+
+Returns cumulative counters for each queue.
+
+**Request**
+
+```json
+{"command": "stats"}
+```
+
+**Output spec**
+
+- Top-level object with:
+  - `stats` (object):
+    - `queues` (array): one object per queue, each containing:
+      - `bytes_read` (u64)
+      - `bytes_written` (u64)
+      - `read_ops` (u64)
+      - `write_ops` (u64)
+      - `flush_ops` (u64)
+
+**Example response**
+
+```json
+{
+  "stats": {
+    "queues": [
+      {
+        "bytes_read": 4096,
+        "bytes_written": 8192,
+        "read_ops": 1,
+        "write_ops": 2,
+        "flush_ops": 1
+      }
+    ]
+  }
+}
+```
+
+## Unknown command handling
+
+If `command` is not recognized, the backend returns an error object.
+
+**Example response**
+
+```json
+{"error":"unknown command: destroy_world"}
+```


### PR DESCRIPTION
### Motivation

- Provide a dedicated, machine-readable reference for the backend RPC commands so users and tools can understand request shapes, output specs and example responses.
- Keep the `README.md` concise while linking to a full command reference for maintainability and discoverability.

### Description

- Add `docs/rpc.md` documenting the RPC `version`, `status`, `queues`, and `stats` commands with request shape, output spec and concrete JSON examples for each command.
- Document unknown-command behavior and include an example error response in `docs/rpc.md`.
- Update `README.md` to replace the inline RPC command list with a link to `docs/rpc.md` while preserving the quick `nc` usage example.

### Testing

- Ran `cargo fmt --all -- --check` and it succeeded.
- Ran `cargo clippy --all-targets --all-features -- -D warnings` and it finished without warnings.
- Ran `cargo test` and the test suite completed successfully (`436 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfddbb43248327af951dfdab5378ae)