### PR TITLE
Set 1.5s minimum retry delay for S3 puts

### DIFF
--- a/docs/archive.md
+++ b/docs/archive.md
@@ -118,6 +118,25 @@ source.env = "UBIBLK_ARCHIVE_KEK"
 | `connect_timeout_ms` | integer | no | 5000 | S3 connection timeout in milliseconds |
 | `operation_attempt_timeout_ms` | integer | no | 20000 | S3 operation attempt timeout in milliseconds |
 | `max_attempts` | integer | no | 3 | Max S3 operation attempts (initial attempt + retries) |
+| `deterministic_retry_backoff_ms` | integer | no | — (unset) | When set, use a deterministic retry backoff of this many ms; unset uses jittered backoff. Must be > 0. See below. |
+
+#### Retry backoff behavior
+
+Failed S3 operations are retried (up to `max_attempts` total tries) with an
+exponential backoff. `deterministic_retry_backoff_ms` chooses the mode:
+
+- **Unset (default) — jittered backoff.** Retry _n_ waits a random duration in
+  `[0, initial * 2ⁿ)` (the AWS SDK's default full jitter, `initial` = 1s).
+  Jitter avoids synchronized retries, but the first retry can fire almost
+  immediately.
+- **Set to `t` — deterministic backoff.** Retry _n_ waits `t * 2ⁿ` ms
+  (`t`, `2t`, `4t`, …, capped at the SDK's default 20s maximum backoff) with no
+  jitter, so **every retry is at least `t`**.
+
+Set this when archiving to an object store that rate-limits rapid retries to
+the same object: after a transient `5xx` on a PUT, a sub-second jittered retry
+can be rejected and fail the whole archive. A deterministic `t` of
+`1500`–`2000` keeps every retry spaced out, at the cost of jitter.
 
 ### `[secrets.*]` and `[danger_zone]`
 

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -115,6 +115,9 @@ source.env = "UBIBLK_ARCHIVE_KEK"
 | `session_token.ref` | string | no | — | Reference to AWS session token secret (for temporary credentials) |
 | `archive_kek.ref` | string | no | — | Reference to a 32-byte AES-256-GCM KEK secret |
 | `autofetch` | boolean | no | false | Fetch stripes in the background |
+| `connect_timeout_ms` | integer | no | 5000 | S3 connection timeout in milliseconds |
+| `operation_attempt_timeout_ms` | integer | no | 20000 | S3 operation attempt timeout in milliseconds |
+| `max_attempts` | integer | no | 3 | Max S3 operation attempts (initial attempt + retries) |
 
 ### `[secrets.*]` and `[danger_zone]`
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -265,6 +265,27 @@ autofetch = false                           # optional, default: false
 | `connect_timeout_ms` | integer | no | 5000 | S3 connection timeout in milliseconds |
 | `operation_attempt_timeout_ms` | integer | no | 20000 | S3 operation attempt timeout in milliseconds |
 | `max_attempts` | integer | no | 3 | Max S3 operation attempts (initial attempt + retries) |
+| `deterministic_retry_backoff_ms` | integer | no | — (unset) | When set, use a deterministic retry backoff of this many ms; unset uses jittered backoff. Must be > 0. See below. |
+
+#### Retry backoff behavior
+
+Retries (up to `max_attempts` total tries) are delayed by an exponential backoff.
+`deterministic_retry_backoff_ms` selects between two modes:
+
+- **Unset (default) — jittered backoff.** Retry _n_ waits a random duration in
+  `[0, initial * 2ⁿ)` (the AWS SDK's default full jitter, `initial` = 1s). Jitter
+  spreads retries across keys to avoid thundering-herd effects, but because the
+  lower bound is 0 the first retry can fire almost immediately.
+- **Set to `t` — deterministic backoff.** Retry _n_ waits `t * 2ⁿ` ms
+  (`t`, `2t`, `4t`, …, capped at the SDK's default 20s maximum backoff) with no
+  jitter, so **every retry is at least `t`**. Use this when the object store
+  rate-limits rapid retries to the same object and may reject a too-fast retry
+  after a transient error, which can fail the whole operation. A deterministic
+  minimum keeps retries spaced out. The trade-off is the loss of jitter.
+
+Set it on the **archive target** config to protect the archiving (PUT) path,
+where such per-object write limits apply. The read (GET) path is not affected
+this way, so leaving it unset there keeps jitter.
 
 ### Remote
 

--- a/src/config/v2/stripe_source.rs
+++ b/src/config/v2/stripe_source.rs
@@ -155,6 +155,8 @@ pub enum ArchiveStorageConfig {
         operation_attempt_timeout_ms: u64,
         #[serde(default = "default_max_attempts")]
         max_attempts: u32,
+        #[serde(default)]
+        deterministic_retry_backoff_ms: Option<u64>,
         archive_kek: Option<SecretRef>,
         #[serde(default)]
         autofetch: bool,
@@ -193,6 +195,7 @@ impl ArchiveStorageConfig {
                 connect_timeout_ms,
                 operation_attempt_timeout_ms,
                 max_attempts,
+                deterministic_retry_backoff_ms,
                 access_key_id,
                 secret_access_key,
                 session_token,
@@ -223,9 +226,21 @@ impl ArchiveStorageConfig {
                 Self::validate_connections(connections)?;
                 Self::validate_connect_timeout_ms(connect_timeout_ms)?;
                 Self::validate_operation_attempt_timeout_ms(operation_attempt_timeout_ms)?;
-                Self::validate_max_attempts(max_attempts)
+                Self::validate_max_attempts(max_attempts)?;
+                Self::validate_deterministic_retry_backoff_ms(deterministic_retry_backoff_ms)
             }
         }
+    }
+
+    fn validate_deterministic_retry_backoff_ms(
+        deterministic_retry_backoff_ms: &Option<u64>,
+    ) -> crate::Result<()> {
+        if let Some(0) = deterministic_retry_backoff_ms {
+            return Err(crate::ubiblk_error!(InvalidParameter {
+                description: "S3 deterministic_retry_backoff_ms must be greater than 0".to_string(),
+            }));
+        }
+        Ok(())
     }
 
     fn validate_prefix(prefix: &Option<String>) -> crate::Result<()> {
@@ -421,6 +436,7 @@ mod tests {
                 connect_timeout_ms: 5_000,
                 operation_attempt_timeout_ms: 20_000,
                 max_attempts: 3,
+                deterministic_retry_backoff_ms: None,
             })
         );
     }
@@ -453,6 +469,7 @@ mod tests {
                 connect_timeout_ms: 5_000,
                 operation_attempt_timeout_ms: 20_000,
                 max_attempts: 3,
+                deterministic_retry_backoff_ms: None,
             })
         );
     }
