### PR TITLE
Drop a fork that dies while prod is quiet

### DIFF
--- a/src/backends/common/snapshot_service.rs
+++ b/src/backends/common/snapshot_service.rs
@@ -127,13 +127,25 @@ pub fn spawn_snapshot_server(
                     continue;
                 }
 
+                // Keepalive only marks the socket dead; something has to look.
+                // The worker looks at this handle, so a fork that dies while
+                // prod is not writing is dropped rather than kept until a push
+                // to it happens to fail.
+                let socket = match stream.try_clone() {
+                    Ok(socket) => socket,
+                    Err(e) => {
+                        error!("Failed to duplicate a snapshot connection: {e}");
+                        continue;
+                    }
+                };
+
                 let server = server.clone();
                 // One thread per fork. A session that subscribes hands its
                 // stream to the snapshot worker and this thread ends.
                 let spawned = thread::Builder::new()
                     .name("snapshot-session".to_string())
                     .spawn(move || match server.start_session(Box::new(stream)) {
-                        Ok(mut session) => session.handle_requests(),
+                        Ok(session) => session.with_socket(Box::new(socket)).handle_requests(),
                         Err(e) => error!("Failed to start a snapshot session: {e}"),
                     });
 

--- a/src/block_device/bdev_snapshot/bdev_snapshot_tests.rs
+++ b/src/block_device/bdev_snapshot/bdev_snapshot_tests.rs
@@ -387,6 +387,78 @@ fn a_dead_destination_is_not_offered_stripes() {
     assert_eq!(channel.poll(), vec![(1, true)]);
 }
 
