### PR TITLE
Make the vhost backend thread Send without unsafe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "atomic_refcell"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e4227379beff4205943696e6c3e0cd809bacdf3f0edd6e3dd153e2269571a4"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1596,7 +1602,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3017,7 +3023,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3497,7 +3503,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3805,6 +3811,7 @@ name = "ubiblk"
 version = "0.5.0"
 dependencies = [
  "aes-gcm",
+ "atomic_refcell",
  "aws-config",
  "aws-sdk-s3",
  "aws-smithy-mocks",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ debug = false
 opt-level = "s"
 
 [dependencies]
+atomic_refcell = "0.1.14"
 clap = { version = "4.5.49", features = ["cargo", "wrap_help", "derive"] }
 serde = { version = "1.0", features = ["derive"] }
 libc = "0.2"

--- a/src/backends/ublk/io_handler.rs
+++ b/src/backends/ublk/io_handler.rs
@@ -1,4 +1,6 @@
-use std::{cell::RefCell, collections::VecDeque, rc::Rc};
+use std::{collections::VecDeque, sync::Arc};
+
+use atomic_refcell::AtomicRefCell;
 
 use libublk::{
     helpers::IoBuf,
@@ -41,7 +43,7 @@ impl UblkIoHandler {
     ) -> Self {
         let backend_bufs = (0..queue_size)
             .map(|_| {
-                Rc::new(RefCell::new(AlignedBuf::new_with_alignment(
+                Arc::new(AtomicRefCell::new(AlignedBuf::new_with_alignment(
                     max_io_bytes,
                     alignment,
                 )))

--- a/src/backends/vhost/backend_thread.rs
+++ b/src/backends/vhost/backend_thread.rs
@@ -1,6 +1,7 @@
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::sync::Arc;
 use std::{ops::Deref, sync::RwLockWriteGuard};
+
+use atomic_refcell::AtomicRefCell;
 
 use super::request::*;
 #[cfg(test)]
@@ -80,7 +81,7 @@ impl UbiBlkBackendThread {
             .map(|_| RequestSlot {
                 used: false,
                 request_type: RequestType::Unsupported(0),
-                buffer: Rc::new(RefCell::new(AlignedBuf::new_with_alignment(
+                buffer: Arc::new(AtomicRefCell::new(AlignedBuf::new_with_alignment(
                     buf_size as usize,
                     alignment,
                 ))),
@@ -136,7 +137,7 @@ impl UbiBlkBackendThread {
         self.request_slots.push(RequestSlot {
             used: true,
             request_type: request.request_type(),
-            buffer: Rc::new(RefCell::new(AlignedBuf::new_with_alignment(
+            buffer: Arc::new(AtomicRefCell::new(AlignedBuf::new_with_alignment(
                 len,
                 self.alignment,
             ))),
@@ -450,8 +451,5 @@ impl UbiBlkBackendThread {
         busy
     }
 }
-
-unsafe impl Sync for UbiBlkBackendThread {}
-unsafe impl Send for UbiBlkBackendThread {}
 
 mod backend_thread_tests;

--- a/src/block_device/bdev_uring.rs
+++ b/src/block_device/bdev_uring.rs
@@ -62,6 +62,14 @@ impl UringIoChannel {
     }
 }
 
+// In-flight buffer contract: `add_read`/`add_write` hand the kernel a raw
+// pointer into `buf` and then drop the `AtomicRefCell` guard, but the kernel
+// keeps reading/writing that memory until the matching completion is reaped in
+// `poll`. Nothing may borrow or move the buffer between submission and its CQE;
+// the borrow system cannot see the kernel's outstanding access. Safety
+// therefore rests on the caller's request-slot lifecycle (a slot is not reused
+// until its completion), not on `AtomicRefCell`; the `Send`/`Sync` on
+// `SharedBuffer` does not make concurrent access during this window sound.
 impl IoChannel for UringIoChannel {
     fn add_read(&mut self, sector_offset: u64, sector_count: u32, buf: SharedBuffer, id: usize) {
         let mut buf = buf.borrow_mut();

--- a/src/block_device/mod.rs
+++ b/src/block_device/mod.rs
@@ -1,14 +1,19 @@
 use crate::utils::aligned_buffer::AlignedBuf;
 use crate::Result;
-use std::{cell::RefCell, rc::Rc};
+use atomic_refcell::AtomicRefCell;
+use std::sync::Arc;
 
-pub type SharedBuffer = Rc<RefCell<AlignedBuf>>;
+pub type SharedBuffer = Arc<AtomicRefCell<AlignedBuf>>;
 
 pub fn shared_buffer(size: usize) -> SharedBuffer {
-    Rc::new(RefCell::new(AlignedBuf::new(size)))
+    Arc::new(AtomicRefCell::new(AlignedBuf::new(size)))
 }
 
-pub trait IoChannel {
+// `Send` lets an `IoChannel` (and the buffers it holds) live on a worker thread
+// that the vhost/ublk backends move it onto. Each channel is still only ever
+// touched by its owning thread; the bound just lets us express that in the type
+// system instead of an `unsafe impl Send` on the backend thread.
+pub trait IoChannel: Send {
     fn add_read(&mut self, sector_offset: u64, sector_count: u32, buf: SharedBuffer, id: usize);
     fn add_write(&mut self, sector_offset: u64, sector_count: u32, buf: SharedBuffer, id: usize);
     fn add_flush(&mut self, id: usize);

--- a/src/stripe_source/remote.rs
+++ b/src/stripe_source/remote.rs
@@ -131,8 +131,8 @@ fn fetch_with_reconnect(
 /// connection (mirroring how the S3-backed `ArchiveStripeSource` uses a pool of
 /// S3 workers). Requests are dispatched to whichever worker is free and
 /// completions come back out of order, matched up by stripe id. The workers
-/// only produce raw bytes (`SharedBuffer` is `!Send`); the copy into the
-/// caller's buffer happens on `poll`. Dropping the source drops `request_tx`,
+/// produce owned byte buffers; the copy into the caller's `SharedBuffer` happens
+/// on `poll`, on the fetcher's own thread. Dropping the source drops `request_tx`,
 /// which makes the workers' `recv` return and the threads exit on their own.
 pub struct RemoteStripeSource {
     source_sector_count: u64,

--- a/src/utils/aligned_buffer_pool.rs
+++ b/src/utils/aligned_buffer_pool.rs
@@ -1,4 +1,6 @@
-use std::{cell::RefCell, collections::VecDeque, rc::Rc};
+use std::{collections::VecDeque, sync::Arc};
+
+use atomic_refcell::AtomicRefCell;
 
 use crate::block_device::SharedBuffer;
 
@@ -16,7 +18,7 @@ impl AlignedBufferPool {
             .map(|index| {
                 let mut buf = AlignedBuf::new_with_alignment(size, alignment);
                 buf.id = index;
-                Rc::new(RefCell::new(buf))
+                Arc::new(AtomicRefCell::new(buf))
             })
             .collect();
 
@@ -49,7 +51,7 @@ impl AlignedBufferPool {
         );
 
         assert!(
-            Rc::ptr_eq(buffer, &self.buffers[index]),
+            Arc::ptr_eq(buffer, &self.buffers[index]),
             "Returned buffer does not match the pool's buffer at index {index}"
         );
 


### PR DESCRIPTION
`UbiBlkBackendThread` carried a blanket `unsafe impl Send + Sync` purely to paper over two `!Send` fields: the `Rc<RefCell<AlignedBuf>>` I/O buffers and the `Box<dyn IoChannel>` trait object. Both are only ever touched by the one worker thread the struct is moved onto, so the assertion was sound — but it was a broad, easy-to-invalidate escape hatch on a large struct.

Swap the buffer alias to `Arc<AtomicRefCell<AlignedBuf>>` and add `Send` as an `IoChannel` supertrait. `AtomicRefCell` keeps the exact borrow()/borrow_mut() API and single-threaded panic-on-conflict semantics of `RefCell` — it guards with one atomic borrow flag rather than a mutex, so there is no locking on the buffer hot path. With both fields now genuinely `Send`, the compiler derives `Send` for the thread and the `unsafe impl`s are gone.