### PR TITLE
Add context to S3 upload failures and archive aborts

### DIFF
--- a/src/archive/archiver.rs
+++ b/src/archive/archiver.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use log::{debug, info};
+use log::{debug, error, info};
 
 use super::ArchiveStore;
 use crate::{
@@ -12,6 +12,7 @@ use crate::{
     backends::SECTOR_SIZE,
     block_device::{metadata_flags, BlockDevice, IoChannel, SharedBuffer, UbiMetadata},
     crypt::XtsBlockCipher,
+    error::ResultExt,
     stripe_source::StripeSource,
     utils::{aligned_buffer::BUFFER_ALIGNMENT, hash::sha256_bytes, AlignedBufferPool},
     KeyEncryptionCipher, Result,
@@ -84,6 +85,21 @@ impl StripeArchiver {
     }
 
     pub fn archive_all(&mut self) -> crate::Result<()> {
+        match self.archive_all_inner() {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                error!(
+                    "Archive aborted: {e}. The manifest (metadata.json and \
+                     stripe-mapping) may be incomplete or missing; the destination \
+                     may contain orphaned data objects from completed and in-flight \
+                     stripe uploads."
+                );
+                Err(e)
+            }
+        }
+    }
+
+    fn archive_all_inner(&mut self) -> crate::Result<()> {
         let mut next_stripe_id = 0;
         while next_stripe_id < self.stripe_count {
             if !self.stripe_should_be_archived(next_stripe_id) {
@@ -221,7 +237,7 @@ impl StripeArchiver {
     fn poll_uploads(&mut self) -> Result<()> {
         let results = self.archive_store.poll_puts();
         for (obj_name, result) in results {
-            result?;
+            result.context(format!("Upload failed for object {}", obj_name))?;
             debug!("Completed uploading object {}", obj_name);
             self.inflight_puts = self.inflight_puts.checked_sub(1).ok_or_else(|| {
                 crate::ubiblk_error!(ArchiveError {

--- a/src/archive/s3_store/s3_store_workers.rs
+++ b/src/archive/s3_store/s3_store_workers.rs
@@ -3,12 +3,32 @@ use std::{
     thread::{self, JoinHandle},
 };
 
+use aws_sdk_s3::error::{DisplayErrorContext, ProvideErrorMetadata};
 use crossbeam_channel::{Receiver, Sender};
 
 use log::{debug, error, info, warn};
 
 use super::{S3ByteStream, S3Client, S3Request, S3Result};
 use crate::Result;
+
+fn format_s3_error<E>(operation: &str, key: &str, err: &E, status: Option<u16>) -> String
+where
+    E: ProvideErrorMetadata + std::error::Error + 'static,
+{
+    let mut msg = format!("{operation} failed for key '{key}': {err}");
+    if let Some(status) = status {
+        msg.push_str(&format!(" (status={status})"));
+    }
+    let meta = err.meta();
+    if let Some(code) = meta.code() {
+        msg.push_str(&format!(" code={code}"));
+    }
+    if let Some(message) = meta.message() {
+        msg.push_str(&format!(" message={message:?}"));
+    }
+    msg.push_str(&format!(" — {}", DisplayErrorContext(err)));
+    msg
+}
 
 struct WorkerContext {
     client: S3Client,
@@ -107,8 +127,9 @@ async fn upload_object(ctx: &WorkerContext, key: &str, data: Vec<u8>) -> Result<
         .send()
         .await
         .map_err(|err| {
+            let status = err.raw_response().map(|r| r.status().as_u16());
             crate::ubiblk_error!(ArchiveError {
-                description: format!("Failed to upload object to S3: {err}"),
+                description: format_s3_error("PutObject", key, &err, status),
             })
         })?;
     Ok(())
@@ -123,8 +144,9 @@ async fn fetch_object(ctx: &WorkerContext, key: &str) -> Result<Vec<u8>> {
         .send()
         .await
         .map_err(|err| {
+            let status = err.raw_response().map(|r| r.status().as_u16());
             crate::ubiblk_error!(ArchiveError {
-                description: format!("Failed to fetch object from S3: {err}"),
+                description: format_s3_error("GetObject", key, &err, status),
             })
         })?;
 
@@ -141,11 +163,62 @@ async fn fetch_object(ctx: &WorkerContext, key: &str) -> Result<Vec<u8>> {
 mod tests {
     use std::time::Duration;
 
+    use aws_sdk_s3::error::ErrorMetadata;
     use aws_sdk_s3::operation::{get_object::GetObjectOutput, put_object::PutObjectOutput};
     use aws_smithy_mocks::{mock, mock_client, Rule};
     use crossbeam_channel::unbounded;
 
     use super::*;
+
+    #[derive(Debug)]
+    struct FakeServiceError {
+        meta: ErrorMetadata,
+    }
+
+    impl std::fmt::Display for FakeServiceError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str("fake service error")
+        }
+    }
+
+    impl std::error::Error for FakeServiceError {}
+
+    impl ProvideErrorMetadata for FakeServiceError {
+        fn meta(&self) -> &ErrorMetadata {
+            &self.meta
+        }
+    }
+
+    #[test]
+    fn format_s3_error_includes_status_code_and_message() {
+        let err = FakeServiceError {
+            meta: ErrorMetadata::builder()
+                .code("SlowDown")
+                .message("Please reduce your request rate.")
+                .build(),
+        };
+        let msg = format_s3_error("PutObject", "data/abc", &err, Some(503));
+        assert!(msg.contains("PutObject"), "missing op: {msg}");
+        assert!(msg.contains("data/abc"), "missing key: {msg}");
+        assert!(msg.contains("status=503"), "missing status: {msg}");
+        assert!(msg.contains("code=SlowDown"), "missing code: {msg}");
+        assert!(
+            msg.contains("Please reduce your request rate."),
+            "missing message: {msg}"
+        );
+    }
+
+    #[test]
+    fn format_s3_error_handles_missing_metadata() {
+        let err = FakeServiceError {
+            meta: ErrorMetadata::builder().build(),
+        };
+        let msg = format_s3_error("GetObject", "metadata.json", &err, None);
+        assert!(msg.contains("GetObject"), "missing op: {msg}");
+        assert!(msg.contains("metadata.json"), "missing key: {msg}");
+        assert!(!msg.contains("status="), "should omit status: {msg}");
+        assert!(!msg.contains("code="), "should omit code: {msg}");
+    }
 
     fn spawn_test_workers(
         rules: &[Rule],


### PR DESCRIPTION
The previous "service error" log gave no actionable detail and the binary could leave orphaned data objects with no indication that the manifest may be incomplete.