@@ -488,6 +505,7 @@ mod tests {
                 connect_timeout_ms: 120,
                 operation_attempt_timeout_ms: 45_000,
                 max_attempts: 7,
+                deterministic_retry_backoff_ms: None,
             })
         );
     }
@@ -770,6 +788,7 @@ mod tests {
             connect_timeout_ms: 5_000,
             operation_attempt_timeout_ms: 20_000,
             max_attempts: 3,
+            deterministic_retry_backoff_ms: None,
         });
         let danger_zone = DangerZone::default();
         let result = config.validate(&danger_zone, &valid_s3_secrets());
@@ -815,6 +834,7 @@ mod tests {
             connect_timeout_ms: 5_000,
             operation_attempt_timeout_ms: 20_000,
             max_attempts: 3,
+            deterministic_retry_backoff_ms: None,
         });
 
         let result = config.validate(&DangerZone::default(), &secrets);
@@ -839,6 +859,7 @@ mod tests {
             connect_timeout_ms: 5_000,
             operation_attempt_timeout_ms: 20_000,
             max_attempts: 3,
+            deterministic_retry_backoff_ms: None,
         });
         let danger_zone = DangerZone::default();
         let result = config.validate(&danger_zone, &valid_s3_secrets());
@@ -863,6 +884,7 @@ mod tests {
             connect_timeout_ms: 0,
             operation_attempt_timeout_ms: 20_000,
             max_attempts: 3,
+            deterministic_retry_backoff_ms: None,
         });
         let result = config.validate(&DangerZone::default(), &valid_s3_secrets());
         assert!(result.is_err());
@@ -886,6 +908,7 @@ mod tests {
             connect_timeout_ms: 5_000,
             operation_attempt_timeout_ms: 0,
             max_attempts: 3,
+            deterministic_retry_backoff_ms: None,
         });
         let result = config.validate(&DangerZone::default(), &valid_s3_secrets());
         assert!(result.is_err());
