### PR TITLE
Keep a metadata request whose submit failed until its completion lands

### DIFF
--- a/src/block_device/bdev_lazy/metadata_flusher.rs
+++ b/src/block_device/bdev_lazy/metadata_flusher.rs
@@ -48,6 +48,11 @@ pub struct MetadataFlusher {
     header_updates: HashMap<usize, HeaderUpdateStatus>,
     queued_requests: VecDeque<MetadataFlusherRequest>,
     buffer_pool: AlignedBufferPool,
+    /// A submit failed with requests in the channel. Their SQEs stay in the
+    /// ring and the next submit enters them (see `bdev_uring::submit`), so
+    /// their completions are still owed: the statuses, buffers and sectors
+    /// stay as they are and `update` submits again until one succeeds.
+    resubmit_needed: bool,
 }
 
 impl MetadataFlusher {
@@ -79,6 +84,7 @@ impl MetadataFlusher {
             queued_requests: VecDeque::new(),
             buffer_pool: AlignedBufferPool::new(4096, MAX_CONCURRENT_CHANGES, SECTOR_SIZE),
             header_updates: HashMap::new(),
+            resubmit_needed: false,
         })
     }
 
@@ -101,25 +107,42 @@ impl MetadataFlusher {
     }
 
     pub fn update(&mut self) {
+        self.resubmit();
         self.start_writes();
         self.poll_channel();
     }
 
