### PR TITLE
Remove unused static_assertions dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3443,12 +3443,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3839,7 +3833,6 @@ dependencies = [
  "serde_with",
  "serde_yaml_ng",
  "sha2 0.11.0",
- "static_assertions",
  "tempfile",
  "thiserror 2.0.19",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ tempfile = "3.23.0"
 serde_with = { version = "3.21.0", features = ["base64"] }
 base64 = "0.23.1"
 aes-gcm = "0.11.0"
-static_assertions = "1.1.0"
 serde_json = "1.0.145"
 serde_yaml_ng = "0.10.0"
 rustyline = "18.0.1"


### PR DESCRIPTION
The static_assertions crate was declared in Cargo.toml but had no references anywhere in the codebase (no const_assert, assert_eq_size, assert_impl_all, etc.). Dropping it trims an unused dependency from the build graph.