### PR TITLE
Make S3 retry backoff configurable and honor Retry-After

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3666,6 +3666,7 @@ dependencies = [
  "aws-smithy-mocks",
  "base64",
  "bindgen 0.72.1",
+ "bytes",
  "ciborium",
  "clap",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ hmac = "0.12.1"
 ciborium = "0.2.2"
 aws-config = "1.8.12"
 aws-sdk-s3 = { version = "1.120.0", default-features = false, features = ["sigv4a", "http-1x", "default-https-client", "rt-tokio"] }
+bytes = "1.7"
 tokio = { version = "1.48.0", features = ["rt"] }
 crossbeam-channel = "0.5.15"
 libublk = "0.4.5"

--- a/src/archive/mod.rs
+++ b/src/archive/mod.rs
@@ -150,7 +150,7 @@ pub use fs_store::FileSystemStore;
 #[cfg(test)]
 pub use hmac::compute_metadata_hmac_tag;
 pub use hmac::{compute_hmac_tag, verify_hmac_tag, verify_metadata_hmac_tag};
-pub use s3_store::S3Store;
+pub use s3_store::{RetryPolicy, S3Store};
 pub use stripe_hashes::{
     deserialize_stripe_mapping, serialize_stripe_mapping, StripeContentMap, StripeContentSpecifier,
 };

--- a/src/archive/s3_store.rs
+++ b/src/archive/s3_store.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, thread::JoinHandle};
+use std::{sync::Arc, thread::JoinHandle, time::Duration};
 
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use log::{debug, error, info};
@@ -11,6 +11,20 @@ type S3Client = aws_sdk_s3::Client;
 type S3ByteStream = aws_sdk_s3::primitives::ByteStream;
 
 mod s3_store_workers;
