### PR TITLE
Bump spin 0.10.0 -> 0.10.1 to fix cargo audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3283,9 +3283,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spki"


### PR DESCRIPTION
spin 0.10.0 (pulled transitively via crc-fast -> aws-smithy-checksums -> aws-sdk-s3) was yanked, failing `cargo audit --deny warnings`. 0.10.1 is a non-yanked release within crc-fast's ^0.10.0 requirement.