### PR TITLE
Remote server improvements

### DIFF
--- a/src/stripe_server/client.rs
+++ b/src/stripe_server/client.rs
@@ -260,7 +260,7 @@ mod tests {
         T: Send + 'static,
     {
         let server_device: Arc<dyn BlockDevice> = stripe_device.clone();
-        let server = StripeServer::new(server_device, metadata);
+        let server = StripeServer::new(server_device, metadata, None);
         let (server_stream, client_stream) = UnixStream::pair().unwrap();
         let (sender, receiver) = std::sync::mpsc::channel();
         let server_stream: DynStream = Box::new(server_stream);
@@ -575,5 +575,99 @@ mod tests {
         assert!(result.is_err());
         let error_message = result.err().unwrap().to_string();
         assert!(error_message.contains("Failed to connect to stripe server"));
+    }
+
+    #[test]
+    fn serves_unfetched_source_stripe_from_source() -> Result<()> {
+        use crate::config::v2::stripe_source::StripeSourceConfig;
+        use crate::config::v2::{self, DangerZone, DeviceSection};
+        use crate::stripe_source::StripeSourceBuilder;
+        use std::io::Write as _;
+        use tempfile::NamedTempFile;
+
+        let stripe_count = 4usize;
+        let stripe_size = SECTOR_SIZE; // stripe_sector_count_shift = 0 -> one sector
+
+        // Source holds pattern A; the overlay holds a different pattern B. Every
+        // stripe has a source and is NOT fetched, so it must be served from the
+        // source (A) rather than the overlay (B).
+        let source_file = NamedTempFile::new()?;
+        let overlay_file = NamedTempFile::new()?;
+        let pattern_a: Vec<u8> = (0..stripe_count * stripe_size)
+            .map(|i| (i % 251) as u8)
+            .collect();
+        let pattern_b = vec![0xBBu8; stripe_count * stripe_size];
+        source_file.as_file().write_all(&pattern_a)?;
+        overlay_file.as_file().write_all(&pattern_b)?;
+
+        let metadata: Arc<UbiMetadata> = Arc::from(UbiMetadata::new(0, stripe_count, stripe_count));
+
+        let config = v2::Config {
+            device: DeviceSection {
+                data_path: overlay_file.path().into(),
+                metadata_path: None,
+                vhost_socket: None,
+                rpc_socket: None,
+                device_id: "ubiblk".to_string(),
+                track_written: false,
+            },
+            tuning: v2::tuning::TuningSection {
+                queue_size: 128,
+                ..Default::default()
+            },
+            encryption: None,
+            danger_zone: DangerZone {
+                enabled: true,
+                allow_unencrypted_disk: true,
+                ..Default::default()
+            },
+            stripe_source: Some(StripeSourceConfig::Raw {
+                image_path: source_file.path().into(),
+                autofetch: false,
+                copy_on_read: false,
+            }),
+            secrets: HashMap::new(),
+        };
+
+        let overlay: Arc<dyn BlockDevice> = Arc::from(crate::backends::build_block_device(
+            overlay_file.path(),
+            &config,
+            false,
+        )?);
+        let builder =
+            StripeSourceBuilder::new(config.clone(), metadata.stripe_sector_count(), false);
+        let server = StripeServer::new(overlay, metadata, Some(builder));
+
+        let (server_stream, client_stream) = UnixStream::pair().unwrap();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let client_stream: DynStream = Box::new(client_stream);
+        thread::spawn(move || {
+            let mut client = StripeServerClient::new(client_stream);
+            client
+                .fetch_metadata()
+                .expect("metadata fetch should succeed");
+            let data = client
+                .fetch_stripe(0)
+                .expect("unfetched source stripe should be served");
+            tx.send(data).unwrap();
+        });
+
+        let mut session = server
+            .start_session(Box::new(server_stream))
+            .expect("session creation should succeed");
+        session.handle_requests();
+        let served = rx.recv().expect("client thread should return data");
+
+        assert_eq!(
+            served,
+            pattern_a[0..stripe_size],
+            "stripe 0 served from the source"
+        );
+        assert_ne!(
+            served,
+            pattern_b[0..stripe_size],
+            "must not be the overlay's data"
+        );
+        Ok(())
     }
 }

--- a/src/stripe_server/mod.rs
+++ b/src/stripe_server/mod.rs
@@ -5,6 +5,7 @@ use std::{
 
 use crate::{
     block_device::{BlockDevice, IoChannel, UbiMetadata},
+    stripe_source::{StripeSource, StripeSourceBuilder},
     Result,
 };
 
@@ -31,12 +32,17 @@ pub const STATUS_SERVER_ERROR: u8 = 0xFF;
 pub struct StripeServer {
     metadata: Arc<UbiMetadata>,
     stripe_device: Arc<dyn BlockDevice>,
+    // A stripe source builder, so each session can build its own source (the
+    // source is not Send, so it cannot be shared across connection threads).
+    // Used to serve stripes that have a source but have not been fetched yet.
+    source_builder: Option<StripeSourceBuilder>,
 }
 
 pub struct StripeServerSession {
     stream: DynStream,
     metadata: Arc<UbiMetadata>,
     stripe_channel: Box<dyn IoChannel>,
+    source: Option<Box<dyn StripeSource>>,
 }
 
 pub struct StripeServerClient {
@@ -50,19 +56,30 @@ pub trait RemoteStripeProvider {
 }
 
 impl StripeServer {
-    pub fn new(stripe_device: Arc<dyn BlockDevice>, metadata: Arc<UbiMetadata>) -> Self {
+    pub fn new(
+        stripe_device: Arc<dyn BlockDevice>,
+        metadata: Arc<UbiMetadata>,
+        source_builder: Option<StripeSourceBuilder>,
+    ) -> Self {
         Self {
             stripe_device,
             metadata,
+            source_builder,
         }
     }
 
     pub fn start_session(&self, stream: DynStream) -> Result<StripeServerSession> {
         let stripe_channel = self.stripe_device.create_channel()?;
+        let source = self
+            .source_builder
+            .as_ref()
+            .map(StripeSourceBuilder::build)
+            .transpose()?;
         Ok(StripeServerSession {
             stream,
             metadata: self.metadata.clone(),
             stripe_channel,
+            source,
         })
     }
 }

--- a/src/stripe_server/prepare.rs
+++ b/src/stripe_server/prepare.rs
@@ -5,17 +5,9 @@ use crate::{
     block_device::{metadata_flags, UbiMetadata, DEFAULT_STRIPE_SECTOR_COUNT_SHIFT},
     config::v2,
     stripe_server::StripeServer,
+    stripe_source::StripeSourceBuilder,
     Result,
 };
-
-fn error_if_incomplete_metadata(metadata: &UbiMetadata) -> Result<()> {
-    if !metadata.has_fetched_all_stripes() {
-        return Err(crate::ubiblk_error!(InvalidParameter {
-            description: "Not all source stripes have been fetched.".to_string()
-        }));
-    }
-    Ok(())
-}
 
 /// A `track_written = false` device does not record guest writes, so a stripe
 /// with no source may still hold written data that the WRITTEN bit does not
@@ -31,30 +23,48 @@ fn mark_no_source_stripes_written(metadata: &mut UbiMetadata) {
 
 pub fn prepare_stripe_server(config: &v2::Config) -> Result<Arc<StripeServer>> {
     let stripe_device = build_block_device(&config.device.data_path, config, false)?;
-    let metadata: Arc<UbiMetadata> = if let Some(metadata_path) =
-        config.device.metadata_path.as_deref()
-    {
-        let metadata_device = build_block_device(metadata_path, config, false)?;
-        let mut metadata = UbiMetadata::load_from_bdev(metadata_device.as_ref())?;
-        error_if_incomplete_metadata(&metadata)?;
-        if !config.device.track_written {
-            mark_no_source_stripes_written(&mut metadata);
-        }
-        Arc::from(metadata)
-    } else {
-        let stripe_sector_count_shift = DEFAULT_STRIPE_SECTOR_COUNT_SHIFT;
-        let stripe_sector_count = 1u64 << stripe_sector_count_shift;
-        let stripe_count = stripe_device.stripe_count(stripe_sector_count);
-        let mut metadata = UbiMetadata::new(stripe_sector_count_shift, stripe_count, stripe_count);
-        for stripe_header in metadata.stripe_headers.iter_mut() {
-            *stripe_header |= metadata_flags::WRITTEN | metadata_flags::FETCHED;
-        }
-        Arc::from(metadata)
-    };
+    let (metadata, source_builder): (Arc<UbiMetadata>, Option<StripeSourceBuilder>) =
+        if let Some(metadata_path) = config.device.metadata_path.as_deref() {
+            let metadata_device = build_block_device(metadata_path, config, false)?;
+            let mut metadata = UbiMetadata::load_from_bdev(metadata_device.as_ref())?;
+            let all_fetched = metadata.has_fetched_all_stripes();
+            // Unfetched source stripes are served from the stripe source, so one
+            // must be configured when the device is not fully fetched; otherwise
+            // reads of those stripes would fail at request time.
+            if !all_fetched && config.stripe_source.is_none() {
+                return Err(crate::ubiblk_error!(InvalidParameter {
+                    description:
+                        "device has unfetched source stripes but no stripe_source is configured"
+                            .to_string(),
+                }));
+            }
+            // The builder yields a null source when everything is already
+            // fetched; otherwise it builds the configured source.
+            let source_builder = StripeSourceBuilder::new(
+                config.clone(),
+                metadata.stripe_sector_count(),
+                all_fetched,
+            );
+            if !config.device.track_written {
+                mark_no_source_stripes_written(&mut metadata);
+            }
+            (Arc::from(metadata), Some(source_builder))
+        } else {
+            let stripe_sector_count_shift = DEFAULT_STRIPE_SECTOR_COUNT_SHIFT;
+            let stripe_sector_count = 1u64 << stripe_sector_count_shift;
+            let stripe_count = stripe_device.stripe_count(stripe_sector_count);
+            let mut metadata =
+                UbiMetadata::new(stripe_sector_count_shift, stripe_count, stripe_count);
+            for stripe_header in metadata.stripe_headers.iter_mut() {
+                *stripe_header |= metadata_flags::WRITTEN | metadata_flags::FETCHED;
+            }
+            (Arc::from(metadata), None)
+        };
 
     Ok(Arc::new(StripeServer::new(
         Arc::from(stripe_device),
         metadata,
+        source_builder,
     )))
 }
 
@@ -198,7 +208,7 @@ mod tests {
             stripe_count,
             image_stripe_count,
         );
-        // Fetch the source stripes so error_if_incomplete_metadata passes.
+        // The source stripes are already fetched (their data is in the overlay).
         for i in 0..image_stripe_count {
             metadata.stripe_headers[i] |= metadata_flags::FETCHED;
         }
@@ -240,16 +250,34 @@ mod tests {
     }
 
     #[test]
-    fn test_error_if_incomplete_metadata() {
-        let mut metadata = UbiMetadata::new(DEFAULT_STRIPE_SECTOR_COUNT_SHIFT, 16, 4);
+    fn test_prepare_rejects_unfetched_without_source() -> Result<()> {
+        let stripe_count = 8usize;
+        let storage_file = NamedTempFile::new()?;
+        let metadata_file = NamedTempFile::new()?;
+        storage_file
+            .as_file()
+            .set_len(stripe_count as u64 * STRIPE_SIZE)?;
 
-        for i in 0..4 {
-            let result = error_if_incomplete_metadata(&metadata);
-            assert!(result.is_err());
-            metadata.stripe_headers[i] |= metadata_flags::FETCHED;
-        }
+        // One source stripe that has NOT been fetched, and (via the config
+        // helper) no stripe_source configured to serve it from.
+        let metadata = UbiMetadata::new(DEFAULT_STRIPE_SECTOR_COUNT_SHIFT, stripe_count, 1);
+        metadata_file.as_file().set_len(4 * 1024 * 1024)?;
+        let mut buf = vec![0u8; metadata.metadata_size()];
+        metadata.write_to_buf(&mut buf)?;
+        metadata_file.as_file().write_all(&buf)?;
 
-        let result = error_if_incomplete_metadata(&metadata);
-        assert!(result.is_ok());
+        let config = config(
+            storage_file.path().to_str().unwrap().to_string(),
+            Some(metadata_file.path().to_str().unwrap().to_string()),
+            false,
+        );
+        let result = prepare_stripe_server(&config);
+        assert!(
+            result.is_err(),
+            "unfetched source stripes with no stripe_source must be rejected"
+        );
+        let err = result.err().unwrap().to_string();
+        assert!(err.contains("no stripe_source is configured"), "{err}");
+        Ok(())
     }
 }

--- a/src/stripe_server/prepare.rs
+++ b/src/stripe_server/prepare.rs
@@ -17,14 +17,29 @@ fn error_if_incomplete_metadata(metadata: &UbiMetadata) -> Result<()> {
     Ok(())
 }
 
+/// A `track_written = false` device does not record guest writes, so a stripe
+/// with no source may still hold written data that the WRITTEN bit does not
+/// reflect. Mark every no-source stripe as written so it is served from the
+/// local device. Stripes that have a source are left untouched.
+fn mark_no_source_stripes_written(metadata: &mut UbiMetadata) {
+    for header in metadata.stripe_headers.iter_mut() {
+        if *header & metadata_flags::HAS_SOURCE == 0 {
+            *header |= metadata_flags::WRITTEN;
+        }
+    }
+}
+
 pub fn prepare_stripe_server(config: &v2::Config) -> Result<Arc<StripeServer>> {
     let stripe_device = build_block_device(&config.device.data_path, config, false)?;
     let metadata: Arc<UbiMetadata> = if let Some(metadata_path) =
         config.device.metadata_path.as_deref()
     {
         let metadata_device = build_block_device(metadata_path, config, false)?;
-        let metadata = UbiMetadata::load_from_bdev(metadata_device.as_ref())?;
+        let mut metadata = UbiMetadata::load_from_bdev(metadata_device.as_ref())?;
         error_if_incomplete_metadata(&metadata)?;
+        if !config.device.track_written {
+            mark_no_source_stripes_written(&mut metadata);
+        }
         Arc::from(metadata)
     } else {
         let stripe_sector_count_shift = DEFAULT_STRIPE_SECTOR_COUNT_SHIFT;
@@ -53,7 +68,7 @@ mod tests {
 
     const STRIPE_SIZE: u64 = (1 << DEFAULT_STRIPE_SECTOR_COUNT_SHIFT) * SECTOR_SIZE as u64;
 
-    fn config(path: String, metadata_path: Option<String>) -> v2::Config {
+    fn config(path: String, metadata_path: Option<String>, track_written: bool) -> v2::Config {
         v2::Config {
             device: v2::DeviceSection {
                 data_path: path.into(),
@@ -61,7 +76,7 @@ mod tests {
                 vhost_socket: None,
                 rpc_socket: None,
                 device_id: "ubiblk".to_string(),
-                track_written: false,
+                track_written,
             },
             tuning: v2::tuning::TuningSection {
                 queue_size: 128,
@@ -87,7 +102,11 @@ mod tests {
         let storage_file = NamedTempFile::new()?;
         storage_file.as_file().set_len(stripe_count * STRIPE_SIZE)?;
 
-        let config = config(storage_file.path().to_str().unwrap().to_string(), None);
+        let config = config(
+            storage_file.path().to_str().unwrap().to_string(),
+            None,
+            false,
+        );
 
         let server = prepare_stripe_server(&config)?;
 
@@ -123,9 +142,11 @@ mod tests {
         metadata.write_to_buf(&mut buf)?;
         metadata_file.as_file().write_all(&buf)?;
 
+        // track_written = true: loaded headers are served verbatim.
         let config = config(
             storage_file.path().to_str().unwrap().to_string(),
             Some(metadata_file.path().to_str().unwrap().to_string()),
+            true,
         );
 
         let server = prepare_stripe_server(&config)?;
@@ -138,6 +159,83 @@ mod tests {
             );
         }
 
+        Ok(())
+    }
+
+    #[test]
+    fn mark_no_source_stripes_written_sets_only_no_source() {
+        // stripes 0..3 have HAS_SOURCE; 3..6 have no source.
+        let mut metadata = UbiMetadata::new(DEFAULT_STRIPE_SECTOR_COUNT_SHIFT, 6, 3);
+        metadata.stripe_headers[1] |= metadata_flags::FETCHED;
+
+        mark_no_source_stripes_written(&mut metadata);
+
+        // Source stripes are untouched (no WRITTEN added).
+        assert_eq!(metadata.stripe_headers[0], metadata_flags::HAS_SOURCE);
+        assert_eq!(
+            metadata.stripe_headers[1],
+            metadata_flags::HAS_SOURCE | metadata_flags::FETCHED
+        );
+        assert_eq!(metadata.stripe_headers[2], metadata_flags::HAS_SOURCE);
+        // No-source stripes are marked written.
+        for i in 3..6 {
+            assert_eq!(metadata.stripe_headers[i], metadata_flags::WRITTEN);
+        }
+    }
+
+    #[test]
+    fn test_prepare_track_written_false_marks_no_source_written() -> Result<()> {
+        let stripe_count = 16usize;
+        let image_stripe_count = 4usize; // first 4 stripes have a source
+        let storage_file = NamedTempFile::new()?;
+        let metadata_file = NamedTempFile::new()?;
+        storage_file
+            .as_file()
+            .set_len(stripe_count as u64 * STRIPE_SIZE)?;
+
+        let mut metadata = UbiMetadata::new(
+            DEFAULT_STRIPE_SECTOR_COUNT_SHIFT,
+            stripe_count,
+            image_stripe_count,
+        );
+        // Fetch the source stripes so error_if_incomplete_metadata passes.
+        for i in 0..image_stripe_count {
+            metadata.stripe_headers[i] |= metadata_flags::FETCHED;
+        }
+        // One no-source stripe carries a real WRITTEN bit; the rest are 0 (an
+        // untracked write is indistinguishable from a hole).
+        metadata.stripe_headers[5] |= metadata_flags::WRITTEN;
+
+        metadata_file.as_file().set_len(4 * 1024 * 1024)?;
+        let mut buf = vec![0u8; metadata.metadata_size()];
+        metadata.write_to_buf(&mut buf)?;
+        metadata_file.as_file().write_all(&buf)?;
+
+        let config = config(
+            storage_file.path().to_str().unwrap().to_string(),
+            Some(metadata_file.path().to_str().unwrap().to_string()),
+            false, // track_written = false
+        );
+        let server = prepare_stripe_server(&config)?;
+        let served = server.metadata.as_ref();
+
+        for (i, &header) in served.stripe_headers.iter().enumerate() {
+            if i < image_stripe_count {
+                // Source stripes are served as-is, never marked written.
+                assert_eq!(
+                    header,
+                    metadata_flags::HAS_SOURCE | metadata_flags::FETCHED,
+                    "source stripe {i}"
+                );
+            } else {
+                // Every no-source stripe is now served, written or not.
+                assert_ne!(
+                    header & metadata_flags::WRITTEN,
+                    0,
+                    "no-source stripe {i} should be served"
+                );
+            }
+        }
         Ok(())
     }
 

--- a/src/stripe_server/session.rs
+++ b/src/stripe_server/session.rs
@@ -110,33 +110,25 @@ impl StripeServerSession {
     fn handle_read_stripe_request(&mut self, stripe_id: u64) -> Result<()> {
         info!("Handling read stripe request for stripe_id: {}", stripe_id);
         if stripe_id >= self.metadata.stripe_count() {
-            self.stream.write_all(&[STATUS_INVALID_STRIPE])?;
-            self.stream.flush()?;
-            return Ok(());
+            return self.reply_status(STATUS_INVALID_STRIPE);
         }
 
-        if self.stripe_not_fetched(stripe_id) {
-            info!(
-                "Stripe {} has not been fetched from source, notifying client",
-                stripe_id
-            );
-            self.stream.write_all(&[STATUS_NOT_FETCHED])?;
-            self.stream.flush()?;
-            return Ok(());
-        }
-
-        if !self.stripe_has_data(stripe_id) {
-            info!("Stripe {} cannot be served, notifying client", stripe_id);
-            self.stream.write_all(&[STATUS_NO_DATA])?;
-            self.stream.flush()?;
-            return Ok(());
-        }
-
-        let stripe_data = self.read_stripe(stripe_id).inspect_err(|_| {
-            if let Err(e) = self.stream.write_all(&[STATUS_SERVER_ERROR]) {
-                error!("Failed to notify client of server error: {}", e);
+        let stripe_data = if self.stripe_not_fetched(stripe_id) {
+            // Not yet copied into the local device: the data still lives in the
+            // source, so serve it straight from there.
+            if self.source.is_none() {
+                info!("Stripe {} not fetched and no source available", stripe_id);
+                return self.reply_status(STATUS_NOT_FETCHED);
             }
-        })?;
+            self.read_stripe_from_source(stripe_id)
+                .inspect_err(|_| self.notify_server_error())?
+        } else if !self.stripe_has_data(stripe_id) {
+            info!("Stripe {} cannot be served, notifying client", stripe_id);
+            return self.reply_status(STATUS_NO_DATA);
+        } else {
+            self.read_stripe(stripe_id)
+                .inspect_err(|_| self.notify_server_error())?
+        };
 
         let stripe_len_bytes = self.metadata.stripe_size();
 
@@ -169,6 +161,27 @@ impl StripeServerSession {
         )?;
 
         Ok(buffer)
+    }
+
+    fn read_stripe_from_source(&mut self, stripe_id: u64) -> Result<SharedBuffer> {
+        let buffer = shared_buffer(self.metadata.stripe_size());
+        let source = self.source.as_mut().expect("caller checked source exists");
+        source.request(stripe_id as usize, buffer.clone())?;
+        source.wait_for_stripe(stripe_id as usize, std::time::Duration::from_secs(30))?;
+        Ok(buffer)
+    }
+
+    /// Reply with a single status byte and no payload.
+    fn reply_status(&mut self, status: u8) -> Result<()> {
+        self.stream.write_all(&[status])?;
+        self.stream.flush()?;
+        Ok(())
+    }
+
+    fn notify_server_error(&mut self) {
+        if let Err(e) = self.stream.write_all(&[STATUS_SERVER_ERROR]) {
+            error!("Failed to notify client of server error: {}", e);
+        }
     }
 }
 
@@ -215,7 +228,7 @@ mod tests {
             read: Cursor::new(input),
             writes: writes.clone(),
         };
-        let server = StripeServer::new(device, metadata);
+        let server = StripeServer::new(device, metadata, None);
         let session = server.start_session(Box::new(stream)).unwrap();
         (session, writes)
     }


### PR DESCRIPTION
### Serve track_written=false disks over the remote protocol 

A track_written=false device never records guest writes, so a stripe with no source keeps a zero header even after it is written. The stripe server decides what to serve from those bits, so it returned NO_DATA for such stripes -- losing the written data (and truncating the served size to the last source/written stripe).

When the served device is track_written=false, mark every no-source stripe written at load, so the whole device is served: its data is already local (all source stripes are fetched, checked separately, and no-source stripes live in the overlay). Source stripes are left untouched, and track_written=true is unchanged (its WRITTEN bits are authoritative).

### Serve partially fetched disks from the stripe source 

The stripe server required every source stripe to be fetched before it would start, so a disk with unfetched source stripes was rejected.

Build a stripe source up front (the builder yields a null source when everything is fetched, so nothing needs checking first). When a read hits a stripe that has a source but isn't fetched yet, serve it from the source rather than returning NOT_FETCHED. The source is not Send, so each connection builds its own from the shared builder.