### PR TITLE
Add S3 backoff config + 429 retry classifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3664,6 +3664,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-s3",
  "aws-smithy-mocks",
+ "aws-smithy-runtime-api",
  "base64",
  "bindgen 0.72.1",
  "ciborium",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ hmac = "0.12.1"
 ciborium = "0.2.2"
 aws-config = "1.8.12"
 aws-sdk-s3 = { version = "1.120.0", default-features = false, features = ["sigv4a", "http-1x", "default-https-client", "rt-tokio"] }
+aws-smithy-runtime-api = "1.7"
 tokio = { version = "1.48.0", features = ["rt"] }
 crossbeam-channel = "0.5.15"
 libublk = "0.4.5"

--- a/src/config/v2/stripe_source.rs
+++ b/src/config/v2/stripe_source.rs
@@ -155,6 +155,10 @@ pub enum ArchiveStorageConfig {
         operation_attempt_timeout_ms: u64,
         #[serde(default = "default_max_attempts")]
         max_attempts: u32,
+        #[serde(default = "default_initial_backoff_ms")]
+        initial_backoff_ms: u64,
+        #[serde(default = "default_max_backoff_ms")]
+        max_backoff_ms: u64,
         archive_kek: Option<SecretRef>,
         #[serde(default)]
         autofetch: bool,
@@ -177,6 +181,19 @@ fn default_max_attempts() -> u32 {
     3
 }
 
+fn default_initial_backoff_ms() -> u64 {
+    // Cloudflare R2 caps writes to the same key at 1 per second; the SDK's
+    // jittered first retry samples [0, 2 * initial_backoff). With 2 seconds
+    // here, the first retry lands inside R2's same-key window only ~25% of the
+    // time, and our `Retry429Classifier` ensures any resulting 429 is itself
+    // retried.
+    2_000
+}
+
+fn default_max_backoff_ms() -> u64 {
+    30_000
+}
+
 impl ArchiveStorageConfig {
     pub fn validate(&self, resolved_secrets: &HashMap<String, ResolvedSecret>) -> Result<()> {
         match self {
@@ -193,6 +210,8 @@ impl ArchiveStorageConfig {
                 connect_timeout_ms,
                 operation_attempt_timeout_ms,
                 max_attempts,
+                initial_backoff_ms,
+                max_backoff_ms,
                 access_key_id,
                 secret_access_key,
                 session_token,
@@ -223,7 +242,8 @@ impl ArchiveStorageConfig {
                 Self::validate_connections(connections)?;
                 Self::validate_connect_timeout_ms(connect_timeout_ms)?;
                 Self::validate_operation_attempt_timeout_ms(operation_attempt_timeout_ms)?;
-                Self::validate_max_attempts(max_attempts)
+                Self::validate_max_attempts(max_attempts)?;
+                Self::validate_backoff(*initial_backoff_ms, *max_backoff_ms)
             }
         }
     }
@@ -275,6 +295,20 @@ impl ArchiveStorageConfig {
         if *max_attempts == 0 {
             return Err(crate::ubiblk_error!(InvalidParameter {
                 description: "S3 max_attempts must be greater than 0".to_string(),
+            }));
+        }
+        Ok(())
+    }
+
+    fn validate_backoff(initial_backoff_ms: u64, max_backoff_ms: u64) -> crate::Result<()> {
+        if initial_backoff_ms == 0 {
+            return Err(crate::ubiblk_error!(InvalidParameter {
+                description: "S3 initial_backoff_ms must be greater than 0".to_string(),
+            }));
+        }
+        if max_backoff_ms < initial_backoff_ms {
+            return Err(crate::ubiblk_error!(InvalidParameter {
+                description: "S3 max_backoff_ms must be >= initial_backoff_ms".to_string(),
             }));
         }
         Ok(())
@@ -421,6 +455,8 @@ mod tests {
                 connect_timeout_ms: 5_000,
                 operation_attempt_timeout_ms: 20_000,
                 max_attempts: 3,
+                initial_backoff_ms: 2_000,
+                max_backoff_ms: 30_000,
             })
         );
     }
@@ -453,6 +489,8 @@ mod tests {
                 connect_timeout_ms: 5_000,
                 operation_attempt_timeout_ms: 20_000,
                 max_attempts: 3,
+                initial_backoff_ms: 2_000,
+                max_backoff_ms: 30_000,
             })
         );
     }
@@ -488,8 +526,37 @@ mod tests {
                 connect_timeout_ms: 120,
                 operation_attempt_timeout_ms: 45_000,
                 max_attempts: 7,
+                initial_backoff_ms: 2_000,
+                max_backoff_ms: 30_000,
             })
         );
