### PR TITLE
Add S3 client tuning (timeouts and retry attempts) and wire through config, builder and utils

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -262,6 +262,9 @@ autofetch = false                           # optional, default: false
 | `endpoint` | string | no | — | Custom S3 endpoint URL |
 | `connections` | integer | no | 16 | Number of S3 connections (must be > 0) |
 | `autofetch` | boolean | no | false | Fetch stripes in the background |
+| `connect_timeout_ms` | integer | no | 5000 | S3 connection timeout in milliseconds |
+| `operation_attempt_timeout_ms` | integer | no | 20000 | S3 operation attempt timeout in milliseconds |
+| `max_attempts` | integer | no | 3 | Max S3 operation attempts (initial attempt + retries) |
 
 ### Remote
 

--- a/src/archive/s3_store/s3_store_workers.rs
+++ b/src/archive/s3_store/s3_store_workers.rs
@@ -9,6 +9,7 @@ use log::{debug, error, info, warn};
 
 use super::{S3ByteStream, S3Client, S3Request, S3Result};
 use crate::Result;
+
 struct WorkerContext {
     client: S3Client,
     bucket: Arc<String>,

--- a/src/config/v2/stripe_source.rs
+++ b/src/config/v2/stripe_source.rs
@@ -149,6 +149,12 @@ pub enum ArchiveStorageConfig {
         endpoint: Option<String>,
         #[serde(default = "default_connections")]
         connections: usize,
+        #[serde(default = "default_connect_timeout_ms")]
+        connect_timeout_ms: u64,
+        #[serde(default = "default_operation_attempt_timeout_ms")]
+        operation_attempt_timeout_ms: u64,
+        #[serde(default = "default_max_attempts")]
+        max_attempts: u32,
         archive_kek: Option<SecretRef>,
         #[serde(default)]
         autofetch: bool,
@@ -157,6 +163,18 @@ pub enum ArchiveStorageConfig {
 
 fn default_connections() -> usize {
     16
+}
+
+fn default_connect_timeout_ms() -> u64 {
+    5_000
+}
+
+fn default_operation_attempt_timeout_ms() -> u64 {
+    20_000
+}
+
+fn default_max_attempts() -> u32 {
+    3
 }
 
 impl ArchiveStorageConfig {
@@ -172,6 +190,9 @@ impl ArchiveStorageConfig {
             ArchiveStorageConfig::S3 {
                 prefix,
                 connections,
+                connect_timeout_ms,
+                operation_attempt_timeout_ms,
+                max_attempts,
                 access_key_id,
                 secret_access_key,
                 session_token,
@@ -199,7 +220,10 @@ impl ArchiveStorageConfig {
                     )?)?;
                 }
                 Self::validate_prefix(prefix)?;
-                Self::validate_connections(connections)
+                Self::validate_connections(connections)?;
+                Self::validate_connect_timeout_ms(connect_timeout_ms)?;
+                Self::validate_operation_attempt_timeout_ms(operation_attempt_timeout_ms)?;
+                Self::validate_max_attempts(max_attempts)
             }
         }
     }
@@ -222,6 +246,35 @@ impl ArchiveStorageConfig {
         if *connections == 0 {
             return Err(crate::ubiblk_error!(InvalidParameter {
                 description: "S3 connections must be greater than 0".to_string(),
+            }));
+        }
+        Ok(())
+    }
+
+    fn validate_connect_timeout_ms(connect_timeout_ms: &u64) -> crate::Result<()> {
+        if *connect_timeout_ms == 0 {
+            return Err(crate::ubiblk_error!(InvalidParameter {
+                description: "S3 connect_timeout_ms must be greater than 0".to_string(),
+            }));
+        }
+        Ok(())
+    }
+
+    fn validate_operation_attempt_timeout_ms(
+        operation_attempt_timeout_ms: &u64,
+    ) -> crate::Result<()> {
+        if *operation_attempt_timeout_ms == 0 {
+            return Err(crate::ubiblk_error!(InvalidParameter {
+                description: "S3 operation_attempt_timeout_ms must be greater than 0".to_string(),
+            }));
+        }
+        Ok(())
+    }
+
+    fn validate_max_attempts(max_attempts: &u32) -> crate::Result<()> {
+        if *max_attempts == 0 {
+            return Err(crate::ubiblk_error!(InvalidParameter {
+                description: "S3 max_attempts must be greater than 0".to_string(),
             }));
         }
         Ok(())
@@ -365,6 +418,9 @@ mod tests {
                 autofetch: false,
                 connections: 16,
                 endpoint: None,
+                connect_timeout_ms: 5_000,
+                operation_attempt_timeout_ms: 20_000,
+                max_attempts: 3,
             })
         );
     }