@@ -909,10 +932,73 @@ mod tests {
             connect_timeout_ms: 5_000,
             operation_attempt_timeout_ms: 20_000,
             max_attempts: 0,
+            deterministic_retry_backoff_ms: None,
         });
         let result = config.validate(&DangerZone::default(), &valid_s3_secrets());
         assert!(result.is_err());
         let error_msg = result.err().unwrap().to_string();
         assert!(error_msg.contains("S3 max_attempts must be greater than 0"));
+    }
+
+    #[test]
+    fn validate_rejects_zero_deterministic_retry_backoff() {
+        let config = StripeSourceConfig::Archive(ArchiveStorageConfig::S3 {
+            bucket: "bucket".to_string(),
+            prefix: None,
+            region: Some("us-east-1".to_string()),
+            access_key_id: SecretRef::Ref("key".to_string()),
+            secret_access_key: SecretRef::Ref("secret".to_string()),
+            session_token: None,
+            archive_kek: Some(SecretRef::Ref("kek".to_string())),
+            autofetch: false,
+            connections: 16,
+            endpoint: None,
+            connect_timeout_ms: 5_000,
+            operation_attempt_timeout_ms: 20_000,
+            max_attempts: 3,
+            deterministic_retry_backoff_ms: Some(0),
+        });
+        let result = config.validate(&DangerZone::default(), &valid_s3_secrets());
+        assert!(result.is_err());
+        let error_msg = result.err().unwrap().to_string();
+        assert!(error_msg.contains("S3 deterministic_retry_backoff_ms must be greater than 0"));
+    }
+
+    #[test]
+    fn archive_s3_deterministic_retry_backoff_config() {
+        // Defaults to None (jittered backoff) when omitted.
+        let default_toml = r#"
+            type = "archive"
+            storage = "s3"
+            bucket = "encrypted-stripes"
+            access_key_id.ref = "aws-access-key-id"
+            secret_access_key.ref = "aws-secret-access-key"
+            archive_kek.ref = "archive-kek"
+        "#;
+        match toml::from_str::<StripeSourceConfig>(default_toml).unwrap() {
+            StripeSourceConfig::Archive(ArchiveStorageConfig::S3 {
+                deterministic_retry_backoff_ms,
+                ..
+            }) => assert_eq!(deterministic_retry_backoff_ms, None),
+            _ => panic!("expected archive/s3 config"),
+        }
+
+        // Explicit value parses through.
+        let set_toml = r#"
+            type = "archive"
+            storage = "s3"
+            bucket = "encrypted-stripes"
+            access_key_id.ref = "aws-access-key-id"
+            secret_access_key.ref = "aws-secret-access-key"
+            archive_kek.ref = "archive-kek"
+            deterministic_retry_backoff_ms = 1500
+        "#;
+        match toml::from_str::<StripeSourceConfig>(set_toml).unwrap() {
+            StripeSourceConfig::Archive(ArchiveStorageConfig::S3 {
+                deterministic_retry_backoff_ms,
+                ..
+            }) => assert_eq!(deterministic_retry_backoff_ms, Some(1500)),
+            _ => panic!("expected archive/s3 config"),
+        }
     }
 }

