### PR TITLE
Bump anyhow to 1.0.103 to fix RUSTSEC-2026-0190

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"


### PR DESCRIPTION
cargo audit flagged anyhow 1.0.102 for an unsoundness in Error::downcast_mut() (RUSTSEC-2026-0190): adding context to an error via Error::context and then calling downcast_mut on the result violates borrow rules and is undefined behavior. Fixed in anyhow >= 1.0.103.

anyhow is a transitive build-dependency (via libublk 0.4.5), so this is a lockfile-only bump within the 1.x range; no Cargo.toml change is needed.