### PR TITLE
rpc: cfg(test)-gate RpcServerHandle::stop, scope dead-code allow

### DIFF
--- a/src/backends/common/rpc.rs
+++ b/src/backends/common/rpc.rs
@@ -38,14 +38,20 @@ struct RpcRequest {
     command: String,
 }
 
-#[allow(dead_code)]
+// The fields are populated when the RPC server starts (see `start_rpc_server`,
+// which is reachable in non-test builds via `run_backend_loop`) but are only
+// ever read by the test-only `stop()` below, so suppress the dead-code lint
+// for non-test builds where they are write-only.
+#[cfg_attr(not(test), allow(dead_code))]
 pub struct RpcServerHandle {
     join_handle: JoinHandle<()>,
     stop_requested: Arc<AtomicBool>,
     path: PathBuf,
 }
 
-#[allow(dead_code)]
+// `stop()` is only used by the tests below; gate the impl on `cfg(test)` so no
+// dead-code allow is needed for it.
+#[cfg(test)]
 impl RpcServerHandle {
     pub fn stop(self) -> Result<()> {
         self.stop_requested.store(true, Ordering::Release);


### PR DESCRIPTION
RpcServerHandle::stop() is only called from the module's tests, and the handle's fields (join_handle/stop_requested/path) are populated but never read outside tests. The blanket `#[allow(dead_code)]` on both the struct and its impl masked more than necessary.

Gate the `impl` (which holds only the test-only `stop()`) on `#[cfg(test)]` so no dead-code allow is needed there. The struct itself must still exist in non-test builds because `start_rpc_server` returns it and `run_backend_loop` holds it to keep the RPC listener alive, so narrow its remaining allow to `#[cfg_attr(not(test), allow(dead_code))]` — where the fields are genuinely write-only. No behavior change.