+/// A fork that dies while prod is not writing has nothing to reveal it: no
+/// copy-out runs, so nothing asks whether it is still there. The worker has to
+/// ask on its own, or the snapshot outlives its last fork for as long as prod
+/// stays quiet, and the next snapshot finds a fork still attached to this one.
+#[test]
+fn a_dead_destination_is_pruned_without_a_write() {
+    let mut h = harness(4);
+    let mut worker = worker_for(&mut h);
+
+    let destination = TestDestination::new(1);
+    attach(&mut worker, &h.state, destination.clone());
+    worker.process_request(SnapshotRequest::Freeze);
+    assert_eq!(h.state.destination_count(), 1);
+
+    // The fork goes away. Nothing is written, so no copy-out will notice.
+    destination.alive.store(false, Ordering::SeqCst);
+
+    // No request is queued: the worker wakes up on its own and looks.
+    worker.receive_requests(true);
+
+    assert!(destination.offered_stripes().is_empty(), "no copy-out ran");
+    assert_eq!(worker.destination_count(), 0);
+    assert_eq!(
+        h.state.destination_count(),
+        0,
+        "snapshot_status no longer reports the dead fork"
+    );
+    assert!(
+        !h.state.snapshot_live(),
+        "it was the last fork, so the snapshot ends"
+    );
+    assert_eq!(h.state.stripe_state(0), FREE, "prod stops paying for it");
+}
+
+#[test]
+fn a_dead_destination_is_pruned_while_another_keeps_the_snapshot() {
+    let mut h = harness(4);
+    let mut worker = worker_for(&mut h);
+
+    let living = TestDestination::new(1);
+    let dying = TestDestination::new(2);
+    attach(&mut worker, &h.state, living.clone());
+    attach(&mut worker, &h.state, dying.clone());
+    worker.process_request(SnapshotRequest::Freeze);
+
+    dying.alive.store(false, Ordering::SeqCst);
+    worker.receive_requests(true);
+
+    assert_eq!(worker.destination_count(), 1);
+    assert_eq!(h.state.destination_count(), 1);
+    assert!(h.state.snapshot_live(), "the other fork still needs it");
+    assert_eq!(h.state.stripe_state(0), LOCKED);
+}
+
+#[test]
+fn a_live_idle_destination_is_not_pruned() {
+    let mut h = harness(4);
+    let mut worker = worker_for(&mut h);
+
+    let destination = TestDestination::new(1);
+    attach(&mut worker, &h.state, destination.clone());
+    worker.process_request(SnapshotRequest::Freeze);
+
+    // A fork that is merely quiet is not a fork that is gone.
+    worker.receive_requests(true);
+
+    assert_eq!(worker.destination_count(), 1);
+    assert_eq!(h.state.destination_count(), 1);
+    assert!(h.state.snapshot_live());
+    assert_eq!(h.state.stripe_state(0), LOCKED);
+}
+
 #[test]
 fn destinations_are_capped() {
     let mut h = harness(2);

--- a/src/block_device/bdev_snapshot/worker.rs
+++ b/src/block_device/bdev_snapshot/worker.rs
@@ -30,6 +30,16 @@ pub const MAX_DESTINATIONS: usize = 8;
 /// the fork to come up.
 const SUBSCRIBER_GRACE: Duration = Duration::from_secs(60);
 
+/// How often the worker wakes up with no request to serve, while a snapshot has
+/// something to look after: a fork that may have died, or a stripe held for a
+/// subscriber that may never come.
+///
+/// A fork that dies while prod is not writing is otherwise never noticed. Only
+/// a copy-out asks whether a destination is still alive, and with nothing being
+/// written no copy-out runs, so the snapshot stays live for as long as prod
+/// stays quiet.
+const IDLE_WAKEUP: Duration = Duration::from_secs(1);
+
 pub enum SnapshotRequest {
     /// A write is waiting on this stripe, or a destination asked for it.
     CopyOut {
@@ -249,11 +259,9 @@ impl SnapshotWorker {
         Ok(data)
     }
 
-    /// Read the pre-write content of a stripe and hand it to every live
-    /// destination. Destinations that fail are dropped, never retried: prod
-    /// writes are waiting on this.
     /// Forget forks that have gone away. Done before every copy-out so a dead
-    /// fork is dropped even when it is not the one holding a stripe up.
+    /// fork is dropped even when it is not the one holding a stripe up, and on
+    /// every idle wakeup so one is dropped even when nothing is written.
     fn prune_dead_destinations(&mut self) {
         let before = self.destinations.len();
         self.destinations
@@ -268,6 +276,9 @@ impl SnapshotWorker {
         }
     }
 
+    /// Read the pre-write content of a stripe and hand it to every live
+    /// destination. Destinations that fail are dropped, never retried: prod
+    /// writes are waiting on this.
     fn copy_out(&mut self, stripe_id: usize) {
         self.prune_dead_destinations();
 
@@ -374,17 +385,22 @@ impl SnapshotWorker {
 
     pub fn receive_requests(&mut self, block: bool) {
         if block {
-            // With stripes held for a subscriber, wake up regularly so the
-            // grace period can expire even if no request arrives.
-            let blocking_recv = if self.deferred.is_empty() {
+            // With a fork attached or stripes held for one, wake up regularly
+            // so a dead fork is dropped and the grace period can expire even if
+            // no request arrives. With neither there is nothing to look after.
+            let idle = self.destinations.is_empty() && self.deferred.is_empty();
+            let blocking_recv = if idle {
                 self.requests.recv().map_err(RecvTimeoutError::from)
             } else {
-                self.requests.recv_timeout(Duration::from_secs(1))
+                self.requests.recv_timeout(IDLE_WAKEUP)
             };
 
             match blocking_recv {
                 Ok(request) => self.process_request(request),
-                Err(RecvTimeoutError::Timeout) => self.expire_grace_if_needed(),
+                Err(RecvTimeoutError::Timeout) => {
+                    self.expire_grace_if_needed();
+                    self.prune_dead_destinations();
+                }
                 Err(RecvTimeoutError::Disconnected) => {
                     error!("Snapshot worker request channel closed");
                     self.done = true;

--- a/src/stripe_server/mod.rs
+++ b/src/stripe_server/mod.rs
@@ -1,5 +1,6 @@
 use std::{
     io::{Read, Write},
+    os::fd::AsRawFd,
     sync::{atomic::AtomicU64, mpsc::Sender, Arc},
 };
 
@@ -68,6 +69,10 @@ pub struct StripeServer {
 
 pub struct StripeServerSession {
     stream: Option<DynStream>,
+    /// A second handle on the socket under `stream`, if the caller has one.
+    /// Handed to the snapshot worker along with the stream when the session
+    /// subscribes, so a fork that dies is noticed without a push to it.
+    socket: Option<Box<dyn AsRawFd + Send>>,
     /// One buffer, reused for every stripe this session serves. Allocating a
     /// megabyte per request means faulting in and zeroing a megabyte per
     /// request, which the serving side pays on every stripe a fork pulls.
@@ -142,6 +147,7 @@ impl StripeServer {
             .transpose()?;
         Ok(StripeServerSession {
             stream: Some(stream),
+            socket: None,
             stripe_buffer: None,
             compression: WireCompression::default(),
             metadata: self.metadata.clone(),
@@ -152,6 +158,16 @@ impl StripeServer {
             live_state: self.live_state.clone(),
             next_destination_id: self.next_destination_id.clone(),
         })
+    }
+}
+
+impl StripeServerSession {
+    /// Let a subscription made on this session be checked for liveness against
+    /// the socket itself. `socket` must be another handle on the connection
+    /// `stream` was built from.
+    pub fn with_socket(mut self, socket: Box<dyn AsRawFd + Send>) -> Self {
+        self.socket = Some(socket);
+        self
     }
 }
 

--- a/src/stripe_server/session.rs
+++ b/src/stripe_server/session.rs
@@ -109,7 +109,10 @@ impl StripeServerSession {
             .next_destination_id
             .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
         let stream = self.stream.take().expect("stream checked above");
-        let destination = RemoteDestination::new(id, stream, compression);
+        let mut destination = RemoteDestination::new(id, stream, compression);
+        if let Some(socket) = self.socket.take() {
+            destination = destination.with_socket(socket);
+        }
 
         if snapshot_ch
             .send(SnapshotRequest::AddDestination {

--- a/src/stripe_server/snapshot_e2e_tests.rs
+++ b/src/stripe_server/snapshot_e2e_tests.rs
@@ -224,6 +224,81 @@ fn subscribing_without_a_snapshot_is_refused() {
     assert!(result.is_err());
 }
 
+/// A fork that goes away while prod is quiet. No write means no copy-out, and a
+/// copy-out was the only thing that ever asked whether a fork was still there:
+/// the snapshot stayed live, `snapshot_status` kept reporting the fork, and the
+/// next fork could not be taken until an operator forced a write on prod.
+#[test]
+fn a_fork_that_goes_away_while_prod_is_quiet_is_dropped() {
+    let file = tempfile::NamedTempFile::new().unwrap();
+    file.as_file()
+        .write_all(&vec![0u8; STRIPES * STRIPE_BYTES])
+        .unwrap();
+    file.as_file().sync_all().unwrap();
+
+    let disk = SyncBlockDevice::new(file.path().to_path_buf(), false, false, false).unwrap();
+    let (snapshot_ch, snapshot_requests) = channel();
+    let snapshot_device = SnapshotBlockDevice::new(
+        BlockDevice::clone(disk.as_ref()),
+        STRIPE_SHIFT,
+        snapshot_ch.clone(),
+    );
+    let state = snapshot_device.state();
+    let mut worker = SnapshotWorker::new(
+        BlockDevice::clone(disk.as_ref()).as_ref(),
+        state.clone(),
+        snapshot_requests,
+    )
+    .unwrap();
+    thread::spawn(move || worker.run());
+
+    let metadata = UbiMetadata::new(STRIPE_SHIFT, STRIPES, 0);
+    let server = Arc::new(
+        StripeServer::new(
+            Arc::from(BlockDevice::clone(disk.as_ref())),
+            Arc::from(metadata),
+            None,
+        )
+        .with_snapshot(snapshot_ch.clone(), state.clone()),
+    );
+
+    // The snapshot server's accept loop: the session gets a second handle on
+    // the socket, so the worker can tell the fork has gone.
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    thread::spawn(move || {
+        if let Some(Ok(stream)) = listener.incoming().next() {
+            let socket = stream.try_clone().unwrap();
+            server
+                .start_session(Box::new(stream))
+                .unwrap()
+                .with_socket(Box::new(socket))
+                .handle_requests();
+        }
+    });
+
+    freeze(&state);
+    let subscriber = SnapshotSubscriber::subscribe(
+        Box::new(TcpStream::connect(address).unwrap()),
+        WireCompression::None,
+    )
+    .unwrap();
+    wait_until("the fork to register as a destination", || {
+        state.destination_count() == 1
+    });
+
+    // The fork dies. Prod writes nothing.
+    drop(subscriber);
+
+    wait_until("the dead fork to be dropped", || {
+        state.destination_count() == 0
+    });
+    assert!(
+        !state.snapshot_live(),
+        "it was the only fork, so the snapshot ends and the next one can be taken"
+    );
+}
+
 /// A device whose reads do not complete until the test says so, so a copy-out
 /// can be made to land while a pull is in flight — the window the check before
 /// the read cannot cover.

--- a/src/stripe_server/snapshot_push.rs
+++ b/src/stripe_server/snapshot_push.rs
@@ -8,9 +8,12 @@
 //! idle fork cannot stall prod writes and a busy fork does not wait for prod to
 //! overwrite something before it can read it.
 
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
+use std::{
+    os::fd::{AsRawFd, RawFd},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
 };
 
 use log::{info, warn};
@@ -26,6 +29,9 @@ use super::{DynStream, WireCompression, PUSH_STRIPE_FRAME, SNAPSHOT_END_FRAME};
 pub struct RemoteDestination {
     id: DestinationId,
     stream: DynStream,
+    /// A second handle on the socket under `stream`, when there is one, so the
+    /// fork can be found dead without writing to it.
+    socket: Option<Box<dyn AsRawFd + Send>>,
     alive: Arc<AtomicBool>,
     compression: WireCompression,
 }
@@ -35,9 +41,19 @@ impl RemoteDestination {
         Self {
             id,
             stream,
+            socket: None,
             alive: Arc::new(AtomicBool::new(true)),
             compression,
         }
+    }
+
+    /// Check liveness against the socket itself, not only against failed
+    /// pushes. Without this a fork is found dead only when a push to it fails,
+    /// and a fork that dies while prod is not writing is never found at all:
+    /// the kernel has given up on the connection, but nothing asks it.
+    pub fn with_socket(mut self, socket: Box<dyn AsRawFd + Send>) -> Self {
+        self.socket = Some(socket);
+        self
     }
 
     /// Shared with whoever wants to hang up on this destination from another
@@ -100,12 +116,46 @@ impl SnapshotDestination for RemoteDestination {
     }
 
     fn is_alive(&self) -> bool {
-        self.alive.load(Ordering::SeqCst)
+        if !self.alive.load(Ordering::SeqCst) {
+            return false;
+        }
+        if self
+            .socket
+            .as_ref()
+            .is_some_and(|socket| peer_hung_up(socket.as_raw_fd()))
+        {
+            info!("Snapshot destination {} hung up", self.id);
+            self.alive.store(false, Ordering::SeqCst);
+            return false;
+        }
+        true
     }
 
     fn finish(&mut self) {
         self.send_end();
     }
+}
+
+/// Whether the peer on a socket has hung up, or the connection has failed.
+///
+/// The kernel knows as soon as a FIN, a reset or a keepalive timeout lands, but
+/// only tells a process that asks. A push socket is only ever written to, so
+/// nothing asks between pushes; this does, without reading or writing a byte.
+fn peer_hung_up(fd: RawFd) -> bool {
+    let mut poll_fd = libc::pollfd {
+        fd,
+        events: libc::POLLRDHUP,
+        revents: 0,
+    };
+    // SAFETY: poll_fd is a valid pollfd that outlives the call, and 1 is the
+    // number of entries it points at.
+    let ready = unsafe { libc::poll(&mut poll_fd, 1, 0) };
+    if ready <= 0 {
+        // Nothing to report, or poll itself failed. Neither says the peer is
+        // gone; a push that fails will still catch it.
+        return false;
+    }
+    poll_fd.revents & (libc::POLLERR | libc::POLLHUP | libc::POLLRDHUP) != 0
 }
 
 /// What a subscribed fork reads off its push session.
@@ -277,6 +327,25 @@ mod tests {
 
         assert!(died, "writing to a closed peer must fail");
         assert!(!destination.is_alive());
+    }
+
+    /// The case a failed push cannot cover: the fork is gone, and prod has no
+    /// write that would make the worker push anything to find that out.
+    #[test]
+    fn a_fork_that_hangs_up_is_found_dead_without_a_push() {
+        let (server, client) = UnixStream::pair().unwrap();
+        let socket = server.try_clone().unwrap();
+        let destination = RemoteDestination::new(4, Box::new(server), WireCompression::None)
+            .with_socket(Box::new(socket));
+
+        assert!(destination.is_alive(), "a quiet fork is not a dead one");
+
+        drop(client);
+        assert!(
+            !destination.is_alive(),
+            "the hang-up is seen without anything being written"
+        );
+        assert!(!destination.is_alive(), "and it stays dead");
     }
 
     #[test]


### PR DESCRIPTION
A fork was only found dead by a copy-out. The snapshot worker checked its destinations before every copy-out, and a push to a fork that had gone away failed and dropped it. With prod not writing there is no copy-out, so a fork whose process or VM had died stayed registered for as long as prod stayed quiet: the snapshot stayed live, `snapshot_status` kept reporting one destination, and the next fork could not be taken until an operator forced a write on prod to shake it loose. That happened three times in one afternoon of testing.

Two things were missing, and fixing only the first would not have helped. The worker only woke up on a request, or once a second while it held stripes for a subscriber that had not arrived yet; it now wakes once a second whenever a fork is attached as well, and prunes dead destinations then, ending the snapshot when the last one goes exactly as the copy-out path does. Separately, a destination's liveness was a flag that only a failed push cleared. Keepalive on the push socket gives up on a dead peer in about eleven seconds, but that only marks the socket in the kernel, and nothing in the process ever read from or polled it after the subscribe handoff, so `is_alive` kept answering true. The snapshot server now duplicates the accepted socket and hands that handle to the session, which passes it on to the destination when the session subscribes; `is_alive` polls it at zero timeout for a hang-up, reset or error without reading or writing a byte, and latches the destination dead once it sees one.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings` and the full test suite pass. New tests:

- `bdev_snapshot_tests::a_dead_destination_is_pruned_without_a_write`: a dead `TestDestination` is pruned by the idle wakeup with no copy-out, and the snapshot ends when it was the last one.
- `bdev_snapshot_tests::a_dead_destination_is_pruned_while_another_keeps_the_snapshot`: a dead one among two is pruned while the snapshot stays live.
- `bdev_snapshot_tests::a_live_idle_destination_is_not_pruned`: a live idle destination is left alone.
- `snapshot_push::tests::a_fork_that_hangs_up_is_found_dead_without_a_push`: a `RemoteDestination` with a socket handle is found dead when its peer closes with nothing written.
- `snapshot_e2e_tests::a_fork_that_goes_away_while_prod_is_quiet_is_dropped`: end to end over TCP, a subscribed fork drops its connection while prod writes nothing, and the destination count goes to zero and the snapshot ends on its own.

## For review

- `receive_requests` in `worker.rs`: when it blocks with a timeout and what runs on timeout.
- `peer_hung_up` in `snapshot_push.rs`: `poll(2)` with `POLLRDHUP` and the revents mask.
- The `try_clone` plus `with_socket` plumbing in `snapshot_service.rs`, `stripe_server/mod.rs` and `session.rs`. Sessions built without a socket handle (the other listeners and existing tests) behave as before.

## Risks

- The change is broader than a timer. A wakeup alone would not have helped because `RemoteDestination::is_alive` never observed the socket, so the fix also plumbs a duplicated socket handle into the destination and adds the poll-based check.
- `POLLRDHUP` is Linux-specific. The crate already depends on Linux-only socket options and io_uring, so this does not narrow the supported platforms.
- The worker's idle wakeup is one second, matching the existing grace cadence. Each wakeup costs one poll syscall per attached fork, which is new but negligible periodic activity on the worker thread.

Opened as a draft while CI is confirmed. All 525 tests pass on the x86_64 runner; the coverage gate (90.48% against a 91% floor) and the cargo audit warning on chacha20 fail identically on the base branch's own most recent run, so neither is introduced here.