@@ -394,6 +450,44 @@ mod tests {
                 autofetch: false,
                 connections: 16,
                 endpoint: None,
+                connect_timeout_ms: 5_000,
+                operation_attempt_timeout_ms: 20_000,
+                max_attempts: 3,
+            })
+        );
+    }
+
+    #[test]
+    fn archive_s3_custom_retry_and_timeout_config() {
+        let toml = r#"
+            type = "archive"
+            storage = "s3"
+            bucket = "encrypted-stripes"
+            region = "eu-west-1"
+            access_key_id.ref = "aws-access-key-id"
+            secret_access_key.ref = "aws-secret-access-key"
+            archive_kek.ref = "archive-kek"
+            connect_timeout_ms = 120
+            operation_attempt_timeout_ms = 45000
+            max_attempts = 7
+        "#;
+        let config: StripeSourceConfig = toml::from_str(toml).unwrap();
+        assert_eq!(
+            config,
+            StripeSourceConfig::Archive(ArchiveStorageConfig::S3 {
+                bucket: "encrypted-stripes".to_string(),
+                prefix: None,
+                region: Some("eu-west-1".to_string()),
+                access_key_id: SecretRef::Ref("aws-access-key-id".to_string()),
+                secret_access_key: SecretRef::Ref("aws-secret-access-key".to_string()),
+                session_token: None,
+                archive_kek: Some(SecretRef::Ref("archive-kek".to_string())),
+                autofetch: false,
+                connections: 16,
+                endpoint: None,
+                connect_timeout_ms: 120,
+                operation_attempt_timeout_ms: 45_000,
+                max_attempts: 7,
             })
         );
     }
@@ -673,6 +767,9 @@ mod tests {
             autofetch: false,
             connections: 16,
             endpoint: None,
+            connect_timeout_ms: 5_000,
+            operation_attempt_timeout_ms: 20_000,
+            max_attempts: 3,
         });
         let danger_zone = DangerZone::default();
         let result = config.validate(&danger_zone, &valid_s3_secrets());
@@ -715,6 +812,9 @@ mod tests {
             autofetch: false,
             connections: 16,
             endpoint: None,
+            connect_timeout_ms: 5_000,
+            operation_attempt_timeout_ms: 20_000,
+            max_attempts: 3,
         });
 
         let result = config.validate(&DangerZone::default(), &secrets);
@@ -736,11 +836,83 @@ mod tests {
             autofetch: false,
             connections: 0,
             endpoint: None,
+            connect_timeout_ms: 5_000,
+            operation_attempt_timeout_ms: 20_000,
+            max_attempts: 3,
         });
         let danger_zone = DangerZone::default();
         let result = config.validate(&danger_zone, &valid_s3_secrets());
         assert!(result.is_err());
         let error_msg = result.err().unwrap().to_string();
         assert!(error_msg.contains("S3 connections must be greater than 0"));