+    }
+
+    #[test]
+    fn archive_s3_custom_backoff_config() {
+        let toml = r#"
+            type = "archive"
+            storage = "s3"
+            bucket = "encrypted-stripes"
+            region = "eu-west-1"
+            access_key_id.ref = "aws-access-key-id"
+            secret_access_key.ref = "aws-secret-access-key"
+            archive_kek.ref = "archive-kek"
+            initial_backoff_ms = 5_000
+            max_backoff_ms = 60_000
+        "#;
+        let config: StripeSourceConfig = toml::from_str(toml).unwrap();
+        match config {
+            StripeSourceConfig::Archive(ArchiveStorageConfig::S3 {
+                initial_backoff_ms,
+                max_backoff_ms,
+                ..
+            }) => {
+                assert_eq!(initial_backoff_ms, 5_000);
+                assert_eq!(max_backoff_ms, 60_000);
+            }
+            _ => panic!("expected archive/s3 config"),
+        }
     }
 
     #[test]
@@ -770,6 +837,8 @@ mod tests {
             connect_timeout_ms: 5_000,
             operation_attempt_timeout_ms: 20_000,
             max_attempts: 3,
+            initial_backoff_ms: 2_000,
+            max_backoff_ms: 30_000,
         });
         let danger_zone = DangerZone::default();
         let result = config.validate(&danger_zone, &valid_s3_secrets());
@@ -815,6 +884,8 @@ mod tests {
             connect_timeout_ms: 5_000,
             operation_attempt_timeout_ms: 20_000,
             max_attempts: 3,
+            initial_backoff_ms: 2_000,
+            max_backoff_ms: 30_000,
         });
 
         let result = config.validate(&DangerZone::default(), &secrets);
@@ -839,6 +910,8 @@ mod tests {
             connect_timeout_ms: 5_000,
             operation_attempt_timeout_ms: 20_000,
             max_attempts: 3,
+            initial_backoff_ms: 2_000,
+            max_backoff_ms: 30_000,
         });
         let danger_zone = DangerZone::default();
         let result = config.validate(&danger_zone, &valid_s3_secrets());
@@ -863,6 +936,8 @@ mod tests {
             connect_timeout_ms: 0,
             operation_attempt_timeout_ms: 20_000,
             max_attempts: 3,
+            initial_backoff_ms: 2_000,
+            max_backoff_ms: 30_000,
         });
         let result = config.validate(&DangerZone::default(), &valid_s3_secrets());
         assert!(result.is_err());
@@ -886,6 +961,8 @@ mod tests {
             connect_timeout_ms: 5_000,
             operation_attempt_timeout_ms: 0,
             max_attempts: 3,
+            initial_backoff_ms: 2_000,
+            max_backoff_ms: 30_000,
         });
         let result = config.validate(&DangerZone::default(), &valid_s3_secrets());
         assert!(result.is_err());
@@ -909,10 +986,62 @@ mod tests {
             connect_timeout_ms: 5_000,
             operation_attempt_timeout_ms: 20_000,
             max_attempts: 0,
+            initial_backoff_ms: 2_000,
+            max_backoff_ms: 30_000,
         });
         let result = config.validate(&DangerZone::default(), &valid_s3_secrets());
         assert!(result.is_err());
         let error_msg = result.err().unwrap().to_string();
         assert!(error_msg.contains("S3 max_attempts must be greater than 0"));
+    }
+
+    #[test]
+    fn validate_rejects_zero_initial_backoff() {
+        let config = StripeSourceConfig::Archive(ArchiveStorageConfig::S3 {
+            bucket: "bucket".to_string(),
+            prefix: None,
+            region: Some("us-east-1".to_string()),
+            access_key_id: SecretRef::Ref("key".to_string()),
+            secret_access_key: SecretRef::Ref("secret".to_string()),
+            session_token: None,
+            archive_kek: Some(SecretRef::Ref("kek".to_string())),
+            autofetch: false,
+            connections: 16,
+            endpoint: None,
+            connect_timeout_ms: 5_000,
+            operation_attempt_timeout_ms: 20_000,
+            max_attempts: 3,
+            initial_backoff_ms: 0,
+            max_backoff_ms: 30_000,
+        });
+        let result = config.validate(&DangerZone::default(), &valid_s3_secrets());
+        assert!(result.is_err());
+        let error_msg = result.err().unwrap().to_string();
+        assert!(error_msg.contains("S3 initial_backoff_ms must be greater than 0"));
+    }
+
+    #[test]
+    fn validate_rejects_max_backoff_smaller_than_initial() {
+        let config = StripeSourceConfig::Archive(ArchiveStorageConfig::S3 {
+            bucket: "bucket".to_string(),
+            prefix: None,
+            region: Some("us-east-1".to_string()),
+            access_key_id: SecretRef::Ref("key".to_string()),
+            secret_access_key: SecretRef::Ref("secret".to_string()),
+            session_token: None,
+            archive_kek: Some(SecretRef::Ref("kek".to_string())),
+            autofetch: false,
+            connections: 16,
+            endpoint: None,
+            connect_timeout_ms: 5_000,
+            operation_attempt_timeout_ms: 20_000,
+            max_attempts: 3,
+            initial_backoff_ms: 10_000,
+            max_backoff_ms: 5_000,
+        });
+        let result = config.validate(&DangerZone::default(), &valid_s3_secrets());
+        assert!(result.is_err());
+        let error_msg = result.err().unwrap().to_string();
+        assert!(error_msg.contains("S3 max_backoff_ms must be >= initial_backoff_ms"));
     }
 }

