### PR TITLE
Complete failed ublk I/O with a negative errno the kernel receives

### DIFF
--- a/src/backends/ublk/io_handler.rs
+++ b/src/backends/ublk/io_handler.rs
@@ -20,6 +20,22 @@ enum UblkIoError {
     Io,
 }
 
+impl UblkIoError {
+    /// The completion handed to libublk for a failed request. Only an error
+    /// that carries a negative errno reaches the kernel: libublk 0.4.x's
+    /// `complete_io_cmd` commits `Ok(Result(res))`, `OtherError(res)` and
+    /// `UringIOError(res)` and drops every other variant on a `_ => {}` arm,
+    /// so a request completed with `InvalidVal` never gets its
+    /// COMMIT_AND_FETCH, the guest's I/O never returns, and tearing the
+    /// device down later deadlocks under ublk_ctl_mutex.
+    fn completion(self) -> UblkError {
+        UblkError::OtherError(match self {
+            UblkIoError::Invalid => -libc::EINVAL,
+            UblkIoError::Io => -libc::EIO,
+        })
+    }
+}
+
 type UblkIoResult<T> = std::result::Result<T, UblkIoError>;
 
 pub struct UblkIoHandler {
@@ -78,7 +94,11 @@ impl UblkIoHandler {
                 self.max_io_bytes
             );
             let completion_slice = BufDesc::Slice(self.bufs[tag as usize].as_slice());
-            let _ = q.complete_io_cmd_unified(tag, completion_slice, Err(UblkError::InvalidVal));
+            let _ = q.complete_io_cmd_unified(
+                tag,
+                completion_slice,
+                Err(UblkIoError::Invalid.completion()),
+            );
             return;
         }
 
@@ -184,7 +204,7 @@ impl UblkIoHandler {
                     let _ = q.complete_io_cmd_unified(
                         tag as u16,
                         completion_slice,
-                        Err(UblkError::InvalidVal),
+                        Err(err.completion()),
                     );
                     continue;
                 }
@@ -201,7 +221,7 @@ impl UblkIoHandler {
                             let _ = q.complete_io_cmd_unified(
                                 tag as u16,
                                 completion_slice,
-                                Err(UblkError::InvalidVal),
+                                Err(UblkIoError::Io.completion()),
                             );
                         }
                     }
@@ -229,7 +249,7 @@ impl UblkIoHandler {
                             "UBLK IO error (op={:?}, sector_offset={}, sector_count={}): {:?}",
                             request.op, request.sector_offset, request.sector_count, err
                         );
-                        Err(UblkError::InvalidVal)
+                        Err(err.completion())
                     }
                 };
 
@@ -454,5 +474,20 @@ mod tests {
             bytes: 0,
         };
         handler.enqueue_request(&request).unwrap();
+    }
+
+    /// A failed request must complete with a variant libublk commits to the
+    /// kernel, carrying the negative errno the guest is to see. `InvalidVal`
+    /// is dropped by `complete_io_cmd` and would leave the request hanging.
+    #[test]
+    fn failed_io_completes_with_a_negative_errno_the_kernel_receives() {
+        assert!(matches!(
+            UblkIoError::Io.completion(),
+            UblkError::OtherError(errno) if errno == -libc::EIO
+        ));
+        assert!(matches!(
+            UblkIoError::Invalid.completion(),
+            UblkError::OtherError(errno) if errno == -libc::EINVAL
+        ));
     }
 }


### PR DESCRIPTION
`UblkIoHandler` completes every failed request with `Err(UblkError::InvalidVal)`. libublk's `complete_io_cmd` (0.4.6 in Cargo.lock; `src/io.rs:2224`, reached through `complete_io_cmd_unified`) commits a completion to the kernel only for `Ok(UblkIORes::Result(res))`, `Err(UblkError::OtherError(res))` and `Err(UblkError::UringIOError(res))`. Every other `Err` falls to the `_ => {}` arm and is dropped, so a request completed with `InvalidVal` never gets its `COMMIT_AND_FETCH`.

Two consequences:

- The guest's I/O never returns. A write the backend failed hangs in the guest instead of failing with an error.
- Device teardown later deadlocks. `del_gendisk` waits in `blk_mq_freeze_queue_wait` for the request that will never complete, while holding `ublk_ctl_mutex`, so every subsequent ublk device creation on the host blocks on that mutex until reboot.

The fix adds `UblkIoError::completion`, which maps the handler's error to `UblkError::OtherError(-errno)`, and uses it at the four completion sites: `-EINVAL` for a request the handler rejects (oversized or unsupported op) and `-EIO` for a request the block device failed or that could not be submitted. Successful I/O is unchanged; only the error path is affected.

Verification: a unit test, `failed_io_completes_with_a_negative_errno_the_kernel_receives`, pins the variant and the errnos. `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings` and `cargo test` pass on Linux. The hang was observed with a backend that returned EIO for writes: the guest's write never returned, and removing the device afterwards wedged the ublk driver on the host.