+    }
+
+    #[test]
+    fn validate_rejects_invalid_s3_connect_timeout() {
+        let config = StripeSourceConfig::Archive(ArchiveStorageConfig::S3 {
+            bucket: "bucket".to_string(),
+            prefix: None,
+            region: Some("us-east-1".to_string()),
+            access_key_id: SecretRef::Ref("key".to_string()),
+            secret_access_key: SecretRef::Ref("secret".to_string()),
+            session_token: None,
+            archive_kek: Some(SecretRef::Ref("kek".to_string())),
+            autofetch: false,
+            connections: 16,
+            endpoint: None,
+            connect_timeout_ms: 0,
+            operation_attempt_timeout_ms: 20_000,
+            max_attempts: 3,
+        });
+        let result = config.validate(&DangerZone::default(), &valid_s3_secrets());
+        assert!(result.is_err());
+        let error_msg = result.err().unwrap().to_string();
+        assert!(error_msg.contains("S3 connect_timeout_ms must be greater than 0"));
+    }
+
+    #[test]
+    fn validate_rejects_invalid_s3_operation_attempt_timeout() {
+        let config = StripeSourceConfig::Archive(ArchiveStorageConfig::S3 {
+            bucket: "bucket".to_string(),
+            prefix: None,
+            region: Some("us-east-1".to_string()),
+            access_key_id: SecretRef::Ref("key".to_string()),
+            secret_access_key: SecretRef::Ref("secret".to_string()),
+            session_token: None,
+            archive_kek: Some(SecretRef::Ref("kek".to_string())),
+            autofetch: false,
+            connections: 16,
+            endpoint: None,
+            connect_timeout_ms: 5_000,
+            operation_attempt_timeout_ms: 0,
+            max_attempts: 3,
+        });
+        let result = config.validate(&DangerZone::default(), &valid_s3_secrets());
+        assert!(result.is_err());
+        let error_msg = result.err().unwrap().to_string();
+        assert!(error_msg.contains("S3 operation_attempt_timeout_ms must be greater than 0"));
+    }
+
+    #[test]
+    fn validate_rejects_invalid_s3_max_attempts() {
+        let config = StripeSourceConfig::Archive(ArchiveStorageConfig::S3 {
+            bucket: "bucket".to_string(),
+            prefix: None,
+            region: Some("us-east-1".to_string()),
+            access_key_id: SecretRef::Ref("key".to_string()),
+            secret_access_key: SecretRef::Ref("secret".to_string()),
+            session_token: None,
+            archive_kek: Some(SecretRef::Ref("kek".to_string())),
+            autofetch: false,
+            connections: 16,
+            endpoint: None,
+            connect_timeout_ms: 5_000,
+            operation_attempt_timeout_ms: 20_000,
+            max_attempts: 0,
+        });
+        let result = config.validate(&DangerZone::default(), &valid_s3_secrets());
+        assert!(result.is_err());
+        let error_msg = result.err().unwrap().to_string();
+        assert!(error_msg.contains("S3 max_attempts must be greater than 0"));
     }
 }

--- a/src/stripe_source/builder.rs
+++ b/src/stripe_source/builder.rs
@@ -11,7 +11,7 @@ use crate::{
         stripe_source::ArchiveStorageConfig,
     },
     stripe_server::connect_to_stripe_server,
-    utils::s3::{build_s3_client, create_runtime},
+    utils::s3::{build_s3_client, create_runtime, S3ClientTuning},
     CipherMethod, KeyEncryptionCipher, Result,
 };
 