-    fn cleanup_failed_submission(&mut self, stripe_ids: &[usize], return_buffer: bool) {
-        for stripe_id in stripe_ids {
-            if let Some(status) = self.header_updates.remove(stripe_id) {
-                self.metadata.stripe_headers[status.stripe_id] &= !status.requested_bitmask;
-                if return_buffer {
-                    self.buffer_pool.return_buffer(&status.buffer);
-                }
-                self.sectors_being_updated.remove(&status.sector);
+    /// Submit the requests added to the channel. A failed submit leaves the
+    /// SQEs in the ring for the next one, so the requests may yet run and
+    /// their completions will arrive: nothing is undone here. Returning a
+    /// buffer now would let the kernel write another sector's bytes to this
+    /// request's sector, with a valid CRC, and reverting the header now
+    /// would report a failure for a write that may still land.
+    fn submit(&mut self, what: &str) {
+        match self.channel.submit() {
+            Ok(()) => self.resubmit_needed = false,
+            Err(e) => {
+                error!("Failed to submit metadata {what}: {e}");
+                self.resubmit_needed = true;
             }
+        }
+    }
+
+    /// Enter the SQEs a failed submit left in the ring, so that their
+    /// completions can arrive even if no new request is added.
+    fn resubmit(&mut self) {
+        if !self.resubmit_needed {
+            return;
+        }
+        match self.channel.submit() {
+            Ok(()) => self.resubmit_needed = false,
+            Err(e) => debug!("Metadata requests still cannot be submitted: {e}"),
         }
     }
 
     fn poll_channel(&mut self) {
         let mut finished_stripes = Vec::new();
-        let mut newly_flushing = Vec::new();
+        let mut newly_flushing = false;
 
         for (stripe_id, success) in self.channel.poll() {
             let maybe_status = self.header_updates.get_mut(&stripe_id);
@@ -148,7 +171,7 @@ impl MetadataFlusher {
                         self.buffer_pool.return_buffer(&status.buffer);
                         self.channel.add_flush(stripe_id);
                         status.stage = RequestStage::Flushing;
-                        newly_flushing.push(stripe_id);
+                        newly_flushing = true;
                     }
                     RequestStage::Flushing => {
                         self.sectors_being_updated.remove(&(status.sector));
@@ -164,22 +187,13 @@ impl MetadataFlusher {
             self.shared_state.set_stripe_header(stripe, header);
         }
 
-        if newly_flushing.is_empty() {
-            return;
-        }
-
-        // submit flushes, if any
-        if let Err(e) = self.channel.submit() {
-            error!("Failed to submit metadata flushes: {e}");
-            // The kernel never received the flush SQEs. Clean up entries
-            // that just transitioned to Flushing to avoid permanently
-            // blocking the affected sectors.
-            self.cleanup_failed_submission(&newly_flushing, false);
+        if newly_flushing {
+            self.submit("flushes");
         }
     }
 
     fn start_writes(&mut self) {
-        let mut newly_added = Vec::new();
+        let mut newly_added = false;
 
         while !self.queued_requests.is_empty() && self.buffer_pool.has_available() {
             let req = *self.queued_requests.front().unwrap();
@@ -224,20 +238,11 @@ impl MetadataFlusher {
                     sector,
                 },
             );
-            newly_added.push(req.stripe_id);
+            newly_added = true;
         }
 
-        if newly_added.is_empty() {
-            return;
-        }
-
-        // submit writes, if any
-        if let Err(e) = self.channel.submit() {
-            error!("Failed to submit metadata writes: {e}");
-            // The kernel never received the SQEs, so no completions will
-            // arrive. Revert all entries we just added to avoid permanently
-            // blocking the affected sectors.
-            self.cleanup_failed_submission(&newly_added, true);
+        if newly_added {
+            self.submit("writes");
         }
     }
 }
@@ -443,8 +448,91 @@ mod tests {
         assert_eq!(metrics.flushes - start_flushes, 2);
     }
 
+    fn io_counts(metadata_dev: &TestBlockDevice) -> (usize, usize) {
+        let metrics = metadata_dev.metrics.read().unwrap();
+        (metrics.writes, metrics.flushes)
+    }
+
+    /// How many buffers the pool has on offer, so a test can tell whether a
+    /// request's buffer has been returned.
+    fn spare_buffers(metadata_flusher: &mut MetadataFlusher) -> usize {
+        let mut spare = Vec::new();
+        while let Some(buf) = metadata_flusher.buffer_pool.get_buffer() {
+            spare.push(buf);
+        }
+        for buf in &spare {
+            metadata_flusher.buffer_pool.return_buffer(buf);
+        }
+        spare.len()
+    }
+
     #[test]
-    fn test_submit_failure_in_start_writes_allows_retry() {
+    fn test_write_submit_failure_keeps_request_until_completion_lands() {
+        // A failed submit leaves the write SQE in the ring, where the next
+        // submit enters it, so the write may still happen. The request must
+        // keep its status, buffer and sector until the completion arrives,
+        // and nothing may be reported before then.
+        let metadata_dev = init_metadata_device();
+        let shared_state = {
+            let metadata = UbiMetadata::load_from_bdev(&metadata_dev).expect("load metadata");
+            SharedMetadataState::new(&metadata)
+        };
+        let mut metadata_flusher =
+            MetadataFlusher::new(&metadata_dev, 8 * 1024, shared_state.clone()).unwrap();
+        let (writes, flushes) = io_counts(&metadata_dev);
+        assert_eq!(spare_buffers(&mut metadata_flusher), MAX_CONCURRENT_CHANGES);
+
+        metadata_flusher.set_stripe_fetched(5);
+        metadata_dev
+            .fail_submit
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        metadata_flusher.update();
+
+        // Nothing reported, nothing undone: the flag stays in memory for the
+        // sector image the kernel will read, and the buffer is not on offer.
+        assert!(!shared_state.stripe_fetched(5));
+        assert!(metadata_flusher.busy());
+        assert_eq!(
+            metadata_flusher.header_updates[&5].stage,
+            RequestStage::Writing
+        );
+        assert_ne!(
+            metadata_flusher.metadata.stripe_headers[5] & metadata_flags::FETCHED,
+            0
+        );
+        assert_eq!(
+            spare_buffers(&mut metadata_flusher),
+            MAX_CONCURRENT_CHANGES - 1
+        );
+
+        // A submit that fails again changes nothing: the write is neither
+        // re-issued nor given up on.
+        metadata_dev
+            .fail_submit
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        metadata_flusher.update();
+        assert!(!shared_state.stripe_fetched(5));
+        assert!(metadata_flusher.busy());
+        assert_eq!(io_counts(&metadata_dev), (writes + 1, flushes));
+        assert_eq!(
+            spare_buffers(&mut metadata_flusher),
+            MAX_CONCURRENT_CHANGES - 1
+        );
+
+        // The next submit succeeds, the completion lands, and the request
+        // finishes once.
+        wait_for_completion(&mut metadata_flusher);
+        assert!(shared_state.stripe_fetched(5));
+        assert!(!metadata_flusher.busy());
+        assert_eq!(io_counts(&metadata_dev), (writes + 1, flushes + 1));
+        assert_eq!(spare_buffers(&mut metadata_flusher), MAX_CONCURRENT_CHANGES);
+    }
+
+    #[test]
+    fn test_write_submit_failure_reports_failed_completion_when_it_lands() {
+        // The completion a failed submit still owes may itself report a
+        // failure. The flag is reverted and the buffer returned when that
+        // completion arrives, not at the failed submit.
         let metadata_dev = init_metadata_device();
         let shared_state = {
             let metadata = UbiMetadata::load_from_bdev(&metadata_dev).expect("load metadata");
@@ -453,25 +541,38 @@ mod tests {
         let mut metadata_flusher =
             MetadataFlusher::new(&metadata_dev, 8 * 1024, shared_state.clone()).unwrap();
 
-        // Queue a request and make submit() fail
         metadata_flusher.set_stripe_fetched(5);
+        metadata_dev
+            .fail_next
+            .store(true, std::sync::atomic::Ordering::SeqCst);
         metadata_dev
             .fail_submit
             .store(true, std::sync::atomic::Ordering::SeqCst);
-
-        // start_writes will add_write then fail on submit
         metadata_flusher.update();
 
-        // Stripe 5 should NOT be marked fetched in shared state
-        assert!(!shared_state.stripe_fetched(5));
-        // Flusher should not be busy (submit failure was cleaned up)
-        assert!(!metadata_flusher.busy());
+        assert!(metadata_flusher.busy());
+        assert_ne!(
+            metadata_flusher.metadata.stripe_headers[5] & metadata_flags::FETCHED,
+            0
+        );
+        assert_eq!(
+            spare_buffers(&mut metadata_flusher),
+            MAX_CONCURRENT_CHANGES - 1
+        );
 
-        // Retry: queue the same request again - should NOT be blocked
+        // The resubmit succeeds and the failed completion is processed.
+        metadata_flusher.update();
+        assert!(!shared_state.stripe_fetched(5));
+        assert!(!metadata_flusher.busy());
+        assert_eq!(
+            metadata_flusher.metadata.stripe_headers[5] & metadata_flags::FETCHED,
+            0
+        );
+        assert_eq!(spare_buffers(&mut metadata_flusher), MAX_CONCURRENT_CHANGES);
+
+        // Retry: queue the same request again - should NOT be skipped by dedup
         metadata_flusher.set_stripe_fetched(5);
         wait_for_completion(&mut metadata_flusher);
-
-        // Now it should succeed
         assert!(shared_state.stripe_fetched(5));
     }
 
@@ -545,7 +646,9 @@ mod tests {
     }
 
     #[test]
-    fn test_submit_failure_in_poll_channel_allows_retry() {
+    fn test_flush_submit_failure_keeps_request_until_completion_lands() {
+        // The same for a flush: its SQE stays in the ring, the request stays
+        // in Flushing, and the stripe lands when the fsync completes.
         let metadata_dev = init_metadata_device();
         let shared_state = {
             let metadata = UbiMetadata::load_from_bdev(&metadata_dev).expect("load metadata");
@@ -553,28 +656,37 @@ mod tests {
         };
         let mut metadata_flusher =
             MetadataFlusher::new(&metadata_dev, 8 * 1024, shared_state.clone()).unwrap();
+        let (writes, flushes) = io_counts(&metadata_dev);
 
         // Queue a request and let the write succeed
         metadata_flusher.set_stripe_fetched(5);
         metadata_flusher.start_writes();
 
-        // Poll should see the write completion and enqueue a flush.
-        // Make submit fail so the flush SQE is never submitted.
+        // Poll sees the write completion and adds a flush, whose submit fails.
         metadata_dev
             .fail_submit
             .store(true, std::sync::atomic::Ordering::SeqCst);
         metadata_flusher.poll_channel();
-
-        // Stripe 5 should NOT be marked fetched (flush never reached kernel)
         assert!(!shared_state.stripe_fetched(5));
-        // Flusher should not be busy (submit failure was cleaned up)
-        assert!(!metadata_flusher.busy());
+        assert!(metadata_flusher.busy());
+        assert_eq!(
+            metadata_flusher.header_updates[&5].stage,
+            RequestStage::Flushing
+        );
 
-        // Retry: queue the same request again - should NOT be blocked
-        metadata_flusher.set_stripe_fetched(5);
+        // A submit that fails again changes nothing.
+        metadata_dev
+            .fail_submit
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        metadata_flusher.update();
+        assert!(!shared_state.stripe_fetched(5));
+        assert!(metadata_flusher.busy());
+        assert_eq!(io_counts(&metadata_dev), (writes + 1, flushes + 1));
+
+        // The next submit succeeds and the flush completion lands.
         wait_for_completion(&mut metadata_flusher);
-
-        // Now it should succeed
         assert!(shared_state.stripe_fetched(5));
+        assert!(!metadata_flusher.busy());
+        assert_eq!(io_counts(&metadata_dev), (writes + 1, flushes + 1));
     }
 }

--- a/src/block_device/bdev_test.rs
+++ b/src/block_device/bdev_test.rs
@@ -15,6 +15,10 @@ struct TestIoChannel {
     fail_next: Arc<AtomicBool>,
     fail_submit: Arc<AtomicBool>,
     finished_requests: Vec<(usize, bool)>,
+    /// Requests a failed submit left behind. They are handed to `poll` once a
+    /// later submit succeeds, the way io_uring enters the SQEs a failed
+    /// io_uring_enter did not consume on the next call.
+    unsubmitted_requests: Vec<(usize, bool)>,
     metrics: Arc<RwLock<TestDeviceMetrics>>,
 }
 
@@ -85,11 +89,15 @@ impl IoChannel for TestIoChannel {
             .fail_submit
             .swap(false, std::sync::atomic::Ordering::SeqCst)
         {
-            self.finished_requests.clear();
+            self.unsubmitted_requests
+                .append(&mut self.finished_requests);
             return Err(crate::ubiblk_error!(IoError {
                 source: std::io::Error::other("injected submit failure"),
             }));
         }
+        let mut requests = std::mem::take(&mut self.unsubmitted_requests);
+        requests.append(&mut self.finished_requests);
+        self.finished_requests = requests;
         Ok(())
     }
 
@@ -98,7 +106,7 @@ impl IoChannel for TestIoChannel {
     }
 
     fn busy(&self) -> bool {
-        !self.finished_requests.is_empty()
+        !self.finished_requests.is_empty() || !self.unsubmitted_requests.is_empty()
     }
 }
 
@@ -157,6 +165,7 @@ impl BlockDevice for TestBlockDevice {
         Ok(Box::new(TestIoChannel {
             mem: self.mem.clone(),
             finished_requests: Vec::new(),
+            unsubmitted_requests: Vec::new(),
             metrics: self.metrics.clone(),
             fail_next: self.fail_next.clone(),
             fail_submit: self.fail_submit.clone(),
@@ -229,6 +238,27 @@ mod tests {
         assert_eq!(metrics.flushes, 1);
         drop(metrics);
         assert_eq!(device.flushes(), 1);
+    }
+
+    #[test]
+    // A failed submit keeps its requests, as io_uring keeps the SQEs a failed
+    // enter did not consume: poll sees nothing until a later submit succeeds.
+    fn test_failed_submit_holds_requests_until_the_next_submit() {
+        let device = TestBlockDevice::new(SECTOR_SIZE as u64);
+        let mut channel = device.create_channel().unwrap();
+        device
+            .fail_submit
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+
+        let buf: SharedBuffer = shared_buffer(SECTOR_SIZE);
+        channel.add_read(0, 1, buf, 1);
+        assert!(channel.submit().is_err());
+        assert!(channel.poll().is_empty());
+        assert!(channel.busy());
+
+        channel.submit().unwrap();
+        assert_eq!(channel.poll(), vec![(1, true)]);
+        assert!(!channel.busy());
     }
 
     #[test]

--- a/src/block_device/bdev_uring.rs
+++ b/src/block_device/bdev_uring.rs
@@ -124,12 +124,18 @@ impl IoChannel for UringIoChannel {
         if self.pending == 0 {
             return Ok(());
         }
-        self.submissions += self.pending;
-        self.pending = 0;
         if let Err(e) = self.ring.submit() {
+            // The SQEs stay in the ring: io_uring_enter did not consume them,
+            // and the next submit enters them along with anything added since.
+            // Keep them counted as pending so the next submit is not skipped
+            // as empty, and so `busy` keeps saying completions are owed.
+            // Callers that hold a request's buffer and bookkeeping across a
+            // failed submit rely on this to get the completion eventually.
             error!("Failed to submit IO request: {e}");
             return Err(crate::ubiblk_error!(IoError { source: e }));
         }
+        self.submissions += self.pending;
+        self.pending = 0;
         Ok(())
     }
 


### PR DESCRIPTION
MetadataFlusher treated a failed submit as proof that the kernel never saw the SQEs: cleanup_failed_submission reverted the header bit, returned the buffer to the pool and freed the sector at once. That is not how io_uring behaves. A failed io_uring_enter leaves the SQEs in the submission ring, and the next submit, with or without new requests, enters them. So the write could still run later, by which time the pool may have handed its buffer to another sector's update: another sector's image, carrying a valid CRC, written over this request's sector. The completion then arrived for a stripe with no status and was logged as unexpected, or was credited to a newer request for the same stripe, and the request that had been treated as failed may in fact have succeeded.

The flusher now keeps status, buffer and sector across a failed submit, asks the channel to submit again on every update until one succeeds, and acts on the completion when it arrives, whatever it says. The header bit stays set in memory in the meantime, since that is the byte the pending write carries; a failed completion reverts it then, as before. cleanup_failed_submission is gone.

bdev_uring::submit used to reset its pending count before entering the ring, so a bare retry with nothing new added returned Ok without entering anything and busy() could not tell the SQEs were still owed. The count now moves to submissions only after a successful enter.

The test device dropped its requests on a failed submit, which is the model the old code was written against. It now holds them back from poll until a later submit succeeds, like the ring does, with a test of its own. The two flusher tests that relied on dropped SQEs are rewritten against held completions: a failed submit leaves the request busy, keeps the buffer off the pool and the flag in memory, does not re-issue the write on a further failed submit, and lands exactly once (one write, one flush) when a submit finally succeeds. A third test checks that a failed completion owed by a failed submit is reported, and the header reverted, only when it lands. The new tests fail against the old flusher body.

## Verification

- cargo fmt --check: no changes
- cargo clippy --all-targets --all-features -- -D warnings: clean
- Full test suite: 474 passed

Tests added:

- block_device::bdev_lazy::metadata_flusher::tests::test_write_submit_failure_keeps_request_until_completion_lands
- block_device::bdev_lazy::metadata_flusher::tests::test_write_submit_failure_reports_failed_completion_when_it_lands
- block_device::bdev_lazy::metadata_flusher::tests::test_flush_submit_failure_keeps_request_until_completion_lands
- block_device::bdev_test::tests::test_failed_submit_holds_requests_until_the_next_submit

## What to look at

- The new submit and resubmit helpers in metadata_flusher.rs and the order of calls in update().
- The moved pending accounting in bdev_uring::submit.
- The changed failure model in bdev_test.rs: a failed submit now holds every as-yet-unpolled completion rather than dropping it. This is shared by every test that sets fail_submit, though only the flusher's tests do today.

## Risks

- bdev_uring::submit is a small behavioural change outside the flusher: after a failed enter, pending stays non-zero, so busy() reports true and the next submit enters the ring. Other IoChannel users (the lazy device channel, the fetcher) treat a failed submit as terminal for their requests and are functionally unaffected, but they will now see busy() true until a later submit enters the SQEs.
- If a submit keeps failing indefinitely (for example EBUSY forever), the affected sectors stay in sectors_being_updated and further requests to those sectors queue behind them. The flusher logs the first failure at error level and retries at debug level. The old code freed the sector instead, at the cost of the corruption described above.
- The bdev_uring error branch itself is not unit-tested, since injecting an io_uring_enter failure needs a real ring. Coverage there is unchanged; the branch existed before.

Opened as a draft while CI is confirmed.