--- a/src/stripe_source/builder.rs
+++ b/src/stripe_source/builder.rs
@@ -160,6 +160,7 @@ impl StripeSourceBuilder {
                 connect_timeout_ms,
                 operation_attempt_timeout_ms,
                 max_attempts,
+                deterministic_retry_backoff_ms,
                 ..
             } => {
                 let decrypted_credentials = Self::build_aws_credentials(
@@ -179,6 +180,7 @@ impl StripeSourceBuilder {
                         connect_timeout_ms: *connect_timeout_ms,
                         operation_attempt_timeout_ms: *operation_attempt_timeout_ms,
                         max_attempts: *max_attempts,
+                        deterministic_retry_backoff_ms: *deterministic_retry_backoff_ms,
                     },
                 )?;
 
@@ -405,6 +407,7 @@ mod tests {
             connect_timeout_ms: 5_000,
             operation_attempt_timeout_ms: 20_000,
             max_attempts: 3,
+            deterministic_retry_backoff_ms: None,
             archive_kek: Some(SecretRef::Ref("my_kek".to_string())),
             autofetch: false,
         };

--- a/src/utils/s3.rs
+++ b/src/utils/s3.rs
@@ -10,6 +10,12 @@ pub struct S3ClientTuning {
     pub connect_timeout_ms: u64,
     pub operation_attempt_timeout_ms: u64,
     pub max_attempts: u32,
+    /// Retry backoff mode. `None` keeps the SDK default (exponential backoff
+    /// with full jitter). `Some(t)` uses a deterministic exponential backoff
+    /// starting at `t` ms with no jitter, so retry N waits `t * 2^N` (capped at
+    /// the SDK's default 20s maximum backoff) and the first retry is guaranteed
+    /// to be at least `t`.
+    pub deterministic_retry_backoff_ms: Option<u64>,
 }
 
 pub fn create_runtime() -> Result<Arc<tokio::runtime::Runtime>> {
@@ -56,8 +62,18 @@ pub fn build_s3_client(
         .operation_attempt_timeout(Duration::from_millis(tuning.operation_attempt_timeout_ms))
         .build();
     builder = builder.timeout_config(timeout_config);
-    let retry_config =
+    let mut retry_config =
         aws_sdk_s3::config::retry::RetryConfig::standard().with_max_attempts(tuning.max_attempts);
+    if let Some(backoff_ms) = tuning.deterministic_retry_backoff_ms {
+        // Deterministic exponential backoff (t, 2t, 4t, ...) with no jitter. The
+        // SDK's default full jitter lets the first retry fire in [0, t), which
+        // can trip object stores that rate-limit rapid retries to the same key.
+        // Pinning the exponential base disables jitter so every retry waits at
+        // least t.
+        retry_config = retry_config
+            .with_initial_backoff(Duration::from_millis(backoff_ms))
+            .with_use_static_exponential_base(true);
+    }
     builder = builder.retry_config(retry_config);
 
     if let Some(endpoint) = endpoint {
@@ -97,6 +113,7 @@ mod tests {
                 connect_timeout_ms: 5_000,
                 operation_attempt_timeout_ms: 20_000,
                 max_attempts: 3,
+                deterministic_retry_backoff_ms: None,
             },
         )
         .expect("client should be created");
@@ -118,10 +135,37 @@ mod tests {
             "S3 operation attempt timeout should be 20 seconds"
         );
 
-        let retry_debug = format!("{:?}", conf.retry_config());
-        assert!(
-            retry_debug.contains("max_attempts: 3"),
-            "S3 retry config should set max_attempts to 3"
-        );
+        let retry_config = conf.retry_config().expect("retry config present");
+        assert_eq!(retry_config.max_attempts(), 3);
+        // Default (None) keeps the SDK's jittered exponential backoff.
+        assert!(!retry_config.use_static_exponential_base());
+    }
+
+    #[test]
+    fn deterministic_backoff_disables_jitter_with_floor() {
+        let runtime = create_runtime().expect("runtime should be created");
+        let client = build_s3_client(
+            &runtime,
+            None,
+            None,
+            Some("auto"),
+            None,
+            S3ClientTuning {
+                connect_timeout_ms: 5_000,
+                operation_attempt_timeout_ms: 20_000,
+                max_attempts: 3,
+                deterministic_retry_backoff_ms: Some(1_500),
+            },
+        )
+        .expect("client should be created");
+
+        let retry_config = client
+            .config()
+            .retry_config()
+            .expect("retry config present");
+        // Deterministic mode: no jitter, first retry floored at the configured value.
+        assert!(retry_config.use_static_exponential_base());
+        assert_eq!(retry_config.initial_backoff(), Duration::from_millis(1_500));
+        assert_eq!(retry_config.max_attempts(), 3);
     }
 }


### PR DESCRIPTION
R2 docs say "Maximum concurrent writes to the same object name is 1 per second". If we get 500 on first write and retry in less than second we'll get 429. Do a little bit more than second to avoid 429 errors.

The AWS SDK standard retry strategy uses full jitter (backoff = random(0..1) * initial_backoff * 2^attempt), so setting initial_backoff alone only caps the first retry delay rather than establishing a floor. Disabling the random exponential base pins the base multiplier at 1.0, making put retries deterministic (1.5s, 3s, 6s, ...) with a 1.5s floor. The override is scoped to puts only via config_override, so gets keep the default jittered backoff, and it preserves the client's other retry settings such as max_attempts.