@@ -157,6 +157,9 @@ impl StripeSourceBuilder {
                 session_token,
                 connections,
                 endpoint,
+                connect_timeout_ms,
+                operation_attempt_timeout_ms,
+                max_attempts,
                 ..
             } => {
                 let decrypted_credentials = Self::build_aws_credentials(
@@ -172,6 +175,11 @@ impl StripeSourceBuilder {
                     endpoint.as_deref(),
                     region.as_deref(),
                     decrypted_credentials,
+                    S3ClientTuning {
+                        connect_timeout_ms: *connect_timeout_ms,
+                        operation_attempt_timeout_ms: *operation_attempt_timeout_ms,
+                        max_attempts: *max_attempts,
+                    },
                 )?;
 
                 Ok(Box::new(S3Store::new(
@@ -394,6 +402,9 @@ mod tests {
             session_token: None,
             endpoint: None,
             connections: 4,
+            connect_timeout_ms: 5_000,
+            operation_attempt_timeout_ms: 20_000,
+            max_attempts: 3,
             archive_kek: Some(SecretRef::Ref("my_kek".to_string())),
             autofetch: false,
         };

--- a/src/utils/s3.rs
+++ b/src/utils/s3.rs
@@ -1,8 +1,16 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use aws_config::{BehaviorVersion, Region};
+use aws_sdk_s3::config::timeout::TimeoutConfig;
 
 use crate::Result;
+
+#[derive(Debug, Clone, Copy)]
+pub struct S3ClientTuning {
+    pub connect_timeout_ms: u64,
+    pub operation_attempt_timeout_ms: u64,
+    pub max_attempts: u32,
+}
 
 pub fn create_runtime() -> Result<Arc<tokio::runtime::Runtime>> {
     tokio::runtime::Builder::new_current_thread()
@@ -22,6 +30,7 @@ pub fn build_s3_client(
     endpoint: Option<&str>,
     region: Option<&str>,
     credentials: Option<aws_sdk_s3::config::Credentials>,
+    tuning: S3ClientTuning,
 ) -> Result<aws_sdk_s3::Client> {
     let config = runtime.block_on(async {
         let mut loader = aws_config::defaults(BehaviorVersion::latest());
@@ -42,6 +51,14 @@ pub fn build_s3_client(
     });
 
     let mut builder = aws_sdk_s3::config::Builder::from(&config);
+    let timeout_config = TimeoutConfig::builder()
+        .connect_timeout(Duration::from_millis(tuning.connect_timeout_ms))
+        .operation_attempt_timeout(Duration::from_millis(tuning.operation_attempt_timeout_ms))
+        .build();
+    builder = builder.timeout_config(timeout_config);
+    let retry_config =
+        aws_sdk_s3::config::retry::RetryConfig::standard().with_max_attempts(tuning.max_attempts);
+    builder = builder.retry_config(retry_config);
 
     if let Some(endpoint) = endpoint {
         builder = builder.endpoint_url(endpoint);
@@ -76,6 +93,11 @@ mod tests {
             Some("http://localhost:9000"),
             Some("auto"),
             Some(credentials),
+            S3ClientTuning {
+                connect_timeout_ms: 5_000,
+                operation_attempt_timeout_ms: 20_000,
+                max_attempts: 3,
+            },
         )
         .expect("client should be created");
 
@@ -84,6 +106,22 @@ mod tests {
         assert!(
             endpoint_debug.contains("localhost:9000"),
             "S3 client config should contain the custom endpoint"
+        );
+
+        let timeout_debug = format!("{:?}", conf.timeout_config());
+        assert!(
+            timeout_debug.contains("5s"),
+            "S3 connect timeout should be 5 seconds"
+        );
+        assert!(
+            timeout_debug.contains("20s"),
+            "S3 operation attempt timeout should be 20 seconds"
+        );
+
+        let retry_debug = format!("{:?}", conf.retry_config());
+        assert!(
+            retry_debug.contains("max_attempts: 3"),
+            "S3 retry config should set max_attempts to 3"
         );
     }
 }


### PR DESCRIPTION
### Motivation
- Expose S3 client timeouts and retry tuning from configuration so S3 operations can be tuned per deployment.

### Description
- Extend `ArchiveStorageConfig::S3` with `connect_timeout_ms`, `operation_attempt_timeout_ms` and `max_attempts` including defaults and validation functions (`validate_connect_timeout_ms`, `validate_operation_attempt_timeout_ms`, `validate_max_attempts`).
- Add `S3ClientTuning` struct and wire it into `build_s3_client` to configure `TimeoutConfig` and retry `RetryConfig` on the AWS S3 client using the provided tuning values.
- Update `StripeSourceBuilder::build_archive_store` to pass the tuning values into `build_s3_client` and update affected tests and constructors to include the new fields.
- Minor whitespace/organization changes in `s3_store_workers.rs`.

### Testing
- Ran unit tests under `config::v2::stripe_source` which cover parsing, validation and new invalid-value checks and they passed.
- Ran `utils::s3` unit tests that exercise `create_runtime` and `build_s3_client` timeout/retry config behavior and they passed.
- Ran builder-related unit tests in `stripe_source::builder` that construct S3 configs and archive KEK behavior and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc0289371483278d59272ff00c25e3)