### PR TITLE
Add shell-based S3 integration tests

### DIFF
--- a/.github/workflows/s3-integration.yaml
+++ b/.github/workflows/s3-integration.yaml
@@ -1,0 +1,100 @@
+name: S3 integration
+
+# Archives a ubiblk device to a real S3-compatible bucket and reads it back,
+# with fault injection through an r2proxy MITM proxy standing in front of the
+# bucket. Needs upstream object-store credentials (R2/S3). Fork PRs have no
+# access to secrets, so the guard step below skips them cleanly.
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+
+# A cancelled run still cleans up its bucket objects (see the runner script), so
+# it is safe to supersede in-progress runs for the same ref.
+concurrency:
+  group: s3-integration-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  ISA_L_CRYPTO_VERSION: "v2.25.0"
+
+jobs:
+  s3-integration:
+    runs-on: ubicloud-standard-4
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      # No-op cleanly when the object-store secrets are not configured (e.g. a
+      # fork or a repo that has not set them up) instead of hard-failing.
+      - name: Check for object-store secrets
+        id: guard
+        env:
+          ACCESS_KEY_ID: ${{ secrets.S3_INTEGRATION_TESTS_ACCESS_KEY_ID }}
+        run: |
+          if [ -n "$ACCESS_KEY_ID" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "S3 secrets not configured; skipping S3 integration tests."
+          fi
+
+      - name: Install build dependencies
+        if: steps.guard.outputs.enabled == 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y autoconf libtool nasm clang build-essential
+
+      - name: Install Rust
+        if: steps.guard.outputs.enabled == 'true'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust (registry, git deps, target/)
+        if: steps.guard.outputs.enabled == 'true'
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Install prebuilt isa-l_crypto
+        if: steps.guard.outputs.enabled == 'true'
+        run: |
+          set -euo pipefail
+          arch="$(uname -m)"
+          archive="isa-l_crypto-${ISA_L_CRYPTO_VERSION}-${arch}.tar.gz"
+          url="https://github.com/ubicloud/ubiblk/releases/download/prebuilt-ci-deps/${archive}"
+          curl -fL -o "${archive}" "${url}"
+          sudo tar -xzf "${archive}" -C /
+
+      - name: Set up Go
+        if: steps.guard.outputs.enabled == 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+
+      - name: Build r2proxy
+        if: steps.guard.outputs.enabled == 'true'
+        run: |
+          set -euo pipefail
+          git clone --depth 1 https://github.com/ubicloud/r2proxy "$RUNNER_TEMP/r2proxy-src"
+          go build -C "$RUNNER_TEMP/r2proxy-src" -o "$RUNNER_TEMP/bin/r2proxy" .
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+
+      - name: Ensure aws CLI (used for bucket cleanup)
+        if: steps.guard.outputs.enabled == 'true'
+        run: |
+          command -v aws >/dev/null 2>&1 && exit 0
+          curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o /tmp/awscli.zip
+          (cd /tmp && unzip -q awscli.zip && sudo ./aws/install)
+
+      - name: Run S3 integration tests
+        if: steps.guard.outputs.enabled == 'true'
+        env:
+          S3_INTEGRATION_TESTS_ENDPOINT: ${{ secrets.S3_INTEGRATION_TESTS_ENDPOINT }}
+          S3_INTEGRATION_TESTS_BUCKET: ${{ secrets.S3_INTEGRATION_TESTS_BUCKET }}
+          S3_INTEGRATION_TESTS_ACCESS_KEY_ID: ${{ secrets.S3_INTEGRATION_TESTS_ACCESS_KEY_ID }}
+          S3_INTEGRATION_TESTS_SECRET_ACCESS_KEY: ${{ secrets.S3_INTEGRATION_TESTS_SECRET_ACCESS_KEY }}
+          S3_INTEGRATION_TESTS_REGION: ${{ secrets.S3_INTEGRATION_TESTS_REGION }}
+        run: tests/s3-integration/run-all.sh

--- a/tests/s3-integration/README.md
+++ b/tests/s3-integration/README.md
@@ -1,0 +1,67 @@
+# S3 integration tests
+
+End-to-end tests that archive a ubiblk device to a **real** S3-compatible bucket
+and read it back, exercising a variety of error conditions along the way. They
+are written as shell scripts that drive the `archive`, `export-archive`, and
+`init-metadata` binaries — nothing here is a Rust `cargo test`.
+
+Fault injection (throttles, 5xx, latency) is done with
+[r2proxy](https://github.com/ubicloud/r2proxy), a MITM proxy placed in front of
+the bucket: the launcher starts it on a loopback port, the tests point at it, and
+it forwards to (and re-signs for) the real store.
+
+## What is covered
+
+| Case | What it checks |
+|------|----------------|
+| `archive_export_roundtrip_plain` | Archive a device, export it, bytes match. |
+| `archive_export_roundtrip_encrypted_zstd` | Same, with `--encrypt` + zstd. |
+| `rate_limited_retry_retries_429_default_does_not` | The default client drops R2's 429; `rate_limited_retry` retries it after a delay (asserted via timing). |
+| `transient_500_fails_then_recovers` | A persistent 500 fails the archive; once cleared, a re-run round-trips. |
+| `transient_errors_recovered_by_retries` | Errors that clear within the retry budget (fail twice per object, then succeed) do not fail a single archive. |
+| `access_denied_fails_fast` | A non-retryable 403 fails without a long backoff. |
+| `latency_injection_still_round_trips` | Injected latency does not break the round-trip. |
+| `get_object_error_fails_export` | A 500 on `GetObject` fails the export. |
+
+## Files
+
+- `run-all.sh` — launcher. Builds the binaries, starts r2proxy in front of your
+  bucket, points the tests at it, runs `cases.sh`, and deletes the run's objects
+  on exit (pass, fail, or cancel).
+- `cases.sh` — the test cases themselves. Builds a device fixture with
+  `scripts/ubiblk-init`, then archives/exports and injects faults.
+
+## Running locally
+
+Provide the **real** store's endpoint, bucket, and keys and run the launcher; it
+takes care of the proxy, the config, and cleanup:
+
+```sh
+S3_INTEGRATION_TESTS_ENDPOINT=https://<account>.r2.cloudflarestorage.com \
+S3_INTEGRATION_TESTS_BUCKET=my-test-bucket \
+S3_INTEGRATION_TESTS_ACCESS_KEY_ID=... \
+S3_INTEGRATION_TESTS_SECRET_ACCESS_KEY=... \
+  tests/s3-integration/run-all.sh
+```
+
+Optional: `S3_INTEGRATION_TESTS_REGION` (default `auto`), and `R2PROXY_BIN` if
+the `r2proxy` binary is not on your `PATH`.
+
+### Requirements
+
+- `r2proxy` built and on `PATH` (or pointed to via `R2PROXY_BIN`) — build it with
+  `go build` from <https://github.com/ubicloud/r2proxy>.
+- `cargo`, `curl`, `python3`, and the `aws` CLI (used only for bucket cleanup).
+
+Every object is written under a unique `s3-integration-tests/<run-id>/` prefix
+that is deleted from the bucket when the launcher exits, so nothing is left
+behind — even if a run is cancelled.
+
+## CI
+
+`.github/workflows/s3-integration.yaml` runs the same launcher on pushes to
+`main`, pull requests, and manual dispatch. It reads the store credentials from
+repository secrets of the same names (`S3_INTEGRATION_TESTS_ENDPOINT`,
+`S3_INTEGRATION_TESTS_BUCKET`, `S3_INTEGRATION_TESTS_ACCESS_KEY_ID`,
+`S3_INTEGRATION_TESTS_SECRET_ACCESS_KEY`, optional `S3_INTEGRATION_TESTS_REGION`).
+When those secrets are absent (for example on fork PRs) the job skips cleanly.

--- a/tests/s3-integration/cases.sh
+++ b/tests/s3-integration/cases.sh
@@ -212,6 +212,12 @@ else
   notok "access_denied_fails_fast" "rc=$a_rc, elapsed=${e}s"
 fi
 
+# Injected latency should not break the round-trip.
+clear_rules
+inject_rule '{"op":"*","delay_ms":200}'
+roundtrip "latency_injection_still_round_trips" "$(store_prefix latency)"
+clear_rules
+
 echo
 echo "# $pass passed, $fail failed"
 [ "$fail" -eq 0 ]

--- a/tests/s3-integration/cases.sh
+++ b/tests/s3-integration/cases.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+#
+# S3 integration test cases, in shell. Archives a ubiblk device to the S3
+# endpoint in the environment and reads it back, injecting faults through the
+# r2proxy admin API.
+#
+# Normally run via run-all.sh (the launcher), which starts r2proxy and points
+# these variables at it. It reads (all set by that launcher):
+#
+#   S3_INTEGRATION_TESTS_ENDPOINT      S3 data-plane URL (the proxy)
+#   S3_INTEGRATION_TESTS_BUCKET        bucket name
+#   S3_INTEGRATION_TESTS_ACCESS_KEY_ID / _SECRET_ACCESS_KEY   (read by `archive`)
+#   S3_INTEGRATION_TESTS_REGION        optional, default "auto"
+#   S3_INTEGRATION_TESTS_ADMIN         r2proxy admin API URL
+#   S3_INTEGRATION_TESTS_ADMIN_TOKEN   r2proxy admin token
+#   S3_INTEGRATION_TESTS_PREFIX        base key prefix for the run
+#
+# Binaries default to target/debug; override with ARCHIVE_BIN/EXPORT_BIN/INIT_BIN.
+# Exits non-zero if any case fails.
+set -uo pipefail
+
+ENDPOINT="${S3_INTEGRATION_TESTS_ENDPOINT:?set S3_INTEGRATION_TESTS_ENDPOINT}"
+BUCKET="${S3_INTEGRATION_TESTS_BUCKET:?}"
+REGION="${S3_INTEGRATION_TESTS_REGION:-auto}"
+ADMIN="${S3_INTEGRATION_TESTS_ADMIN:?}"
+TOKEN="${S3_INTEGRATION_TESTS_ADMIN_TOKEN:?}"
+PREFIX="${S3_INTEGRATION_TESTS_PREFIX:-}"
+: "${S3_INTEGRATION_TESTS_ACCESS_KEY_ID:?}"     # consumed by the archive binary
+: "${S3_INTEGRATION_TESTS_SECRET_ACCESS_KEY:?}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ARCHIVE="${ARCHIVE_BIN:-$ROOT/target/debug/archive}"
+EXPORT="${EXPORT_BIN:-$ROOT/target/debug/export-archive}"
+INIT="${INIT_BIN:-$ROOT/target/debug/init-metadata}"
+# ubiblk-init shells out to init-metadata by name; make our build findable.
+INIT_DIR="$(dirname "$INIT")"
+export PATH="$INIT_DIR:$PATH"
+
+DEVICE_MB=4 # four 1 MiB stripes
+ARCHIVE_KEK="0123456789abcdef0123456789abcdef"
+
+# Work on a real filesystem: the binaries open image files with O_DIRECT, which
+# tmpfs (/tmp on many systems) rejects. target/ is on the repo's filesystem.
+WORK="$(mktemp -d "$ROOT/target/s3-it-XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+ok() { echo "ok   - $1"; pass=$((pass + 1)); }
+notok() {
+  echo "FAIL - $1 ($2)"
+  fail=$((fail + 1))
+}
+
+seq_n=0
+uid() {
+  seq_n=$((seq_n + 1))
+  echo "$seq_n-$RANDOM"
+}
+store_prefix() { echo "${PREFIX}$1-$(uid)"; }
+now() { date +%s.%N; }
+since() { awk -v a="$1" -v b="$(date +%s.%N)" 'BEGIN { printf "%.3f", b - a }'; }
+
+# --- device fixture (built once, reused with a fresh prefix per case) ---------
+
+# Reuse the project's own initializer to write config.toml, disk.raw, and the
+# metadata, with our random image as the raw stripe source. This keeps the
+# device-config format in sync with real usage instead of duplicating it here.
+make_fixture() {
+  head -c "$((DEVICE_MB * 1024 * 1024))" /dev/urandom >"$WORK/base.raw"
+  python3 "$ROOT/scripts/ubiblk-init" --size "${DEVICE_MB}M" --dir "$WORK" \
+    --base "$WORK/base.raw" --stripe-size 1M --io-engine io_uring --force >/dev/null 2>&1
+}
+
+# --- config + archive/export drivers -----------------------------------------
+
+# write_store_config SECTION PREFIX RETRY -> prints the config path. SECTION is
+# "target" (archive) or "archive" (export). RETRY is "" or "min_ms,jitter_ms".
+write_store_config() {
+  local section="$1" prefix="$2" retry="$3" file rlr=""
+  file="$WORK/$section-$(uid).toml"
+  if [ -n "$retry" ]; then
+    rlr=$'\n'"[$section.rate_limited_retry]"$'\n'"enabled = true"
+    rlr+=$'\n'"min_delay_ms = ${retry%,*}"$'\n'"jitter_ms = ${retry#*,}"$'\n'
+  fi
+  cat >"$file" <<EOF
+[$section]
+storage = "s3"
+bucket = "$BUCKET"
+prefix = "$prefix"
+region = "$REGION"
+endpoint = "$ENDPOINT"
+connections = 4
+max_attempts = 3
+access_key_id.ref = "ak"
+secret_access_key.ref = "sk"
+archive_kek.ref = "kek"
+$rlr
+[secrets.ak]
+source.env = "S3_INTEGRATION_TESTS_ACCESS_KEY_ID"
+
+[secrets.sk]
+source.env = "S3_INTEGRATION_TESTS_SECRET_ACCESS_KEY"
+
+[secrets.kek]
+source.inline = "$ARCHIVE_KEK"
+
+[danger_zone]
+enabled = true
+allow_env_secrets = true
+allow_inline_plaintext_secrets = true
+EOF
+  echo "$file"
+}
+
+# do_archive PREFIX RETRY [extra archive flags...] -> exit code
+do_archive() {
+  local prefix="$1" retry="$2" cfg
+  shift 2
+  cfg="$(write_store_config target "$prefix" "$retry")"
+  "$ARCHIVE" -f "$WORK/config.toml" --target-config "$cfg" "$@" >/dev/null 2>&1
+}
+
+# do_export PREFIX OUT -> exit code
+do_export() {
+  local cfg
+  cfg="$(write_store_config archive "$1" "")"
+  "$EXPORT" --source "$cfg" --target "$2" >/dev/null 2>&1
+}
+
+# roundtrip NAME PREFIX [extra archive flags...]: archive, export, compare bytes.
+roundtrip() {
+  local name="$1" prefix="$2" out
+  shift 2
+  if ! do_archive "$prefix" "" "$@"; then
+    notok "$name" "archive failed"
+    return
+  fi
+  out="$WORK/export-$(uid).raw"
+  if ! do_export "$prefix" "$out"; then
+    notok "$name" "export failed"
+    return
+  fi
+  if cmp -s "$out" "$WORK/base.raw"; then
+    ok "$name"
+  else
+    notok "$name" "exported bytes differ from source"
+  fi
+}
+
+# --- r2proxy fault injection (persistent rules) ------------------------------
+
+admin() { curl -s -m15 -H "Authorization: Bearer $TOKEN" "$@"; }
+inject_rule() { admin -H "Content-Type: application/json" -d "$1" "$ADMIN/api/rules" | grep -q '"id"'; }
+clear_rules() { admin -X DELETE "$ADMIN/api/rules" >/dev/null; }
+
+# --- cases -------------------------------------------------------------------
+
+make_fixture
+
+# Happy path.
+clear_rules
+roundtrip "archive_export_roundtrip_plain" "$(store_prefix plain)"
+
+echo
+echo "# $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/tests/s3-integration/cases.sh
+++ b/tests/s3-integration/cases.sh
@@ -166,6 +166,27 @@ roundtrip "archive_export_roundtrip_plain" "$(store_prefix plain)"
 roundtrip "archive_export_roundtrip_encrypted_zstd" "$(store_prefix enc-zstd)" \
   --encrypt --compression zstd --zstd-level 1
 
+# The default client drops R2's 429; rate_limited_retry retries it after a delay,
+# so the (still failing, rule is persistent) run takes measurably longer.
+clear_rules
+inject_rule '{"op":"PutObject","status":429}'
+t=$(now)
+do_archive "$(store_prefix t429-default)" ""
+d_rc=$?
+d=$(since "$t")
+t=$(now)
+do_archive "$(store_prefix t429-rlr)" "1000,0"
+r_rc=$?
+r=$(since "$t")
+clear_rules
+if [ "$d_rc" -ne 0 ] && [ "$r_rc" -ne 0 ] &&
+  awk -v r="$r" -v d="$d" 'BEGIN { exit !(r >= d + 1.2) }'; then
+  ok "rate_limited_retry_retries_429_default_does_not"
+else
+  notok "rate_limited_retry_retries_429_default_does_not" \
+    "default rc=$d_rc (${d}s), rate_limited rc=$r_rc (${r}s)"
+fi
+
 echo
 echo "# $pass passed, $fail failed"
 [ "$fail" -eq 0 ]

--- a/tests/s3-integration/cases.sh
+++ b/tests/s3-integration/cases.sh
@@ -36,7 +36,8 @@ INIT="${INIT_BIN:-$ROOT/target/debug/init-metadata}"
 INIT_DIR="$(dirname "$INIT")"
 export PATH="$INIT_DIR:$PATH"
 
-DEVICE_MB=4 # four 1 MiB stripes
+DEVICE_MB=4        # with 128K stripes below -> 32 stripes (32 data objects)
+STRIPE_SIZE="128K" # ubiblk-init --stripe-size choice
 ARCHIVE_KEK="0123456789abcdef0123456789abcdef"
 
 # Work on a real filesystem: the binaries open image files with O_DIRECT, which
@@ -69,7 +70,7 @@ since() { awk -v a="$1" -v b="$(date +%s.%N)" 'BEGIN { printf "%.3f", b - a }'; 
 make_fixture() {
   head -c "$((DEVICE_MB * 1024 * 1024))" /dev/urandom >"$WORK/base.raw"
   python3 "$ROOT/scripts/ubiblk-init" --size "${DEVICE_MB}M" --dir "$WORK" \
-    --base "$WORK/base.raw" --stripe-size 1M --io-engine io_uring --force >/dev/null 2>&1
+    --base "$WORK/base.raw" --stripe-size "$STRIPE_SIZE" --io-engine io_uring --force >/dev/null 2>&1
 }
 
 # --- config + archive/export drivers -----------------------------------------

--- a/tests/s3-integration/cases.sh
+++ b/tests/s3-integration/cases.sh
@@ -218,6 +218,22 @@ inject_rule '{"op":"*","delay_ms":200}'
 roundtrip "latency_injection_still_round_trips" "$(store_prefix latency)"
 clear_rules
 
+# A read-path error surfaces: archive succeeds, then a 500 on GetObject fails
+# the export.
+clear_rules
+p="$(store_prefix get-err)"
+if ! do_archive "$p" ""; then
+  notok "get_object_error_fails_export" "archive failed"
+else
+  inject_rule '{"op":"GetObject","status":500}'
+  if do_export "$p" "$WORK/get-err.raw"; then
+    notok "get_object_error_fails_export" "export unexpectedly succeeded"
+  else
+    ok "get_object_error_fails_export"
+  fi
+  clear_rules
+fi
+
 echo
 echo "# $pass passed, $fail failed"
 [ "$fail" -eq 0 ]

--- a/tests/s3-integration/cases.sh
+++ b/tests/s3-integration/cases.sh
@@ -198,6 +198,20 @@ else
   roundtrip "transient_500_fails_then_recovers" "$p"
 fi
 
+# A non-retryable 403 fails fast (not retried into a long backoff).
+clear_rules
+inject_rule '{"op":"PutObject","status":403,"code":"AccessDenied"}'
+t=$(now)
+do_archive "$(store_prefix t403)" ""
+a_rc=$?
+e=$(since "$t")
+clear_rules
+if [ "$a_rc" -ne 0 ] && awk -v e="$e" 'BEGIN { exit !(e < 10) }'; then
+  ok "access_denied_fails_fast"
+else
+  notok "access_denied_fails_fast" "rc=$a_rc, elapsed=${e}s"
+fi
+
 echo
 echo "# $pass passed, $fail failed"
 [ "$fail" -eq 0 ]

--- a/tests/s3-integration/cases.sh
+++ b/tests/s3-integration/cases.sh
@@ -199,6 +199,16 @@ else
   roundtrip "transient_500_fails_then_recovers" "$p"
 fi
 
+# Transient errors that clear within the retry budget must not fail the archive.
+# Fail PutObject with probability 0.3, capped at 2 failures per object so every
+# object still succeeds within max_attempts. Across ~34 objects that is a >99.99%
+# chance of at least one retry (1 - 0.7^34), while staying fast -- far cheaper
+# than failing every object.
+clear_rules
+inject_rule '{"op":"PutObject","status":500,"probability":0.3,"max_failures_per_object":2}'
+roundtrip "transient_errors_recovered_by_retries" "$(store_prefix retry-heal)"
+clear_rules
+
 # A non-retryable 403 fails fast (not retried into a long backoff).
 clear_rules
 inject_rule '{"op":"PutObject","status":403,"code":"AccessDenied"}'

--- a/tests/s3-integration/cases.sh
+++ b/tests/s3-integration/cases.sh
@@ -187,6 +187,17 @@ else
     "default rc=$d_rc (${d}s), rate_limited rc=$r_rc (${r}s)"
 fi
 
+# A persistent 500 fails the archive; once cleared, a re-run round-trips.
+clear_rules
+p="$(store_prefix t500)"
+inject_rule '{"op":"PutObject","status":500}'
+if do_archive "$p" ""; then
+  notok "transient_500_fails_then_recovers" "archive unexpectedly succeeded under 500"
+else
+  clear_rules
+  roundtrip "transient_500_fails_then_recovers" "$p"
+fi
+
 echo
 echo "# $pass passed, $fail failed"
 [ "$fail" -eq 0 ]

--- a/tests/s3-integration/cases.sh
+++ b/tests/s3-integration/cases.sh
@@ -162,6 +162,10 @@ make_fixture
 clear_rules
 roundtrip "archive_export_roundtrip_plain" "$(store_prefix plain)"
 
+# With encryption + zstd compression.
+roundtrip "archive_export_roundtrip_encrypted_zstd" "$(store_prefix enc-zstd)" \
+  --encrypt --compression zstd --zstd-level 1
+
 echo
 echo "# $pass passed, $fail failed"
 [ "$fail" -eq 0 ]

--- a/tests/s3-integration/run-all.sh
+++ b/tests/s3-integration/run-all.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# Run the S3 integration test cases (cases.sh) against a real S3-compatible
+# bucket. This builds the ubiblk binaries, starts an r2proxy MITM
+# in front of the bucket on a loopback port, points the tests at the proxy so
+# they can inject faults, and tears it down afterwards.
+#
+# Every object is written under a unique run prefix, which is deleted from the
+# bucket on exit — whether the tests pass, fail, or the run is cancelled — so the
+# bucket is left clean.
+#
+# You provide only the real store's endpoint, bucket, and keys:
+#
+#   S3_INTEGRATION_TESTS_ENDPOINT=https://<account>.r2.cloudflarestorage.com \
+#   S3_INTEGRATION_TESTS_BUCKET=my-test-bucket \
+#   S3_INTEGRATION_TESTS_ACCESS_KEY_ID=... \
+#   S3_INTEGRATION_TESTS_SECRET_ACCESS_KEY=... \
+#     tests/s3-integration/run-all.sh
+#
+# Optional:
+#   S3_INTEGRATION_TESTS_REGION   defaults to "auto"
+#   R2PROXY_BIN                   path to the r2proxy binary (default: "r2proxy" on PATH)
+#
+# Requires r2proxy (https://github.com/ubicloud/r2proxy), curl, python3, cargo,
+# and the aws CLI (used only for cleanup).
+set -euo pipefail
+
+: "${S3_INTEGRATION_TESTS_ENDPOINT:?set the real store endpoint}"
+: "${S3_INTEGRATION_TESTS_BUCKET:?set the bucket}"
+: "${S3_INTEGRATION_TESTS_ACCESS_KEY_ID:?set the access key id}"
+: "${S3_INTEGRATION_TESTS_SECRET_ACCESS_KEY:?set the secret access key}"
+REGION="${S3_INTEGRATION_TESTS_REGION:-auto}"
+R2PROXY_BIN="${R2PROXY_BIN:-r2proxy}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+
+# Keep the real store coordinates; the test variables get pointed at the proxy
+# below, but cleanup deletes from the real bucket directly.
+REAL_ENDPOINT="$S3_INTEGRATION_TESTS_ENDPOINT"
+REAL_ACCESS_KEY_ID="$S3_INTEGRATION_TESTS_ACCESS_KEY_ID"
+REAL_SECRET_ACCESS_KEY="$S3_INTEGRATION_TESTS_SECRET_ACCESS_KEY"
+BUCKET="$S3_INTEGRATION_TESTS_BUCKET"
+
+RUN_ID="$(head -c8 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+RUN_PREFIX="s3-integration-tests/${RUN_ID}/"
+
+TMP="$(mktemp -d)"
+TOKEN="s3-it-$(head -c16 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+PROXY_PID=""
+
+cleanup() {
+  # Delete everything this run wrote, straight from the real bucket (does not
+  # depend on the proxy still being alive). Best-effort.
+  if command -v aws >/dev/null 2>&1; then
+    AWS_ACCESS_KEY_ID="$REAL_ACCESS_KEY_ID" \
+    AWS_SECRET_ACCESS_KEY="$REAL_SECRET_ACCESS_KEY" \
+    AWS_DEFAULT_REGION="$REGION" \
+      aws s3 rm --recursive --endpoint-url "$REAL_ENDPOINT" \
+      "s3://$BUCKET/$RUN_PREFIX" >>"$TMP/cleanup.log" 2>&1 ||
+      echo "warning: cleanup failed; see $TMP/cleanup.log" >&2
+  else
+    echo "warning: aws CLI not found; objects under $RUN_PREFIX were not cleaned" >&2
+  fi
+
+  if [ -n "$PROXY_PID" ]; then kill "$PROXY_PID" 2>/dev/null || true; fi
+  rm -rf "$TMP"
+}
+# Turn signals into a normal exit so the EXIT trap (cleanup) always runs.
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap cleanup EXIT
+
+# Build the binaries under test.
+cargo build -q --manifest-path "$ROOT/Cargo.toml" \
+  --bin archive --bin export-archive --bin init-metadata
+
+# Two free loopback ports (data plane + admin API).
+read -r DATA_PORT ADMIN_PORT < <(python3 - <<'PY'
+import socket
+s = [socket.socket() for _ in range(2)]
+for x in s:
+    x.bind(("127.0.0.1", 0))
+print(*[x.getsockname()[1] for x in s])
+for x in s:
+    x.close()
+PY
+)
+
+# Start r2proxy in front of the real bucket, on loopback. The IP host makes the
+# AWS SDK use path-style addressing, which r2proxy requires.
+R2PROXY_ENDPOINT="$REAL_ENDPOINT" \
+R2PROXY_ACCESS_KEY="$REAL_ACCESS_KEY_ID" \
+R2PROXY_SECRET_KEY="$REAL_SECRET_ACCESS_KEY" \
+R2PROXY_REGION="$REGION" \
+R2PROXY_LISTEN="127.0.0.1:${DATA_PORT}" \
+R2PROXY_ADMIN_LISTEN="127.0.0.1:${ADMIN_PORT}" \
+R2PROXY_ADMIN_TOKEN="$TOKEN" \
+R2PROXY_CONFIG="$TMP/r2proxy.json" \
+  "$R2PROXY_BIN" serve >"$TMP/r2proxy.log" 2>&1 &
+PROXY_PID=$!
+
+# Wait for the admin API to come up.
+for _ in $(seq 1 40); do
+  curl -sf -m2 "http://127.0.0.1:${ADMIN_PORT}/api/serverinfo" >/dev/null 2>&1 && break
+  sleep 0.5
+done
+if ! curl -sf -m2 "http://127.0.0.1:${ADMIN_PORT}/api/serverinfo" >/dev/null 2>&1; then
+  echo "r2proxy did not start; log:" >&2
+  cat "$TMP/r2proxy.log" >&2 || true
+  exit 1
+fi
+
+# The proxy mints its own client-facing credentials; read them back and point
+# the tests at the proxy (the real credentials stay with the proxy).
+info="$(curl -s -m10 -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:${ADMIN_PORT}/api/info")"
+field() { printf '%s' "$info" | python3 -c "import json,sys;print(json.load(sys.stdin)['$1'])"; }
+
+export S3_INTEGRATION_TESTS_ENDPOINT="http://127.0.0.1:${DATA_PORT}"
+export S3_INTEGRATION_TESTS_ADMIN="http://127.0.0.1:${ADMIN_PORT}"
+export S3_INTEGRATION_TESTS_ADMIN_TOKEN="$TOKEN"
+export S3_INTEGRATION_TESTS_REGION="$REGION"
+S3_INTEGRATION_TESTS_ACCESS_KEY_ID="$(field proxy_access_key)"
+S3_INTEGRATION_TESTS_SECRET_ACCESS_KEY="$(field proxy_secret_key)"
+export S3_INTEGRATION_TESTS_ACCESS_KEY_ID S3_INTEGRATION_TESTS_SECRET_ACCESS_KEY
+export S3_INTEGRATION_TESTS_PREFIX="$RUN_PREFIX"
+# S3_INTEGRATION_TESTS_BUCKET is passed through unchanged.
+
+"$HERE/cases.sh"


### PR DESCRIPTION
End-to-end archive/export tests against a real S3-compatible bucket, driven by shell instead of a Rust test: tests/s3-integration/cases.sh runs the scenarios (roundtrip, encryption, retry/error conditions) and tests.sh starts an r2proxy MITM in front of the bucket, points the cases at it, and deletes the run's objects on exit. The device fixture is built with scripts/ubiblk-init. A CI workflow runs the same launcher; it needs the aws CLI for cleanup.