### PR TITLE
Add CLA

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -1,0 +1,38 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        # Run on PR events, and on issue comments only when they are on a PR
+        # (issue_comment also fires for plain issues, which have no PR context).
+        if: |
+          github.event_name == 'pull_request_target' ||
+          (github.event.issue.pull_request &&
+            (github.event.comment.body == 'recheck' ||
+             github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'))
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/cla.json'
+          path-to-document: 'https://docs.google.com/document/d/1ymjqOk6fXhi-VxnV2qZEgI5ibX9gtg7Y/edit?usp=sharing&ouid=105153831332304232521&rtpof=true&sd=true' # e.g. a CLA or a DCO document
+          branch: 'main'
+          allowlist: byucesoy, enescakir, fdr, ozgune, pykello, umurc, velioglu, bot*
+          remote-organization-name: ubicloud
+          remote-repository-name: cla-signers
+          create-file-commit-message: 'Creating file for storing CLA Signatures'
+          signed-commit-message: '$contributorName has signed the CLA in $owner/$repo#$pullRequestNo'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing to ubiblk
+
+Thanks for your interest in contributing to ubiblk! This document explains how to
+contribute and the one requirement we ask of every contributor: signing our
+Contributor License Agreement (CLA).
+
+## Contributor License Agreement
+
+Before we can merge your contribution, you must sign the Ubicloud Contributor
+License Agreement. Signing is a one-time action, and the same signature covers
+all Ubicloud projects that use this CLA (including ubicloud itself), so if you
+have already signed it elsewhere you are all set.
+
+When you open your first pull request, the CLA Assistant bot comments on it with
+a link to the CLA and instructions. To sign:
+
+1. Read the [CLA document][cla].
+2. Post this exact comment on your pull request:
+
+   ```
+   I have read the CLA Document and I hereby sign the CLA
+   ```
+
+The bot then records your signature in the [ubicloud/cla-signers][signers]
+repository and marks the CLA status check as passed. If a later change makes the
+bot ask again, comment `recheck` to re-run it.
+
+Ubicloud employees and a small set of maintainers are exempt; they are listed in
+the `allowlist` of [`.github/workflows/cla.yaml`](.github/workflows/cla.yaml).
+
+## How to contribute
+
+1. Fork the repository and create a branch for your change.
+2. Make your change, keeping it focused and covered by tests where practical.
+3. Run the checks locally (see [`.github/workflows/ci.yaml`](.github/workflows/ci.yaml)).
+4. Open a pull request against `main` and sign the CLA as described above.
+
+[cla]: https://docs.google.com/document/d/1ymjqOk6fXhi-VxnV2qZEgI5ibX9gtg7Y/edit?usp=sharing&ouid=105153831332304232521&rtpof=true&sd=true
+[signers]: https://github.com/ubicloud/cla-signers

--- a/README.md
+++ b/README.md
@@ -211,6 +211,12 @@ xts --config <CONFIG_TOML> [options] <INPUT> <OUTPUT>
 | `--len` | — | no | Number of sectors to process |
 | `--action` | — | no | `encode` or `decode` (default: `decode`) |
 
+## Contributing
+
+Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md), which
+covers how to open a pull request and the Contributor License Agreement (CLA)
+you'll need to sign before your first contribution can be merged.
+
 ## License
 
 This project is licensed under the GNU Affero General Public License v3.0


### PR DESCRIPTION
### Add CLA Assistant workflow 

Mirror the ubicloud repo's CLA Assistant workflow so every pull request from a new contributor is blocked until they sign the Ubicloud Contributor License Agreement. Signatures are recorded in the shared ubicloud/cla-signers repository, so a contributor signs once for all Ubicloud projects.

### Document the CLA requirement for contributors 

Add CONTRIBUTING.md explaining that contributors must sign the CLA before their change can be merged and how to do it, and link it from the README.