--- a/src/stripe_source/builder.rs
+++ b/src/stripe_source/builder.rs
@@ -160,6 +160,8 @@ impl StripeSourceBuilder {
                 connect_timeout_ms,
                 operation_attempt_timeout_ms,
                 max_attempts,
+                initial_backoff_ms,
+                max_backoff_ms,
                 ..
             } => {
                 let decrypted_credentials = Self::build_aws_credentials(
@@ -179,6 +181,8 @@ impl StripeSourceBuilder {
                         connect_timeout_ms: *connect_timeout_ms,
                         operation_attempt_timeout_ms: *operation_attempt_timeout_ms,
                         max_attempts: *max_attempts,
+                        initial_backoff_ms: *initial_backoff_ms,
+                        max_backoff_ms: *max_backoff_ms,
                     },
                 )?;
 
@@ -405,6 +409,8 @@ mod tests {
             connect_timeout_ms: 5_000,
             operation_attempt_timeout_ms: 20_000,
             max_attempts: 3,
+            initial_backoff_ms: 2_000,
+            max_backoff_ms: 30_000,
             archive_kek: Some(SecretRef::Ref("my_kek".to_string())),
             autofetch: false,
         };

--- a/src/utils/s3.rs
+++ b/src/utils/s3.rs
@@ -2,6 +2,12 @@ use std::{sync::Arc, time::Duration};
 
 use aws_config::{BehaviorVersion, Region};
 use aws_sdk_s3::config::timeout::TimeoutConfig;
+use aws_smithy_runtime_api::client::{
+    interceptors::context::InterceptorContext,
+    retries::classifiers::{
+        ClassifyRetry, RetryAction, RetryClassifierPriority, SharedRetryClassifier,
+    },
+};
 
 use crate::Result;
 
@@ -10,6 +16,52 @@ pub struct S3ClientTuning {
     pub connect_timeout_ms: u64,
     pub operation_attempt_timeout_ms: u64,
     pub max_attempts: u32,
+    pub initial_backoff_ms: u64,
+    pub max_backoff_ms: u64,
+}
+
+/// The SDK's default `HttpStatusCodeClassifier` only marks 500/502/503/504 as
+/// retryable. Cloudflare R2 returns HTTP 429 for its per-object rate limit and
+/// includes a `Retry-After` header; without this classifier the SDK gives up
+/// on the first throttle response.
+#[derive(Debug)]
+struct Retry429Classifier;
+
+impl ClassifyRetry for Retry429Classifier {
+    fn classify_retry(&self, ctx: &InterceptorContext) -> RetryAction {
+        let Some(response) = ctx.response() else {
+            return RetryAction::NoActionIndicated;
+        };
+        if response.status().as_u16() != 429 {
+            return RetryAction::NoActionIndicated;
+        }
+        // Honor Retry-After (delta-seconds form) when the server provides it.
+        // HTTP-date form is uncommon for S3-compatible peers; if it appears we
+        // fall back to the standard exponential schedule.
+        let retry_after = response
+            .headers()
+            .get("retry-after")
+            .and_then(|v| v.parse::<u64>().ok())
+            .map(Duration::from_secs);
+        match retry_after {
+            Some(d) => RetryAction::retryable_error_with_explicit_delay(
+                aws_smithy_runtime_api::client::retries::ErrorKind::ThrottlingError,
+                d,
+            ),
+            None => RetryAction::throttling_error(),
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        "Retry429"
+    }
+
+    fn priority(&self) -> RetryClassifierPriority {
+        // Run after the SDK's built-in classifiers so a `ThrottlingError` decision
+        // here overrides any equal-priority `transient_error` they might produce
+        // on the same 429. Equal-priority ordering is unspecified by the SDK.
+        RetryClassifierPriority::run_after(RetryClassifierPriority::transient_error_classifier())
+    }
 }
 
 pub fn create_runtime() -> Result<Arc<tokio::runtime::Runtime>> {
@@ -56,9 +108,12 @@ pub fn build_s3_client(
         .operation_attempt_timeout(Duration::from_millis(tuning.operation_attempt_timeout_ms))
         .build();
     builder = builder.timeout_config(timeout_config);
-    let retry_config =
-        aws_sdk_s3::config::retry::RetryConfig::standard().with_max_attempts(tuning.max_attempts);
+    let retry_config = aws_sdk_s3::config::retry::RetryConfig::standard()
+        .with_max_attempts(tuning.max_attempts)
+        .with_initial_backoff(Duration::from_millis(tuning.initial_backoff_ms))
+        .with_max_backoff(Duration::from_millis(tuning.max_backoff_ms));
     builder = builder.retry_config(retry_config);
+    builder.push_retry_classifier(SharedRetryClassifier::new(Retry429Classifier));
 
     if let Some(endpoint) = endpoint {
         builder = builder.endpoint_url(endpoint);
@@ -97,6 +152,8 @@ mod tests {
                 connect_timeout_ms: 5_000,
                 operation_attempt_timeout_ms: 20_000,
                 max_attempts: 3,
+                initial_backoff_ms: 2_000,
+                max_backoff_ms: 30_000,
             },
         )
         .expect("client should be created");
@@ -118,10 +175,60 @@ mod tests {
             "S3 operation attempt timeout should be 20 seconds"
         );
 
-        let retry_debug = format!("{:?}", conf.retry_config());
-        assert!(
-            retry_debug.contains("max_attempts: 3"),
-            "S3 retry config should set max_attempts to 3"
+        let retry_config = conf.retry_config().expect("retry config present");
+        assert_eq!(retry_config.max_attempts(), 3);
+        assert_eq!(retry_config.initial_backoff(), Duration::from_millis(2_000));
+        assert_eq!(retry_config.max_backoff(), Duration::from_millis(30_000));
+    }
+
+    #[test]
+    fn retry_429_classifier_marks_throttle_response_retryable() {
+        use aws_sdk_s3::primitives::SdkBody;
+        use aws_smithy_runtime_api::client::interceptors::context::{Input, InterceptorContext};
+        use aws_smithy_runtime_api::http::{Response, StatusCode};
+
+        let classifier = Retry429Classifier;
+
+        // No response yet -> no opinion.
+        let ctx = InterceptorContext::new(Input::doesnt_matter());
+        assert_eq!(
+            classifier.classify_retry(&ctx),
+            RetryAction::NoActionIndicated
+        );
+
+        // 200 -> no opinion.
+        let mut ctx = InterceptorContext::new(Input::doesnt_matter());
+        ctx.set_response(Response::new(
+            StatusCode::try_from(200).unwrap(),
+            SdkBody::empty(),
+        ));
+        assert_eq!(
+            classifier.classify_retry(&ctx),
+            RetryAction::NoActionIndicated
+        );
+
+        // 429 without Retry-After -> throttling retry, no explicit delay.
+        let mut ctx = InterceptorContext::new(Input::doesnt_matter());
+        ctx.set_response(Response::new(
+            StatusCode::try_from(429).unwrap(),
+            SdkBody::empty(),
+        ));
+        assert_eq!(
+            classifier.classify_retry(&ctx),
+            RetryAction::throttling_error()
+        );
+
+        // 429 with Retry-After: 5 -> throttling retry with explicit 5s delay.
+        let mut response = Response::new(StatusCode::try_from(429).unwrap(), SdkBody::empty());
+        response.headers_mut().append("retry-after", "5");
+        let mut ctx = InterceptorContext::new(Input::doesnt_matter());
+        ctx.set_response(response);
+        assert_eq!(
+            classifier.classify_retry(&ctx),
+            RetryAction::retryable_error_with_explicit_delay(
+                aws_smithy_runtime_api::client::retries::ErrorKind::ThrottlingError,
+                Duration::from_secs(5)
+            )
         );
     }
 }


### PR DESCRIPTION
Cloudflare R2 throttles per-object writes with HTTP 429 and a `Retry-After` header. The AWS SDK's default `HttpStatusCodeClassifier` only treats 500/502/503/504 as retryable, so 429s fall through as fatal errors. Default initial_backoff is ~1s; the SDK's first retry samples [0, 2s) jittered, which can land inside R2's same-key 1s window — the exact race that caused the original incident.

Add three knobs to ArchiveStorageConfig::S3:
- max_attempts (existing): now also drives the retry budget for 429s.
- initial_backoff_ms (new, default 2000): bigger window keeps most first retries outside R2's same-key window.
- max_backoff_ms (new, default 30000).

Register a small `Retry429Classifier` via `push_retry_classifier` so the SDK treats 429 as a retryable throttling error. When the server sends `Retry-After: <seconds>`, surface it via
`retryable_error_with_explicit_delay`; the standard strategy honors it directly, bypassing exponential backoff.