### PR TITLE
Add `s3_operation_timeout_secs` config

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -262,6 +262,7 @@ autofetch = false                           # optional, default: false
 | `endpoint` | string | no | — | Custom S3 endpoint URL |
 | `connections` | integer | no | 16 | Number of S3 connections (must be > 0) |
 | `autofetch` | boolean | no | false | Fetch stripes in the background |
+| `operation_timeout_ms` | integer | no | 60000 | S3 operation timeout in milliseconds |
 
 ### Remote
 

--- a/src/archive/s3_store/s3_store_workers.rs
+++ b/src/archive/s3_store/s3_store_workers.rs
@@ -9,6 +9,7 @@ use log::{debug, error, info, warn};
 
 use super::{S3ByteStream, S3Client, S3Request, S3Result};
 use crate::Result;
+
 struct WorkerContext {
     client: S3Client,
     bucket: Arc<String>,

--- a/src/config/v2/stripe_source.rs
+++ b/src/config/v2/stripe_source.rs
@@ -149,6 +149,8 @@ pub enum ArchiveStorageConfig {
         endpoint: Option<String>,
         #[serde(default = "default_connections")]
         connections: usize,
+        #[serde(default = "default_operation_timeout_ms")]
+        operation_timeout_ms: u64,
         archive_kek: Option<SecretRef>,
         #[serde(default)]
         autofetch: bool,
@@ -157,6 +159,10 @@ pub enum ArchiveStorageConfig {
 
 fn default_connections() -> usize {
     16
+}
+
+fn default_operation_timeout_ms() -> u64 {
+    60000
 }
 
 impl ArchiveStorageConfig {
@@ -172,6 +178,7 @@ impl ArchiveStorageConfig {
             ArchiveStorageConfig::S3 {
                 prefix,
                 connections,
+                operation_timeout_ms,
                 access_key_id,
                 secret_access_key,
                 session_token,
@@ -199,7 +206,8 @@ impl ArchiveStorageConfig {
                     )?)?;
                 }
                 Self::validate_prefix(prefix)?;
-                Self::validate_connections(connections)
+                Self::validate_connections(connections)?;
+                Self::validate_operation_timeout_ms(operation_timeout_ms)
             }
         }
     }
@@ -222,6 +230,15 @@ impl ArchiveStorageConfig {
         if *connections == 0 {
             return Err(crate::ubiblk_error!(InvalidParameter {
                 description: "S3 connections must be greater than 0".to_string(),
+            }));
+        }
+        Ok(())
+    }
+
+    fn validate_operation_timeout_ms(operation_timeout_ms: &u64) -> crate::Result<()> {
+        if *operation_timeout_ms == 0 {
+            return Err(crate::ubiblk_error!(InvalidParameter {
+                description: "S3 operation timeout must be greater than 0 seconds".to_string(),
             }));
         }
         Ok(())
@@ -365,6 +382,7 @@ mod tests {
                 autofetch: false,
                 connections: 16,
                 endpoint: None,
+                operation_timeout_ms: 60000,
             })
         );
     }
@@ -394,6 +412,38 @@ mod tests {
                 autofetch: false,
                 connections: 16,
                 endpoint: None,
+                operation_timeout_ms: 60000,
+            })
+        );
+    }
+
+    #[test]
+    fn archive_s3_custom_timeout() {
+        let toml = r#"
+            type = "archive"
+            storage = "s3"
+            bucket = "encrypted-stripes"
+            region = "eu-west-1"
+            access_key_id.ref = "aws-access-key-id"
+            secret_access_key.ref = "aws-secret-access-key"
+            archive_kek.ref = "archive-kek"
+            operation_timeout_ms = 120
+        "#;
+        let config: StripeSourceConfig = toml::from_str(toml).unwrap();
+        assert_eq!(
+            config,
+            StripeSourceConfig::Archive(ArchiveStorageConfig::S3 {
+                bucket: "encrypted-stripes".to_string(),
+                prefix: None,
+                region: Some("eu-west-1".to_string()),
+                access_key_id: SecretRef::Ref("aws-access-key-id".to_string()),
+                secret_access_key: SecretRef::Ref("aws-secret-access-key".to_string()),
+                session_token: None,
+                archive_kek: Some(SecretRef::Ref("archive-kek".to_string())),
+                autofetch: false,
+                connections: 16,
+                endpoint: None,
+                operation_timeout_ms: 120,
             })
         );
     }
