### PR TITLE
Do not write a push over a stripe the fetcher has already pulled

### DIFF
--- a/src/block_device/bdev_lazy/stripe_fetcher.rs
+++ b/src/block_device/bdev_lazy/stripe_fetcher.rs
@@ -280,10 +280,7 @@ impl StripeFetcher {
     }
 
     pub fn accept_pushed_stripe(&mut self, stripe_id: usize, data: &[u8], permit: PushPermit) {
-        if self
-            .shared_metadata_state
-            .stripe_fetched_if_needed(stripe_id)
-        {
+        if self.stripe_is_local(stripe_id) {
             debug!("Stripe {stripe_id} is already local, ignoring the pushed copy");
             return;
         }
@@ -309,6 +306,18 @@ impl StripeFetcher {
             self.stripe_states.get(&stripe_id),
             Some(FetchState::Queued) | Some(FetchState::Fetching) | Some(FetchState::Flushing)
         )
+    }
+
+    /// Whether this stripe's data is already on the target, by either account
+    /// of it. The shared state is the coordinator's, and on a pool it lags: a
+    /// worker reports a landed pull and the coordinator marks it, so for a
+    /// while only the worker's own state knows. A push written in that gap is
+    /// a second write of the stripe, landing after the guest has been let
+    /// onto it and over anything the guest wrote there.
+    fn stripe_is_local(&self, stripe_id: usize) -> bool {
+        self.shared_metadata_state
+            .stripe_fetched_if_needed(stripe_id)
+            || self.stripe_states.get(&stripe_id) == Some(&FetchState::Fetched)
     }
 
     fn write_pushed_stripe(&mut self, stripe_id: usize, data: &[u8]) {
@@ -359,10 +368,9 @@ impl StripeFetcher {
             let Some(data) = self.pending_pushes.remove(&stripe_id) else {
                 continue;
             };
-            if self
-                .shared_metadata_state
-                .stripe_fetched_if_needed(stripe_id)
-            {
+            if self.stripe_is_local(stripe_id) {
+                // The pull it waited behind succeeded, or the stripe arrived
+                // some other way. Either brought the snapshot content.
                 self.push_permits.remove(&stripe_id);
                 continue;
             }
@@ -634,7 +642,7 @@ impl StripeFetcher {
 mod tests {
     use super::*;
     use crate::block_device::bdev_test::TestBlockDevice;
-    use crate::stripe_source::BlockDeviceStripeSource;
+    use crate::stripe_source::{BlockDeviceStripeSource, FlakyStripeSource};
 
     struct TestState {
         source_dev: Box<TestBlockDevice>,
@@ -643,6 +651,14 @@ mod tests {
     }
 
     fn prep(autofetch: bool) -> TestState {
+        prep_with_source(autofetch, |source| source)
+    }
+
+    /// Like `prep`, with the source wrapped: for a source that refuses.
+    fn prep_with_source(
+        autofetch: bool,
+        wrap: impl FnOnce(Box<dyn StripeSource>) -> Box<dyn StripeSource>,
+    ) -> TestState {
         let source_size: u64 = 1024 * 1024; // 1 MiB
         let target_size: u64 = 2 * 1024 * 1024; // 2 MiB
         let stripe_sector_count_shift = 3; // 8 sectors per stripe
@@ -651,9 +667,9 @@ mod tests {
         let source_dev = Box::new(TestBlockDevice::new(source_size));
         let target_dev = Box::new(TestBlockDevice::new(target_size));
 
-        let stripe_source = Box::new(
+        let stripe_source = wrap(Box::new(
             BlockDeviceStripeSource::new(source_dev.clone(), stripe_sector_count).unwrap(),
-        );
+        ));
 
         let metadata = UbiMetadata::new(
             stripe_sector_count_shift,
@@ -709,17 +725,21 @@ mod tests {
     /// never succeed and the pushed copy is the only correct one.
     #[test]
     fn pushed_stripe_is_applied_after_the_racing_fetch_fails() {
-        let mut state = prep(false);
+        // A source that refuses this stripe for good, the way prod refuses a
+        // stripe it has already copied out: every attempt fails, retries
+        // included. A pull that eventually succeeded would make the push
+        // redundant instead.
+        let mut state = prep_with_source(false, |source| {
+            Box::new(FlakyStripeSource::new(
+                source,
+                vec![(0, MAX_FETCH_RETRIES as usize + 1)],
+            ))
+        });
         let pushed = vec![0xAB; (state.fetcher.stripe_sector_count as usize) * SECTOR_SIZE];
 
-        // Start a pull and make it fail, the way a pull for a stripe prod has
-        // already copied out fails.
-        state
-            .source_dev
-            .fail_next
-            .store(true, std::sync::atomic::Ordering::SeqCst);
         state.fetcher.handle_fetch_request(0);
         state.fetcher.update();
+        assert!(state.fetcher.fetch_in_flight(0));
 
         // The push arrives while that pull is still outstanding.
         state
@@ -817,6 +837,103 @@ mod tests {
             0,
             "and released once the stripe is on the fork's disk"
         );
+    }
+
+    /// A push parked behind a pull that then succeeds is dropped, not written.
+    /// The pull brought the snapshot content, and for a moment only this
+    /// fetcher knows: the coordinator marks the shared state once it hears the
+    /// pull finished. Checking the shared state alone lets the pushed copy go to
+    /// the disk as a second write of the stripe, in flight while the guest is
+    /// being let onto it.
+    #[test]
+    fn a_parked_push_is_dropped_when_its_own_pull_lands() {
+        let mut state = prep(false);
+        let stripe_bytes = (state.fetcher.stripe_sector_count as usize) * SECTOR_SIZE;
+        state
+            .source_dev
+            .write(0, &vec![0x11; stripe_bytes], stripe_bytes);
+        let pushed = vec![0x22; stripe_bytes];
+        let gate = super::super::push_gate::PushGate::new(4);
+
+        // One update puts the pull in flight, and the push arrives behind it.
+        state.fetcher.handle_fetch_request(0);
+        state.fetcher.update();
+        assert!(state.fetcher.fetch_in_flight(0));
+        state
+            .fetcher
+            .accept_pushed_stripe(0, &pushed, gate.acquire());
+        assert_eq!(gate.queued(), 1, "the slot is held while the copy waits");
+
+        for _ in 0..10 {
+            state.fetcher.update();
+        }
+
+        assert_eq!(state.fetcher.take_finished_fetches(), vec![(0, true)]);
+        assert_eq!(
+            state.target_dev.metrics.read().unwrap().writes,
+            1,
+            "the pull's write is the only write of the stripe"
+        );
+        let mut written = vec![0u8; stripe_bytes];
+        state.target_dev.read(0, &mut written, stripe_bytes);
+        assert_eq!(
+            written,
+            vec![0x11; stripe_bytes],
+            "what the pull brought stands"
+        );
+        assert!(state.fetcher.pending_pushes.is_empty());
+        assert_eq!(gate.queued(), 0, "and the slot goes with the dropped push");
+    }
+
+    /// A push for a stripe this fetcher has already pulled is dropped even
+    /// before the shared state says the stripe is there. On a pool the push
+    /// queues behind the pull on the worker's channel, and the worker can
+    /// dequeue it after its pull landed but before the coordinator has heard
+    /// so; written then, it lands over the stripe as the guest is let onto it.
+    #[test]
+    fn a_push_for_a_stripe_already_pulled_is_dropped_before_the_coordinator_hears() {
+        let mut state = prep(false);
+        let stripe_bytes = (state.fetcher.stripe_sector_count as usize) * SECTOR_SIZE;
+        state
+            .source_dev
+            .write(0, &vec![0x11; stripe_bytes], stripe_bytes);
+        let pushed = vec![0x22; stripe_bytes];
+        let gate = super::super::push_gate::PushGate::new(4);
+
+        state.fetcher.handle_fetch_request(0);
+        for _ in 0..10 {
+            state.fetcher.update();
+        }
+        assert_eq!(state.fetcher.take_finished_fetches(), vec![(0, true)]);
+        assert!(
+            !state.fetcher.shared_metadata_state.stripe_fetched(0),
+            "the coordinator has not marked the stripe yet"
+        );
+
+        state
+            .fetcher
+            .accept_pushed_stripe(0, &pushed, gate.acquire());
+        for _ in 0..10 {
+            state.fetcher.update();
+        }
+
+        assert_eq!(
+            state.target_dev.metrics.read().unwrap().writes,
+            1,
+            "the pull's write is the only write of the stripe"
+        );
+        let mut written = vec![0u8; stripe_bytes];
+        state.target_dev.read(0, &mut written, stripe_bytes);
+        assert_eq!(
+            written,
+            vec![0x11; stripe_bytes],
+            "what the pull brought stands"
+        );
+        assert!(
+            state.fetcher.take_finished_fetches().is_empty(),
+            "and there is nothing new to report"
+        );
+        assert_eq!(gate.queued(), 0, "the slot goes with the dropped push");
     }
 
     /// With no pull in flight the push is written straight away.


### PR DESCRIPTION
A push for a stripe was dropped only when the shared metadata state said the stripe was already local. On the ingest pool that state belongs to the coordinator: a worker reports a landed pull as FetchCompleted and the coordinator marks it, so for a while after a worker's own pull lands the shared state still says the stripe is missing. A push for that stripe sitting in the worker's queue, whether parked behind the pull or dequeued just after it, passed the check and was written as a second copy of the stripe. By then the coordinator had marked the stripe fetched and released the guest's queued I/O to it, so the pushed pre-image landed on top of whatever the guest had written there.

The inline fetcher had the same gap, one write wide: a parked push was applied in the same update() that completed the pull, before the coordinator marked the stripe, and its write was still in flight when the guest was let onto the stripe.

The fix is one predicate. A stripe now counts as local by either account of it, the shared state or the fetcher's own record of a finished pull (stripe_states == Fetched), and a push for a local stripe is dropped along with its subscriber slot, both when it arrives and when a parked copy comes up for applying. A pull that succeeded returned the snapshot content the push carries, so nothing is lost by dropping it; only a refused pull needs the pushed copy, and that path is unchanged.

## Verification

Two new tests in stripe_fetcher.rs drive the fetcher through both shapes of the race and assert that the pull's write is the only write of the stripe, that the pulled content stands, that nothing is reported twice, and that the push's slot is released. Both fail on snapshot-fork without the fix:

- a_parked_push_is_dropped_when_its_own_pull_lands
- a_push_for_a_stripe_already_pulled_is_dropped_before_the_coordinator_hears

The existing pushed_stripe_is_applied_after_the_racing_fetch_fails only failed the pull's first attempt, so its retry succeeded against the test source and the test was passing precisely because the push then overwrote the pull. It now uses a source that refuses the stripe for good, which is the situation its docstring describes, via a small prep_with_source helper.

cargo fmt, clippy with -D warnings and the full test suite pass. This is opened as a draft while CI is confirmed.

## For review

- stripe_is_local in stripe_fetcher.rs and its two call sites in accept_pushed_stripe and apply_pending_pushes.
- Whether the fetcher's own Fetched state is a safe account of locality. It is set only in fetch_completed(success) after the write and flush complete, or in start_fetches when the shared state already says fetched or no-source, and it is never cleared. On a pool each worker sees only its own stripe range, so there is no cross-worker staleness. Any future code that resets stripe_states after a successful fetch would reopen this window.
- The reworked pushed_stripe_is_applied_after_the_racing_fetch_fails still exercises a push parked behind a pull that is in flight and applied once that pull has given up. Because the source now fails all attempts, the shared state passes through Failed before the push is applied and reported. That transient Failed is pre-existing behaviour of the retry path and is not changed here, but the test now depends on it.

## Risks

The fix only stops a push being written over a stripe the fetcher already has. It does not change the order in which the coordinator marks a stripe fetched relative to any other in-flight write, and a push that arrives after the coordinator has marked the stripe is still dropped by the shared-state check as before. Verification is at the fetcher level with the synchronous test block device; no end-to-end pool test with real worker threads was added.