+
+/// Retry policy applied by the S3 worker. The AWS SDK is configured with
+/// `RetryConfig::disabled()`, so this is the only retry layer.
+#[derive(Debug, Clone, Copy)]
+pub struct RetryPolicy {
+    /// Total number of attempts including the first one.
+    pub max_attempts: u32,
+    /// Delay before the first retry; later retries grow geometrically up to
+    /// `max_backoff`.
+    pub initial_backoff: Duration,
+    /// Cap on the delay between retries, including server-supplied
+    /// `Retry-After` hints.
+    pub max_backoff: Duration,
+}
 
 enum S3Request {
     Put {
@@ -50,6 +64,7 @@ impl S3Store {
         bucket: String,
         prefix: Option<String>,
         worker_threads: usize,
+        retry: RetryPolicy,
     ) -> Result<Self> {
         let normalized_prefix = prefix.and_then(|p| {
             let p = p.trim_matches('/');
@@ -67,6 +82,7 @@ impl S3Store {
             client,
             Arc::clone(&bucket),
             worker_threads,
+            retry,
             request_rx,
             result_tx,
         )?;
@@ -208,6 +224,12 @@ mod tests {
             bucket.to_string(),
             prefix.map(|p| p.to_string()),
             2,
+            // Single attempt so tests don't sleep on transient errors.
+            RetryPolicy {
+                max_attempts: 1,
+                initial_backoff: Duration::from_millis(1),
+                max_backoff: Duration::from_millis(1),
+            },
         )
         .unwrap()
     }

--- a/src/archive/s3_store/s3_store_workers.rs
+++ b/src/archive/s3_store/s3_store_workers.rs
@@ -273,6 +273,46 @@ mod tests {
         }
     }
 
+    fn policy(max_attempts: u32, initial_ms: u64, max_ms: u64) -> RetryPolicy {
+        RetryPolicy {
+            max_attempts,
+            initial_backoff: Duration::from_millis(initial_ms),
+            max_backoff: Duration::from_millis(max_ms),
+        }
+    }
+
+    #[test]
+    fn parse_retry_after_only_accepts_delta_seconds() {
+        assert_eq!(parse_retry_after_seconds("5"), Some(Duration::from_secs(5)));
+        // HTTP-date form is unsupported and currently falls back to the
+        // exponential schedule.
+        assert_eq!(
+            parse_retry_after_seconds("Wed, 21 Oct 2026 07:28:00 GMT"),
+            None
+        );
+    }
+
+    #[test]
+    fn retry_delay_grows_clamps_and_honors_hint() {
+        let p = policy(5, 1_000, 10_000);
+        // Exponential growth: initial * 2^(n-1).
+        assert_eq!(retry_delay(&p, 1, None), Duration::from_millis(1_000));
+        assert_eq!(retry_delay(&p, 2, None), Duration::from_millis(2_000));
+        assert_eq!(retry_delay(&p, 3, None), Duration::from_millis(4_000));
+        // Capped at max_backoff once 2^(n-1) overshoots.
+        assert_eq!(retry_delay(&p, 5, None), Duration::from_millis(10_000));
+        // Server hint takes precedence over the exponential schedule,
+        // but is still clamped by max_backoff.
+        assert_eq!(
+            retry_delay(&p, 1, Some(Duration::from_secs(3))),
+            Duration::from_secs(3)
+        );
+        assert_eq!(
+            retry_delay(&p, 1, Some(Duration::from_secs(86_400))),
+            Duration::from_millis(10_000)
+        );
+    }
+
     #[test]
     fn format_s3_error_includes_status_code_and_message() {
         let err = FakeServiceError {
@@ -307,18 +347,21 @@ mod tests {
     fn spawn_test_workers(
         rules: &[Rule],
     ) -> (Sender<S3Request>, Receiver<S3Result>, Vec<JoinHandle<()>>) {
+        // Single attempt so tests don't sleep on transient errors.
+        spawn_test_workers_with(rules, policy(1, 1, 1))
+    }
+
+    fn spawn_test_workers_with(
+        rules: &[Rule],
+        retry: RetryPolicy,
+    ) -> (Sender<S3Request>, Receiver<S3Result>, Vec<JoinHandle<()>>) {
         let (request_tx, request_rx) = unbounded();
         let (result_tx, result_rx) = unbounded();
         let workers = spawn_workers(
             mock_client!(aws_sdk_s3, rules),
             Arc::new("test-bucket".to_string()),
             1,
-            // Single attempt so tests don't sleep on transient errors.
-            RetryPolicy {
-                max_attempts: 1,
-                initial_backoff: Duration::from_millis(1),
-                max_backoff: Duration::from_millis(1),
-            },
+            retry,
             request_rx,
             result_tx,
         )
@@ -385,6 +428,111 @@ mod tests {
                 assert!(result.is_ok());
             }
             _ => panic!("expected put result second after sort"),
+        }
+
+        drop(request_tx);
+        join_workers(workers);
+    }
+
+    #[test]
+    fn worker_retries_put_on_5xx_then_succeeds() {
+        let rule = mock!(S3Client::put_object)
+            .sequence()
+            .http_status(503, None)
+            .output(|| PutObjectOutput::builder().build())
+            .build();
+        let (request_tx, result_rx, workers) = spawn_test_workers_with(&[rule], policy(3, 1, 1));
+
+        request_tx
+            .send(S3Request::Put {
+                name: "obj".to_string(),
+                key: "prefix/obj".to_string(),
+                data: b"payload".to_vec(),
+            })
+            .expect("send");
+
+        match result_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("result")
+        {
+            S3Result::Put { name, result } => {
+                assert_eq!(name, "obj");
+                assert!(
+                    result.is_ok(),
+                    "expected ok after retry, got {:?}",
+                    result.err()
+                );
+            }
+            _ => panic!("expected Put result"),
+        }
+
+        drop(request_tx);
+        join_workers(workers);
+    }
+
+    #[test]
+    fn worker_retries_get_on_5xx_then_succeeds() {
+        let rule = mock!(S3Client::get_object)
+            .sequence()
+            .http_status(503, None)
+            .output(|| {
+                GetObjectOutput::builder()
+                    .body(S3ByteStream::from_static(b"hello"))
+                    .build()
+            })
+            .build();
+        let (request_tx, result_rx, workers) = spawn_test_workers_with(&[rule], policy(3, 1, 1));
+
+        request_tx
+            .send(S3Request::Get {
+                name: "obj".to_string(),
+                key: "prefix/obj".to_string(),
+            })
+            .expect("send");
+
+        match result_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("result")
+        {
+            S3Result::Get { name, result } => {
+                assert_eq!(name, "obj");
+                assert_eq!(result.expect("expected ok after retry"), b"hello");
+            }
+            _ => panic!("expected Get result"),
+        }
+
+        drop(request_tx);
+        join_workers(workers);
+    }
+
+    #[test]
+    fn worker_gives_up_put_on_permanent_4xx() {
+        let rule = mock!(S3Client::put_object)
+            .sequence()
+            .http_status(403, None)
+            .times(10)
+            .build();
+        let (request_tx, result_rx, workers) = spawn_test_workers_with(&[rule], policy(3, 1, 1));
+
+        request_tx
+            .send(S3Request::Put {
+                name: "obj".to_string(),
+                key: "prefix/obj".to_string(),
+                data: b"payload".to_vec(),
+            })
+            .expect("send");
+
+        match result_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("result")
+        {
+            S3Result::Put { name, result } => {
+                assert_eq!(name, "obj");
+                let err = result.expect_err("expected permanent failure");
+                let msg = err.to_string();
+                assert!(msg.contains("status=403"), "expected 403 in error: {msg}");
+            }
+            _ => panic!("expected Put result"),
         }
 
         drop(request_tx);

--- a/src/archive/s3_store/s3_store_workers.rs
+++ b/src/archive/s3_store/s3_store_workers.rs
@@ -1,15 +1,40 @@
 use std::{
     sync::Arc,
     thread::{self, JoinHandle},
+    time::Duration,
 };
 
 use aws_sdk_s3::error::{DisplayErrorContext, ProvideErrorMetadata};
+use bytes::Bytes;
 use crossbeam_channel::{Receiver, Sender};
 
 use log::{debug, error, info, warn};
 
-use super::{S3ByteStream, S3Client, S3Request, S3Result};
+use super::{RetryPolicy, S3ByteStream, S3Client, S3Request, S3Result};
 use crate::Result;
+
+/// Parse a Retry-After header value in delta-seconds form.
+///
+/// RFC 9110 §10.2.3 also permits an HTTP-date form (e.g.
+/// `"Wed, 21 Oct 2026 07:28:00 GMT"`). We do not parse that here; if a peer
+/// emits it, callers fall back to the exponential schedule. R2 and AWS S3
+/// both use delta-seconds in practice.
+fn parse_retry_after_seconds(value: &str) -> Option<Duration> {
+    value.parse::<u64>().ok().map(Duration::from_secs)
+}
+
+/// Sleep duration before the (1-indexed) `attempt`-th retry. Honors a
+/// server-supplied Retry-After hint when present; otherwise grows as
+/// `initial_backoff * 2^(attempt - 1)`. Either way, clamps to `max_backoff`
+/// so a misbehaving peer can't stall the worker indefinitely.
+fn retry_delay(policy: &RetryPolicy, attempt: u32, hint: Option<Duration>) -> Duration {
+    let exp = {
+        let shift = attempt.saturating_sub(1).min(32);
+        let base_ms = policy.initial_backoff.as_millis() as u64;
+        Duration::from_millis(base_ms.saturating_mul(1u64 << shift))
+    };
+    hint.unwrap_or(exp).min(policy.max_backoff)
+}
 
 fn format_s3_error<E>(operation: &str, key: &str, err: &E, status: Option<u16>) -> String
 where
@@ -33,12 +58,14 @@ where
 struct WorkerContext {
     client: S3Client,
     bucket: Arc<String>,
+    retry: RetryPolicy,
 }
 
 pub(super) fn spawn_workers(
     client: S3Client,
     bucket: Arc<String>,
     mut worker_threads: usize,
+    retry: RetryPolicy,
     request_rx: Receiver<S3Request>,
     result_tx: Sender<S3Result>,
 ) -> Result<Vec<JoinHandle<()>>> {
@@ -59,6 +86,7 @@ pub(super) fn spawn_workers(
         let ctx = WorkerContext {
             client: S3Client::from_conf(client_config.clone()),
             bucket: Arc::clone(&bucket),
+            retry,
         };
         let rx = request_rx.clone();
         let tx = result_tx.clone();
@@ -97,7 +125,10 @@ async fn process_request(ctx: &WorkerContext, req: S3Request, tx: &Sender<S3Resu
     match req {
         S3Request::Put { name, key, data } => {
             debug!("Uploading object to S3: {}", name);
-            let result = upload_object(ctx, &key, data).await;
+            // Vec<u8> -> Bytes is O(1) and lets retry attempts share the buffer
+            // via cheap refcount clones.
+            let body = Bytes::from(data);
+            let result = upload_object(ctx, &key, body).await;
             if let Err(e) = tx.send(S3Result::Put {
                 name: name.clone(),
                 result,
@@ -118,37 +149,90 @@ async fn process_request(ctx: &WorkerContext, req: S3Request, tx: &Sender<S3Resu
     }
 }
 
-async fn upload_object(ctx: &WorkerContext, key: &str, data: Vec<u8>) -> Result<()> {
-    ctx.client
-        .put_object()
-        .bucket(ctx.bucket.as_str())
-        .key(key)
-        .body(S3ByteStream::from(data))
-        .send()
-        .await
-        .map_err(|err| {
-            let status = err.raw_response().map(|r| r.status().as_u16());
-            crate::ubiblk_error!(ArchiveError {
-                description: format_s3_error("PutObject", key, &err, status),
-            })
-        })?;
-    Ok(())
+async fn upload_object(ctx: &WorkerContext, key: &str, body: Bytes) -> Result<()> {
+    let mut attempt: u32 = 0;
+    let err = loop {
+        attempt += 1;
+        let send_result = ctx
+            .client
+            .put_object()
+            .bucket(ctx.bucket.as_str())
+            .key(key)
+            .body(S3ByteStream::from(body.clone()))
+            .send()
+            .await;
+        let err = match send_result {
+            Ok(_) => return Ok(()),
+            Err(e) => e,
+        };
+        let raw = err.raw_response();
+        let retryable = matches!(
+            raw.map(|r| r.status().as_u16()),
+            Some(408) | Some(429) | Some(500..=599) | None
+        );
+        if !retryable || attempt >= ctx.retry.max_attempts {
+            break err;
+        }
+        let hint = raw
+            .and_then(|r| r.headers().get("retry-after"))
+            .and_then(parse_retry_after_seconds);
+        let delay = retry_delay(&ctx.retry, attempt, hint);
+        warn!(
+            "S3 PutObject for {} failed (attempt {}/{}), retrying in {:?}: {}",
+            key,
+            attempt,
+            ctx.retry.max_attempts,
+            delay,
+            DisplayErrorContext(&err)
+        );
+        tokio::time::sleep(delay).await;
+    };
+    let status = err.raw_response().map(|r| r.status().as_u16());
+    Err(crate::ubiblk_error!(ArchiveError {
+        description: format_s3_error("PutObject", key, &err, status),
+    }))
 }
 
 async fn fetch_object(ctx: &WorkerContext, key: &str) -> Result<Vec<u8>> {
-    let output = ctx
-        .client
-        .get_object()
-        .bucket(ctx.bucket.as_str())
-        .key(key)
-        .send()
-        .await
-        .map_err(|err| {
-            let status = err.raw_response().map(|r| r.status().as_u16());
-            crate::ubiblk_error!(ArchiveError {
+    let mut attempt: u32 = 0;
+    let output = loop {
+        attempt += 1;
+        let send_result = ctx
+            .client
+            .get_object()
+            .bucket(ctx.bucket.as_str())
+            .key(key)
+            .send()
+            .await;
+        let err = match send_result {
+            Ok(o) => break o,
+            Err(e) => e,
+        };
+        let raw = err.raw_response();
+        let retryable = matches!(
+            raw.map(|r| r.status().as_u16()),
+            Some(408) | Some(429) | Some(500..=599) | None
+        );
+        if !retryable || attempt >= ctx.retry.max_attempts {
+            let status = raw.map(|r| r.status().as_u16());
+            return Err(crate::ubiblk_error!(ArchiveError {
                 description: format_s3_error("GetObject", key, &err, status),
-            })
-        })?;
+            }));
+        }
+        let hint = raw
+            .and_then(|r| r.headers().get("retry-after"))
+            .and_then(parse_retry_after_seconds);
+        let delay = retry_delay(&ctx.retry, attempt, hint);
+        warn!(
+            "S3 GetObject for {} failed (attempt {}/{}), retrying in {:?}: {}",
+            key,
+            attempt,
+            ctx.retry.max_attempts,
+            delay,
+            DisplayErrorContext(&err)
+        );
+        tokio::time::sleep(delay).await;
+    };
 
     let bytes = output.body.collect().await.map_err(|err| {
         crate::ubiblk_error!(ArchiveError {
@@ -229,6 +313,12 @@ mod tests {
             mock_client!(aws_sdk_s3, rules),
             Arc::new("test-bucket".to_string()),
             1,
+            // Single attempt so tests don't sleep on transient errors.
+            RetryPolicy {
+                max_attempts: 1,
+                initial_backoff: Duration::from_millis(1),
+                max_backoff: Duration::from_millis(1),
+            },
             request_rx,
             result_tx,
         )

--- a/src/config/v2/stripe_source.rs
+++ b/src/config/v2/stripe_source.rs
@@ -155,6 +155,10 @@ pub enum ArchiveStorageConfig {
         operation_attempt_timeout_ms: u64,
         #[serde(default = "default_max_attempts")]
         max_attempts: u32,
+        #[serde(default = "default_initial_backoff_ms")]
+        initial_backoff_ms: u64,
+        #[serde(default = "default_max_backoff_ms")]
+        max_backoff_ms: u64,
         archive_kek: Option<SecretRef>,
         #[serde(default)]
         autofetch: bool,
@@ -177,6 +181,14 @@ fn default_max_attempts() -> u32 {
     3
 }
 
+fn default_initial_backoff_ms() -> u64 {
+    5_000
+}
+
+fn default_max_backoff_ms() -> u64 {
+    30_000
+}
+
 impl ArchiveStorageConfig {
     pub fn validate(&self, resolved_secrets: &HashMap<String, ResolvedSecret>) -> Result<()> {
         match self {
@@ -193,6 +205,8 @@ impl ArchiveStorageConfig {
                 connect_timeout_ms,
                 operation_attempt_timeout_ms,
                 max_attempts,
+                initial_backoff_ms,
+                max_backoff_ms,
                 access_key_id,
                 secret_access_key,
                 session_token,
@@ -223,7 +237,8 @@ impl ArchiveStorageConfig {
                 Self::validate_connections(connections)?;
                 Self::validate_connect_timeout_ms(connect_timeout_ms)?;
                 Self::validate_operation_attempt_timeout_ms(operation_attempt_timeout_ms)?;
-                Self::validate_max_attempts(max_attempts)
+                Self::validate_max_attempts(max_attempts)?;
+                Self::validate_backoff(*initial_backoff_ms, *max_backoff_ms)
             }
         }
     }
@@ -275,6 +290,20 @@ impl ArchiveStorageConfig {
         if *max_attempts == 0 {
             return Err(crate::ubiblk_error!(InvalidParameter {
                 description: "S3 max_attempts must be greater than 0".to_string(),
+            }));
+        }
+        Ok(())
+    }
+
+    fn validate_backoff(initial_backoff_ms: u64, max_backoff_ms: u64) -> crate::Result<()> {
+        if initial_backoff_ms == 0 {
+            return Err(crate::ubiblk_error!(InvalidParameter {
+                description: "S3 initial_backoff_ms must be greater than 0".to_string(),
+            }));
+        }
+        if max_backoff_ms < initial_backoff_ms {
+            return Err(crate::ubiblk_error!(InvalidParameter {
+                description: "S3 max_backoff_ms must be >= initial_backoff_ms".to_string(),
             }));
         }
         Ok(())
@@ -421,6 +450,8 @@ mod tests {
                 connect_timeout_ms: 5_000,
                 operation_attempt_timeout_ms: 20_000,
                 max_attempts: 3,
+                initial_backoff_ms: 5_000,
+                max_backoff_ms: 30_000,
             })
         );
     }
@@ -453,6 +484,8 @@ mod tests {
                 connect_timeout_ms: 5_000,
                 operation_attempt_timeout_ms: 20_000,
                 max_attempts: 3,
+                initial_backoff_ms: 5_000,
+                max_backoff_ms: 30_000,
             })
         );
     }
@@ -488,6 +521,8 @@ mod tests {
                 connect_timeout_ms: 120,
                 operation_attempt_timeout_ms: 45_000,
                 max_attempts: 7,
+                initial_backoff_ms: 5_000,
+                max_backoff_ms: 30_000,
             })
         );
     }
@@ -770,6 +805,8 @@ mod tests {
             connect_timeout_ms: 5_000,
             operation_attempt_timeout_ms: 20_000,
             max_attempts: 3,
+            initial_backoff_ms: 5_000,
+            max_backoff_ms: 30_000,
         });
         let danger_zone = DangerZone::default();
         let result = config.validate(&danger_zone, &valid_s3_secrets());
@@ -815,6 +852,8 @@ mod tests {
             connect_timeout_ms: 5_000,
             operation_attempt_timeout_ms: 20_000,
             max_attempts: 3,
+            initial_backoff_ms: 5_000,
+            max_backoff_ms: 30_000,
         });
 
         let result = config.validate(&DangerZone::default(), &secrets);
@@ -839,6 +878,8 @@ mod tests {
             connect_timeout_ms: 5_000,
             operation_attempt_timeout_ms: 20_000,
             max_attempts: 3,
+            initial_backoff_ms: 5_000,
+            max_backoff_ms: 30_000,
         });
         let danger_zone = DangerZone::default();
         let result = config.validate(&danger_zone, &valid_s3_secrets());
@@ -863,6 +904,8 @@ mod tests {
             connect_timeout_ms: 0,
             operation_attempt_timeout_ms: 20_000,
             max_attempts: 3,
+            initial_backoff_ms: 5_000,
+            max_backoff_ms: 30_000,
         });
         let result = config.validate(&DangerZone::default(), &valid_s3_secrets());
         assert!(result.is_err());
@@ -886,6 +929,8 @@ mod tests {
             connect_timeout_ms: 5_000,
             operation_attempt_timeout_ms: 0,
             max_attempts: 3,
+            initial_backoff_ms: 5_000,
+            max_backoff_ms: 30_000,
         });
         let result = config.validate(&DangerZone::default(), &valid_s3_secrets());
         assert!(result.is_err());
@@ -909,10 +954,13 @@ mod tests {
             connect_timeout_ms: 5_000,
             operation_attempt_timeout_ms: 20_000,
             max_attempts: 0,
+            initial_backoff_ms: 5_000,
+            max_backoff_ms: 30_000,
         });
         let result = config.validate(&DangerZone::default(), &valid_s3_secrets());
         assert!(result.is_err());
         let error_msg = result.err().unwrap().to_string();
         assert!(error_msg.contains("S3 max_attempts must be greater than 0"));
     }
+
 }

--- a/src/config/v2/stripe_source.rs
+++ b/src/config/v2/stripe_source.rs
@@ -528,6 +528,33 @@ mod tests {
     }
 
     #[test]
+    fn archive_s3_custom_backoff_config() {
+        let toml = r#"
+            type = "archive"
+            storage = "s3"
+            bucket = "encrypted-stripes"
+            region = "eu-west-1"
+            access_key_id.ref = "aws-access-key-id"
+            secret_access_key.ref = "aws-secret-access-key"
+            archive_kek.ref = "archive-kek"
+            initial_backoff_ms = 2_000
+            max_backoff_ms = 60_000
+        "#;
+        let config: StripeSourceConfig = toml::from_str(toml).unwrap();
+        match config {
+            StripeSourceConfig::Archive(ArchiveStorageConfig::S3 {
+                initial_backoff_ms,
+                max_backoff_ms,
+                ..
+            }) => {
+                assert_eq!(initial_backoff_ms, 2_000);
+                assert_eq!(max_backoff_ms, 60_000);
+            }
+            _ => panic!("expected archive/s3 config"),
+        }
+    }
+
+    #[test]
     fn remote_stripe_source() {
         let toml = r#"
             type = "remote"
@@ -963,4 +990,53 @@ mod tests {
         assert!(error_msg.contains("S3 max_attempts must be greater than 0"));
     }
 
+    #[test]
+    fn validate_rejects_zero_initial_backoff() {
+        let config = StripeSourceConfig::Archive(ArchiveStorageConfig::S3 {
+            bucket: "bucket".to_string(),
+            prefix: None,
+            region: Some("us-east-1".to_string()),
+            access_key_id: SecretRef::Ref("key".to_string()),
+            secret_access_key: SecretRef::Ref("secret".to_string()),
+            session_token: None,
+            archive_kek: Some(SecretRef::Ref("kek".to_string())),
+            autofetch: false,
+            connections: 16,
+            endpoint: None,
+            connect_timeout_ms: 5_000,
+            operation_attempt_timeout_ms: 20_000,
+            max_attempts: 3,
+            initial_backoff_ms: 0,
+            max_backoff_ms: 30_000,
+        });
+        let result = config.validate(&DangerZone::default(), &valid_s3_secrets());
+        assert!(result.is_err());
+        let error_msg = result.err().unwrap().to_string();
+        assert!(error_msg.contains("S3 initial_backoff_ms must be greater than 0"));
+    }
+
+    #[test]
+    fn validate_rejects_max_backoff_smaller_than_initial() {
+        let config = StripeSourceConfig::Archive(ArchiveStorageConfig::S3 {
+            bucket: "bucket".to_string(),
+            prefix: None,
+            region: Some("us-east-1".to_string()),
+            access_key_id: SecretRef::Ref("key".to_string()),
+            secret_access_key: SecretRef::Ref("secret".to_string()),
+            session_token: None,
+            archive_kek: Some(SecretRef::Ref("kek".to_string())),
+            autofetch: false,
+            connections: 16,
+            endpoint: None,
+            connect_timeout_ms: 5_000,
+            operation_attempt_timeout_ms: 20_000,
+            max_attempts: 3,
+            initial_backoff_ms: 10_000,
+            max_backoff_ms: 5_000,
+        });
+        let result = config.validate(&DangerZone::default(), &valid_s3_secrets());
+        assert!(result.is_err());
+        let error_msg = result.err().unwrap().to_string();
+        assert!(error_msg.contains("S3 max_backoff_ms must be >= initial_backoff_ms"));
+    }
 }

--- a/src/stripe_source/builder.rs
+++ b/src/stripe_source/builder.rs
@@ -160,6 +160,8 @@ impl StripeSourceBuilder {
                 connect_timeout_ms,
                 operation_attempt_timeout_ms,
                 max_attempts,
+                initial_backoff_ms,
+                max_backoff_ms,
                 ..
             } => {
                 let decrypted_credentials = Self::build_aws_credentials(
@@ -179,6 +181,8 @@ impl StripeSourceBuilder {
                         connect_timeout_ms: *connect_timeout_ms,
                         operation_attempt_timeout_ms: *operation_attempt_timeout_ms,
                         max_attempts: *max_attempts,
+                        initial_backoff_ms: *initial_backoff_ms,
+                        max_backoff_ms: *max_backoff_ms,
                     },
                 )?;
 
@@ -405,6 +409,8 @@ mod tests {
             connect_timeout_ms: 5_000,
             operation_attempt_timeout_ms: 20_000,
             max_attempts: 3,
+            initial_backoff_ms: 5_000,
+            max_backoff_ms: 30_000,
             archive_kek: Some(SecretRef::Ref("my_kek".to_string())),
             autofetch: false,
         };

--- a/src/stripe_source/builder.rs
+++ b/src/stripe_source/builder.rs
@@ -1,8 +1,10 @@
 use log::info;
 use ubiblk_macros::error_context;
 
+use std::time::Duration;
+
 use crate::{
-    archive::{ArchiveStore, FileSystemStore, S3Store},
+    archive::{ArchiveStore, FileSystemStore, RetryPolicy, S3Store},
     backends::build_raw_image_device,
     block_device::NullBlockDevice,
     config::v2::{
@@ -180,17 +182,20 @@ impl StripeSourceBuilder {
                     S3ClientTuning {
                         connect_timeout_ms: *connect_timeout_ms,
                         operation_attempt_timeout_ms: *operation_attempt_timeout_ms,
-                        max_attempts: *max_attempts,
-                        initial_backoff_ms: *initial_backoff_ms,
-                        max_backoff_ms: *max_backoff_ms,
                     },
                 )?;
+                let retry = RetryPolicy {
+                    max_attempts: *max_attempts,
+                    initial_backoff: Duration::from_millis(*initial_backoff_ms),
+                    max_backoff: Duration::from_millis(*max_backoff_ms),
+                };
 
                 Ok(Box::new(S3Store::new(
                     client,
                     bucket.to_string(),
                     prefix.clone(),
                     *connections,
+                    retry,
                 )?))
             }
         }

--- a/src/utils/s3.rs
+++ b/src/utils/s3.rs
@@ -9,9 +9,6 @@ use crate::Result;
 pub struct S3ClientTuning {
     pub connect_timeout_ms: u64,
     pub operation_attempt_timeout_ms: u64,
-    pub max_attempts: u32,
-    pub initial_backoff_ms: u64,
-    pub max_backoff_ms: u64,
 }
 
 pub fn create_runtime() -> Result<Arc<tokio::runtime::Runtime>> {
@@ -58,11 +55,10 @@ pub fn build_s3_client(
         .operation_attempt_timeout(Duration::from_millis(tuning.operation_attempt_timeout_ms))
         .build();
     builder = builder.timeout_config(timeout_config);
-    let retry_config = aws_sdk_s3::config::retry::RetryConfig::standard()
-        .with_max_attempts(tuning.max_attempts)
-        .with_initial_backoff(Duration::from_millis(tuning.initial_backoff_ms))
-        .with_max_backoff(Duration::from_millis(tuning.max_backoff_ms));
-    builder = builder.retry_config(retry_config);
+    // Retries are handled in the S3 worker (see `archive::s3_store`) so that we
+    // can honor Retry-After hints and apply a deterministic backoff. Disable the
+    // SDK's built-in retry to avoid stacking two retry layers.
+    builder = builder.retry_config(aws_sdk_s3::config::retry::RetryConfig::disabled());
 
     if let Some(endpoint) = endpoint {
         builder = builder.endpoint_url(endpoint);
@@ -100,9 +96,6 @@ mod tests {
             S3ClientTuning {
                 connect_timeout_ms: 5_000,
                 operation_attempt_timeout_ms: 20_000,
-                max_attempts: 3,
-                initial_backoff_ms: 5_000,
-                max_backoff_ms: 30_000,
             },
         )
         .expect("client should be created");
@@ -124,10 +117,8 @@ mod tests {
             "S3 operation attempt timeout should be 20 seconds"
         );
 
-        let retry_debug = format!("{:?}", conf.retry_config());
-        assert!(
-            retry_debug.contains("max_attempts: 3"),
-            "S3 retry config should set max_attempts to 3"
-        );
+        // SDK retry is disabled — the S3 worker performs retries itself.
+        let retry_config = conf.retry_config().expect("retry config present");
+        assert_eq!(retry_config.max_attempts(), 1);
     }
 }

--- a/src/utils/s3.rs
+++ b/src/utils/s3.rs
@@ -10,6 +10,8 @@ pub struct S3ClientTuning {
     pub connect_timeout_ms: u64,
     pub operation_attempt_timeout_ms: u64,
     pub max_attempts: u32,
+    pub initial_backoff_ms: u64,
+    pub max_backoff_ms: u64,
 }
 
 pub fn create_runtime() -> Result<Arc<tokio::runtime::Runtime>> {
@@ -56,8 +58,10 @@ pub fn build_s3_client(
         .operation_attempt_timeout(Duration::from_millis(tuning.operation_attempt_timeout_ms))
         .build();
     builder = builder.timeout_config(timeout_config);
-    let retry_config =
-        aws_sdk_s3::config::retry::RetryConfig::standard().with_max_attempts(tuning.max_attempts);
+    let retry_config = aws_sdk_s3::config::retry::RetryConfig::standard()
+        .with_max_attempts(tuning.max_attempts)
+        .with_initial_backoff(Duration::from_millis(tuning.initial_backoff_ms))
+        .with_max_backoff(Duration::from_millis(tuning.max_backoff_ms));
     builder = builder.retry_config(retry_config);
 
     if let Some(endpoint) = endpoint {
@@ -97,6 +101,8 @@ mod tests {
                 connect_timeout_ms: 5_000,
                 operation_attempt_timeout_ms: 20_000,
                 max_attempts: 3,
+                initial_backoff_ms: 5_000,
+                max_backoff_ms: 30_000,
             },
         )
         .expect("client should be created");


### PR DESCRIPTION
### Add S3 archive backoff config knobs
Until now, the AWS SDK retry layer used its default initial backoff of ~1s. With Cloudflare R2's typical Retry-After of 5s, the first retry lands inside R2's window and the request is rejected again.

Expose initial_backoff_ms (default 5000) and max_backoff_ms (default 30000) under archive S3 storage and wire them through S3ClientTuning into the SDK's RetryConfig.

### Drive S3 retries from the worker and honor Retry-After 
Cloudflare R2 throttles per-object writes with HTTP 429 and a `Retry-After: 5` header. The AWS SDK ignores Retry-After and retries with jittered exponential backoff starting near 1s, so retries land back inside R2's window and the archive aborts.

Disable SDK retries (RetryConfig::disabled) and drive them from the S3 worker: honor Retry-After (delta-seconds) when present; otherwise sleep for `min(initial_backoff * 2^(attempt - 1), max_backoff)` with no jitter, capped by max_attempts. Retry-After is also clamped by max_backoff so a misbehaving peer can't stall the worker. Each retry emits a warn! line with operation, key, attempt, delay, and cause.