@@ -673,6 +723,7 @@ mod tests {
             autofetch: false,
             connections: 16,
             endpoint: None,
+            operation_timeout_ms: 60000,
         });
         let danger_zone = DangerZone::default();
         let result = config.validate(&danger_zone, &valid_s3_secrets());
@@ -715,6 +766,7 @@ mod tests {
             autofetch: false,
             connections: 16,
             endpoint: None,
+            operation_timeout_ms: 60000,
         });
 
         let result = config.validate(&DangerZone::default(), &secrets);
@@ -736,11 +788,33 @@ mod tests {
             autofetch: false,
             connections: 0,
             endpoint: None,
+            operation_timeout_ms: 60000,
         });
         let danger_zone = DangerZone::default();
         let result = config.validate(&danger_zone, &valid_s3_secrets());
         assert!(result.is_err());
         let error_msg = result.err().unwrap().to_string();
         assert!(error_msg.contains("S3 connections must be greater than 0"));
+    }
+
+    #[test]
+    fn validate_rejects_invalid_s3_operation_timeout() {
+        let config = StripeSourceConfig::Archive(ArchiveStorageConfig::S3 {
+            bucket: "bucket".to_string(),
+            prefix: None,
+            region: Some("us-east-1".to_string()),
+            access_key_id: SecretRef::Ref("key".to_string()),
+            secret_access_key: SecretRef::Ref("secret".to_string()),
+            session_token: None,
+            archive_kek: Some(SecretRef::Ref("kek".to_string())),
+            autofetch: false,
+            connections: 16,
+            endpoint: None,
+            operation_timeout_ms: 0,
+        });
+        let result = config.validate(&DangerZone::default(), &valid_s3_secrets());
+        assert!(result.is_err());
+        let error_msg = result.err().unwrap().to_string();
+        assert!(error_msg.contains("S3 operation timeout must be greater than 0 seconds"));
     }
 }

--- a/src/stripe_source/builder.rs
+++ b/src/stripe_source/builder.rs
@@ -157,6 +157,7 @@ impl StripeSourceBuilder {
                 session_token,
                 connections,
                 endpoint,
+                operation_timeout_ms,
                 ..
             } => {
                 let decrypted_credentials = Self::build_aws_credentials(
@@ -172,6 +173,7 @@ impl StripeSourceBuilder {
                     endpoint.as_deref(),
                     region.as_deref(),
                     decrypted_credentials,
+                    *operation_timeout_ms,
                 )?;
 
                 Ok(Box::new(S3Store::new(
@@ -394,6 +396,7 @@ mod tests {
             session_token: None,
             endpoint: None,
             connections: 4,
+            operation_timeout_ms: 60,
             archive_kek: Some(SecretRef::Ref("my_kek".to_string())),
             autofetch: false,
         };

--- a/src/utils/s3.rs
+++ b/src/utils/s3.rs
@@ -1,6 +1,7 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use aws_config::{BehaviorVersion, Region};
+use aws_sdk_s3::config::timeout::TimeoutConfig;
 
 use crate::Result;
 
@@ -22,6 +23,7 @@ pub fn build_s3_client(
     endpoint: Option<&str>,
     region: Option<&str>,
     credentials: Option<aws_sdk_s3::config::Credentials>,
+    operation_timeout_ms: u64,
 ) -> Result<aws_sdk_s3::Client> {
     let config = runtime.block_on(async {
         let mut loader = aws_config::defaults(BehaviorVersion::latest());
@@ -42,6 +44,10 @@ pub fn build_s3_client(
     });
 
     let mut builder = aws_sdk_s3::config::Builder::from(&config);
+    let timeout_config = TimeoutConfig::builder()
+        .operation_timeout(Duration::from_millis(operation_timeout_ms))
+        .build();
+    builder = builder.timeout_config(timeout_config);
 
     if let Some(endpoint) = endpoint {
         builder = builder.endpoint_url(endpoint);
@@ -76,6 +82,7 @@ mod tests {
             Some("http://localhost:9000"),
             Some("auto"),
             Some(credentials),
+            60,
         )
         .expect("client should be created");
 
@@ -84,6 +91,12 @@ mod tests {
         assert!(
             endpoint_debug.contains("localhost:9000"),
             "S3 client config should contain the custom endpoint"
+        );
+
+        let timeout_debug = format!("{:?}", conf.timeout_config());
+        assert!(
+            timeout_debug.contains("60s"),
+            "S3 client timeout config should contain 60 seconds operation timeout"
         );
     }
 }


### PR DESCRIPTION
Configures a per-operation timeout for the S3 client. Defaults to 60 seconds.