### PR TITLE
Coalesce same-sector metadata header updates into one write and fsync

### DIFF
--- a/src/block_device/bdev_lazy/bgworker.rs
+++ b/src/block_device/bdev_lazy/bgworker.rs
@@ -235,4 +235,60 @@ mod tests {
 
         assert!(bg_worker.shared_state().is_stripe_failed(0));
     }
+
+    #[test]
+    fn bg_worker_marks_a_batch_of_fetches_with_one_header_write() {
+        let stripe_sector_count_shift = 8;
+        let stripe_sector_count = 1u64 << stripe_sector_count_shift;
+        let source_dev = TestBlockDevice::new(1024 * 1024);
+        let target_dev = TestBlockDevice::new(1024 * 1024);
+        let metadata_dev = TestBlockDevice::new(1024 * 1024);
+        let stripe_source = Box::new(
+            stripe_source::BlockDeviceStripeSource::new(source_dev.clone(), stripe_sector_count)
+                .unwrap(),
+        );
+
+        let metadata = UbiMetadata::new(stripe_sector_count_shift, 16, 8);
+        metadata.save_to_bdev(&metadata_dev).unwrap();
+        let metadata_state = {
+            let metadata = UbiMetadata::load_from_bdev(&metadata_dev).expect("load metadata");
+            SharedMetadataState::new(&metadata)
+        };
+        let (tx, rx) = channel();
+        let mut bg_worker = BgWorker::new(
+            stripe_source,
+            &target_dev,
+            &metadata_dev,
+            4096,
+            false,
+            metadata_state,
+            rx,
+        )
+        .unwrap();
+        let (start_writes, start_flushes) = {
+            let metrics = metadata_dev.metrics.read().unwrap();
+            (metrics.writes, metrics.flushes)
+        };
+
+        // Eight fetches arrive together, as when a guest has several reads
+        // outstanding on stripes that are not local yet.
+        for stripe_id in 0..8 {
+            tx.send(BgWorkerRequest::Fetch { stripe_id }).unwrap();
+        }
+        bg_worker.receive_requests(false);
+        for _ in 0..10 {
+            bg_worker.update();
+        }
+
+        for stripe_id in 0..8 {
+            assert!(bg_worker.shared_state().stripe_fetched(stripe_id));
+        }
+        // Each stripe's data was written on its own, but their headers share
+        // a sector, so marking all eight fetched took one metadata write and
+        // one flush rather than eight of each.
+        assert_eq!(target_dev.metrics.read().unwrap().writes, 8);
+        let metrics = metadata_dev.metrics.read().unwrap();
+        assert_eq!(metrics.writes - start_writes, 1);
+        assert_eq!(metrics.flushes - start_flushes, 1);
+    }
 }

--- a/src/block_device/bdev_lazy/metadata_flusher.rs
+++ b/src/block_device/bdev_lazy/metadata_flusher.rs
@@ -8,7 +8,7 @@ use crate::{
     Result,
 };
 use log::{debug, error};
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{hash_map::Entry, HashMap, VecDeque};
 
 const MAX_CONCURRENT_CHANGES: usize = 16;
 
@@ -30,22 +30,34 @@ enum RequestStage {
     Flushing,
 }
 
-struct HeaderUpdateStatus {
-    buffer: SharedBuffer,
-    stage: RequestStage,
+/// One stripe's part of a sector write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct HeaderUpdate {
     stripe_id: usize,
     header: u8,
     /// The specific flag bit(s) added by this request, used to revert on failure.
     requested_bitmask: u8,
-    sector: u64,
+}
+
+/// A metadata sector write in flight, carrying every header update that was
+/// queued for the sector when it started.
+///
+/// A sector holds the headers of 508 consecutive stripes, so stripes fetched
+/// close together nearly always share one. Writing them one header at a time
+/// would cost a write and an fsync each; one sector write covers them all for
+/// the price of one.
+struct SectorUpdateStatus {
+    buffer: SharedBuffer,
+    stage: RequestStage,
+    group: usize,
+    updates: Vec<HeaderUpdate>,
 }
 
 pub struct MetadataFlusher {
     channel: Box<dyn IoChannel>,
     metadata: Box<UbiMetadata>,
     shared_state: SharedMetadataState,
-    sectors_being_updated: HashSet<u64>,
-    header_updates: HashMap<usize, HeaderUpdateStatus>,
+    sector_updates: HashMap<u64, SectorUpdateStatus>,
     queued_requests: VecDeque<MetadataFlusherRequest>,
     buffer_pool: AlignedBufferPool,
 }
@@ -75,15 +87,14 @@ impl MetadataFlusher {
             channel,
             shared_state,
             metadata,
-            sectors_being_updated: HashSet::new(),
+            sector_updates: HashMap::new(),
             queued_requests: VecDeque::new(),
             buffer_pool: AlignedBufferPool::new(4096, MAX_CONCURRENT_CHANGES, SECTOR_SIZE),
-            header_updates: HashMap::new(),
         })
     }
 
     pub fn busy(&self) -> bool {
-        !self.sectors_being_updated.is_empty() || !self.queued_requests.is_empty()
+        !self.sector_updates.is_empty() || !self.queued_requests.is_empty()
     }
 
     pub fn set_stripe_fetched(&mut self, stripe_id: usize) {
@@ -105,63 +116,73 @@ impl MetadataFlusher {
         self.poll_channel();
     }
 
-    fn cleanup_failed_submission(&mut self, stripe_ids: &[usize], return_buffer: bool) {
-        for stripe_id in stripe_ids {
-            if let Some(status) = self.header_updates.remove(stripe_id) {
-                self.metadata.stripe_headers[status.stripe_id] &= !status.requested_bitmask;
+    fn cleanup_failed_submission(&mut self, sectors: &[u64], return_buffer: bool) {
+        for sector in sectors {
+            if let Some(status) = self.sector_updates.remove(sector) {
+                for update in &status.updates {
+                    self.metadata.stripe_headers[update.stripe_id] &= !update.requested_bitmask;
+                }
                 if return_buffer {
                     self.buffer_pool.return_buffer(&status.buffer);
                 }
-                self.sectors_being_updated.remove(&status.sector);
             }
         }
     }
 
     fn poll_channel(&mut self) {
-        let mut finished_stripes = Vec::new();
+        let mut finished_sectors = Vec::new();
         let mut newly_flushing = Vec::new();
 
-        for (stripe_id, success) in self.channel.poll() {
-            let maybe_status = self.header_updates.get_mut(&stripe_id);
-            match (maybe_status, success) {
-                (None, _) => {
-                    error!("Received unexpected response for stripe {stripe_id}");
+        for (id, success) in self.channel.poll() {
+            let sector = id as u64;
+            let Some(status) = self.sector_updates.get_mut(&sector) else {
+                error!("Received unexpected response for metadata sector {sector}");
+                continue;
+            };
+
+            if !success {
+                error!("Failed to write metadata sector {sector}");
+                // Revert only the specific flag bits we added, so a future
+                // retry for the same operations won't be skipped by the
+                // dedup check in start_writes.
+                for update in &status.updates {
+                    self.metadata.stripe_headers[update.stripe_id] &= !update.requested_bitmask;
                 }
-                (Some(status), false) => {
-                    error!("Failed to write metadata for stripe {stripe_id}");
-                    // Revert only the specific flag bit we added, so a future
-                    // retry for the same operation won't be skipped by the
-                    // dedup check in start_writes.
-                    self.metadata.stripe_headers[status.stripe_id] &= !status.requested_bitmask;
-                    // Only return the buffer if it hasn't already been returned.
-                    // On write success the buffer is returned before transitioning
-                    // to Flushing, so a subsequent flush failure must not return
-                    // it a second time.
-                    if status.stage == RequestStage::Writing {
-                        self.buffer_pool.return_buffer(&status.buffer);
-                    }
-                    self.sectors_being_updated.remove(&status.sector);
-                    self.header_updates.remove(&stripe_id);
+                // Only return the buffer if it hasn't already been returned.
+                // On write success the buffer is returned before transitioning
+                // to Flushing, so a subsequent flush failure must not return
+                // it a second time.
+                if status.stage == RequestStage::Writing {
+                    self.buffer_pool.return_buffer(&status.buffer);
                 }
-                (Some(status), true) => match status.stage {
-                    RequestStage::Writing => {
-                        self.buffer_pool.return_buffer(&status.buffer);
-                        self.channel.add_flush(stripe_id);
-                        status.stage = RequestStage::Flushing;
-                        newly_flushing.push(stripe_id);
-                    }
-                    RequestStage::Flushing => {
-                        self.sectors_being_updated.remove(&(status.sector));
-                        finished_stripes.push((status.stripe_id, status.header));
-                    }
-                },
+                self.sector_updates.remove(&sector);
+                continue;
+            }
+
+            match status.stage {
+                RequestStage::Writing => {
+                    self.buffer_pool.return_buffer(&status.buffer);
+                    self.channel.add_flush(id);
+                    status.stage = RequestStage::Flushing;
+                    newly_flushing.push(sector);
+                }
+                RequestStage::Flushing => {
+                    finished_sectors.push(sector);
+                }
             }
         }
 
-        for (stripe, header) in finished_stripes {
-            debug!("Stripe {stripe} metadata updated with header {header}");
-            self.header_updates.remove(&stripe);
-            self.shared_state.set_stripe_header(stripe, header);
+        for sector in finished_sectors {
+            if let Some(status) = self.sector_updates.remove(&sector) {
+                for update in status.updates {
+                    debug!(
+                        "Stripe {} metadata updated with header {}",
+                        update.stripe_id, update.header
+                    );
+                    self.shared_state
+                        .set_stripe_header(update.stripe_id, update.header);
+                }
+            }
         }
 
         if newly_flushing.is_empty() {
@@ -179,17 +200,21 @@ impl MetadataFlusher {
     }
 
     fn start_writes(&mut self) {
-        let mut newly_added = Vec::new();
+        let mut newly_added: Vec<u64> = Vec::new();
+        let mut deferred = VecDeque::new();
 
-        while !self.queued_requests.is_empty() && self.buffer_pool.has_available() {
-            let req = *self.queued_requests.front().unwrap();
-            let group = UbiMetadata::stripe_id_to_group(req.stripe_id);
+        while let Some(req) = self.queued_requests.pop_front() {
             let sector = UbiMetadata::stripe_id_to_sector(req.stripe_id);
-            if self.sectors_being_updated.contains(&sector) {
-                // Updates to each sector should be serialized
-                break;
+
+            // Updates to each sector are serialized: a request for a sector
+            // whose write is already in flight waits for the next round.
+            // It is looked at again once that write has completed, so it is
+            // dropped if the write made it redundant and retried if the
+            // write failed. Requests for other sectors are not held up.
+            if self.sector_updates.contains_key(&sector) && !newly_added.contains(&sector) {
+                deferred.push_back(req);
+                continue;
             }
-            self.queued_requests.pop_front();
 
             let requested_bitmask = match req.kind {
                 MetadataFlusherRequestKind::SetFetched => metadata_flags::FETCHED,
@@ -201,34 +226,50 @@ impl MetadataFlusher {
                 continue;
             }
 
-            let buf = self.buffer_pool.get_buffer().unwrap();
+            let status = match self.sector_updates.entry(sector) {
+                Entry::Occupied(entry) => entry.into_mut(),
+                Entry::Vacant(entry) => {
+                    let Some(buffer) = self.buffer_pool.get_buffer() else {
+                        deferred.push_back(req);
+                        continue;
+                    };
+                    newly_added.push(sector);
+                    entry.insert(SectorUpdateStatus {
+                        buffer,
+                        stage: RequestStage::Writing,
+                        group: UbiMetadata::stripe_id_to_group(req.stripe_id),
+                        updates: Vec::new(),
+                    })
+                }
+            };
+
             self.metadata.stripe_headers[req.stripe_id] |= requested_bitmask;
-
-            let headers_start = group * STRIPE_HEADERS_PER_SECTOR;
-            let headers_end =
-                (headers_start + STRIPE_HEADERS_PER_SECTOR).min(self.metadata.stripe_headers.len());
-            let headers = &self.metadata.stripe_headers[headers_start..headers_end];
-            write_sector_with_crc32(buf.borrow_mut().as_mut_slice(), headers);
-
-            self.channel
-                .add_write(sector, 1, buf.clone(), req.stripe_id);
-            self.sectors_being_updated.insert(sector);
-            self.header_updates.insert(
-                req.stripe_id,
-                HeaderUpdateStatus {
-                    buffer: buf,
-                    stage: RequestStage::Writing,
-                    stripe_id: req.stripe_id,
-                    header: self.metadata.stripe_headers[req.stripe_id],
-                    requested_bitmask,
-                    sector,
-                },
-            );
-            newly_added.push(req.stripe_id);
+            status.updates.push(HeaderUpdate {
+                stripe_id: req.stripe_id,
+                header: self.metadata.stripe_headers[req.stripe_id],
+                requested_bitmask,
+            });
         }
+        self.queued_requests = deferred;
 
         if newly_added.is_empty() {
             return;
+        }
+
+        // Every request for a sector has been applied to the in-memory
+        // headers, so one write of the sector carries all of them.
+        for sector in &newly_added {
+            let Some(status) = self.sector_updates.get(sector) else {
+                continue;
+            };
+            let headers_start = status.group * STRIPE_HEADERS_PER_SECTOR;
+            let headers_end =
+                (headers_start + STRIPE_HEADERS_PER_SECTOR).min(self.metadata.stripe_headers.len());
+            let headers = &self.metadata.stripe_headers[headers_start..headers_end];
+            write_sector_with_crc32(status.buffer.borrow_mut().as_mut_slice(), headers);
+
+            self.channel
+                .add_write(*sector, 1, status.buffer.clone(), *sector as usize);
         }
 
         // submit writes, if any
@@ -249,8 +290,12 @@ mod tests {
     use super::*;
 
     fn init_metadata_device() -> TestBlockDevice {
-        let metadata = UbiMetadata::new(11, 16, 16);
-        let block_device = TestBlockDevice::new(8 * 1024);
+        init_metadata_device_with_stripes(16)
+    }
+
+    fn init_metadata_device_with_stripes(stripe_count: usize) -> TestBlockDevice {
+        let metadata = UbiMetadata::new(11, stripe_count, stripe_count);
+        let block_device = TestBlockDevice::new(64 * 1024);
         metadata.save_to_bdev(&block_device).unwrap();
         block_device
     }
@@ -438,9 +483,11 @@ mod tests {
         assert!(shared_state.stripe_written(3));
         assert!(shared_state.stripe_fetched(3));
 
+        // Every request was for one stripe in one sector, so one write and
+        // one flush carried all of them.
         let metrics = metadata_dev.metrics.read().unwrap();
-        assert_eq!(metrics.writes - start_writes, 2);
-        assert_eq!(metrics.flushes - start_flushes, 2);
+        assert_eq!(metrics.writes - start_writes, 1);
+        assert_eq!(metrics.flushes - start_flushes, 1);
     }
 
     #[test]
@@ -576,5 +623,155 @@ mod tests {
 
         // Now it should succeed
         assert!(shared_state.stripe_fetched(5));
+    }
+
+    #[test]
+    fn test_same_sector_updates_share_one_write_and_flush() {
+        let metadata_dev = init_metadata_device();
+        let shared_state = {
+            let metadata = UbiMetadata::load_from_bdev(&metadata_dev).expect("load metadata");
+            SharedMetadataState::new(&metadata)
+        };
+        let mut metadata_flusher =
+            MetadataFlusher::new(&metadata_dev, 8 * 1024, shared_state.clone()).unwrap();
+        let (start_writes, start_flushes) = {
+            let metrics = metadata_dev.metrics.read().unwrap();
+            (metrics.writes, metrics.flushes)
+        };
+
+        // Stripes 0-7 are in sector 1. Queued together, they go out as one
+        // sector write and one flush rather than one of each per stripe.
+        for stripe_id in 0..8 {
+            metadata_flusher.set_stripe_fetched(stripe_id);
+        }
+        metadata_flusher.set_stripe_written(3);
+
+        wait_for_completion(&mut metadata_flusher);
+
+        for stripe_id in 0..8 {
+            assert!(shared_state.stripe_fetched(stripe_id));
+        }
+        assert!(shared_state.stripe_written(3));
+        assert!(!shared_state.stripe_written(4));
+
+        let metrics = metadata_dev.metrics.read().unwrap();
+        assert_eq!(metrics.writes - start_writes, 1);
+        assert_eq!(metrics.flushes - start_flushes, 1);
+    }
+
+    #[test]
+    fn test_requests_behind_a_busy_sector_share_its_next_write() {
+        let metadata_dev = init_metadata_device();
+        let shared_state = {
+            let metadata = UbiMetadata::load_from_bdev(&metadata_dev).expect("load metadata");
+            SharedMetadataState::new(&metadata)
+        };
+        let mut metadata_flusher =
+            MetadataFlusher::new(&metadata_dev, 8 * 1024, shared_state.clone()).unwrap();
+        let (start_writes, start_flushes) = {
+            let metrics = metadata_dev.metrics.read().unwrap();
+            (metrics.writes, metrics.flushes)
+        };
+
+        // Start a write for sector 1 and leave it in flight.
+        metadata_flusher.set_stripe_fetched(0);
+        metadata_flusher.start_writes();
+        assert_eq!(
+            metadata_dev.metrics.read().unwrap().writes - start_writes,
+            1
+        );
+
+        // Requests for the same sector that arrive meanwhile wait for it...
+        for stripe_id in 1..4 {
+            metadata_flusher.set_stripe_fetched(stripe_id);
+        }
+        metadata_flusher.start_writes();
+        assert_eq!(
+            metadata_dev.metrics.read().unwrap().writes - start_writes,
+            1
+        );
+        assert_eq!(metadata_flusher.queued_requests.len(), 3);
+
+        // ...and then all share the next write.
+        wait_for_completion(&mut metadata_flusher);
+        for stripe_id in 0..4 {
+            assert!(shared_state.stripe_fetched(stripe_id));
+        }
+        let metrics = metadata_dev.metrics.read().unwrap();
+        assert_eq!(metrics.writes - start_writes, 2);
+        assert_eq!(metrics.flushes - start_flushes, 2);
+    }
+
+    #[test]
+    fn test_busy_sector_does_not_hold_up_other_sectors() {
+        // 1024 stripes span three header sectors: stripe 0 is in sector 1,
+        // stripe 600 in sector 2.
+        let metadata_dev = init_metadata_device_with_stripes(1024);
+        let shared_state = {
+            let metadata = UbiMetadata::load_from_bdev(&metadata_dev).expect("load metadata");
+            SharedMetadataState::new(&metadata)
+        };
+        let mut metadata_flusher =
+            MetadataFlusher::new(&metadata_dev, 8 * 1024, shared_state.clone()).unwrap();
+        let start_writes = metadata_dev.metrics.read().unwrap().writes;
+
+        metadata_flusher.set_stripe_fetched(0);
+        metadata_flusher.start_writes();
+        assert_eq!(
+            metadata_dev.metrics.read().unwrap().writes - start_writes,
+            1
+        );
+
+        // Stripe 1 shares the in-flight sector and has to wait; stripe 600
+        // does not and must not be held up behind it.
+        metadata_flusher.set_stripe_fetched(1);
+        metadata_flusher.set_stripe_fetched(600);
+        metadata_flusher.start_writes();
+        assert_eq!(
+            metadata_dev.metrics.read().unwrap().writes - start_writes,
+            2
+        );
+        assert_eq!(metadata_flusher.queued_requests.len(), 1);
+        assert_eq!(metadata_flusher.queued_requests[0].stripe_id, 1);
+
+        wait_for_completion(&mut metadata_flusher);
+        for stripe_id in [0, 1, 600] {
+            assert!(shared_state.stripe_fetched(stripe_id));
+        }
+        assert_eq!(
+            metadata_dev.metrics.read().unwrap().writes - start_writes,
+            3
+        );
+    }
+
+    #[test]
+    fn test_write_failure_reverts_every_stripe_in_the_sector() {
+        let metadata_dev = init_metadata_device();
+        let shared_state = {
+            let metadata = UbiMetadata::load_from_bdev(&metadata_dev).expect("load metadata");
+            SharedMetadataState::new(&metadata)
+        };
+        let mut metadata_flusher =
+            MetadataFlusher::new(&metadata_dev, 8 * 1024, shared_state.clone()).unwrap();
+
+        // Two stripes share one failing sector write.
+        metadata_flusher.set_stripe_fetched(1);
+        metadata_flusher.set_stripe_written(2);
+        metadata_dev
+            .fail_next
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        metadata_flusher.update();
+
+        assert!(!shared_state.stripe_fetched(1));
+        assert!(!shared_state.stripe_written(2));
+        assert!(!metadata_flusher.busy());
+
+        // Neither bit was left set in memory, so both retries go through.
+        metadata_flusher.set_stripe_fetched(1);
+        metadata_flusher.set_stripe_written(2);
+        wait_for_completion(&mut metadata_flusher);
+
+        assert!(shared_state.stripe_fetched(1));
+        assert!(shared_state.stripe_written(2));
     }
 }

--- a/src/block_device/bdev_lazy/stripe_fetcher.rs
+++ b/src/block_device/bdev_lazy/stripe_fetcher.rs
@@ -306,6 +306,7 @@ mod tests {
     use super::*;
     use crate::block_device::bdev_test::TestBlockDevice;
     use crate::stripe_source::BlockDeviceStripeSource;
+    use std::{cell::RefCell, rc::Rc};
 
     struct TestState {
         source_dev: Box<TestBlockDevice>,
@@ -537,5 +538,152 @@ mod tests {
         state.fetcher.disconnect_from_source_if_all_fetched();
         assert_eq!(state.fetcher.stripe_source.sector_count(), 0);
         assert!(state.fetcher.disconnected);
+    }
+
+    #[test]
+    fn test_queued_fetches_are_issued_together() {
+        let mut state = prep(false);
+        // More requests than the fetcher has buffers for.
+        let requested = MAX_CONCURRENT_FETCHES + 4;
+        for stripe_id in 0..requested {
+            state.fetcher.handle_fetch_request(stripe_id);
+        }
+
+        // One pass hands the source every queued fetch the buffer pool can
+        // hold, not one per pass.
+        state.fetcher.update();
+        assert_eq!(
+            state.source_dev.metrics.read().unwrap().reads,
+            MAX_CONCURRENT_FETCHES
+        );
+        assert_eq!(state.fetcher.fetch_queue.len(), 4);
+
+        // The rest follow as buffers come back.
+        for _ in 0..10 {
+            state.fetcher.update();
+        }
+        let mut finished = state.fetcher.take_finished_fetches();
+        assert_eq!(finished.len(), requested);
+        finished.sort_by_key(|(stripe_id, _)| *stripe_id);
+        for (idx, (stripe_id, success)) in finished.iter().enumerate() {
+            assert_eq!(*stripe_id, idx);
+            assert!(success);
+        }
+        assert_eq!(state.source_dev.metrics.read().unwrap().reads, requested);
+        assert_eq!(state.target_dev.metrics.read().unwrap().writes, requested);
+    }
+
+    /// A source that completes a fetch only when the test says so, in the
+    /// order the test chooses.
+    #[derive(Default)]
+    struct ManualSourceState {
+        pending: Vec<(usize, SharedBuffer)>,
+        completed: Vec<(usize, bool)>,
+    }
+
+    impl ManualSourceState {
+        fn complete(&mut self, stripe_id: usize) {
+            let idx = self
+                .pending
+                .iter()
+                .position(|(id, _)| *id == stripe_id)
+                .expect("stripe was requested");
+            let (_, buffer) = self.pending.remove(idx);
+            buffer
+                .borrow_mut()
+                .as_mut_slice()
+                .fill((stripe_id + 1) as u8);
+            self.completed.push((stripe_id, true));
+        }
+    }
+
+    struct ManualStripeSource {
+        state: Rc<RefCell<ManualSourceState>>,
+        sector_count: u64,
+    }
+
+    impl StripeSource for ManualStripeSource {
+        fn request(&mut self, stripe_id: usize, buffer: SharedBuffer) -> Result<()> {
+            self.state.borrow_mut().pending.push((stripe_id, buffer));
+            Ok(())
+        }
+
+        fn poll(&mut self) -> Vec<(usize, bool)> {
+            std::mem::take(&mut self.state.borrow_mut().completed)
+        }
+
+        fn busy(&self) -> bool {
+            let state = self.state.borrow();
+            !state.pending.is_empty() || !state.completed.is_empty()
+        }
+
+        fn sector_count(&self) -> u64 {
+            self.sector_count
+        }
+
+        fn has_stripe(&self, _stripe_id: usize) -> bool {
+            true
+        }
+    }
+
+    #[test]
+    fn test_fetches_finish_in_the_order_the_source_completes_them() {
+        let stripe_sector_count_shift = 3;
+        let stripe_sector_count = 1u64 << stripe_sector_count_shift;
+        let stripe_size = stripe_sector_count as usize * SECTOR_SIZE;
+        let target_dev = TestBlockDevice::new(1024 * 1024);
+        let source_state = Rc::new(RefCell::new(ManualSourceState::default()));
+        let stripe_source = Box::new(ManualStripeSource {
+            state: source_state.clone(),
+            sector_count: target_dev.sector_count(),
+        });
+        let stripe_count = target_dev.stripe_count(stripe_sector_count);
+        let metadata = UbiMetadata::new(stripe_sector_count_shift, stripe_count, stripe_count);
+        let mut fetcher = StripeFetcher::new(
+            stripe_source,
+            &target_dev,
+            stripe_sector_count,
+            SharedMetadataState::new(&metadata),
+            SECTOR_SIZE,
+            false,
+        )
+        .unwrap();
+
+        for stripe_id in [0, 1, 2] {
+            fetcher.handle_fetch_request(stripe_id);
+        }
+        fetcher.update();
+        // All three are outstanding at the source at once.
+        assert_eq!(source_state.borrow().pending.len(), 3);
+        assert!(fetcher.take_finished_fetches().is_empty());
+
+        // The last one asked for comes back first. It alone is written,
+        // flushed and reported; the others are still waiting on the source.
+        source_state.borrow_mut().complete(2);
+        for _ in 0..3 {
+            fetcher.update();
+        }
+        assert_eq!(fetcher.take_finished_fetches(), vec![(2, true)]);
+        assert_eq!(target_dev.metrics.read().unwrap().writes, 1);
+        assert_eq!(target_dev.metrics.read().unwrap().flushes, 1);
+        let mut stripe = vec![0u8; stripe_size];
+        target_dev.read(2 * stripe_size, &mut stripe, stripe_size);
+        assert!(stripe.iter().all(|byte| *byte == 3));
+        target_dev.read(0, &mut stripe, stripe_size);
+        assert!(stripe.iter().all(|byte| *byte == 0));
+
+        source_state.borrow_mut().complete(0);
+        for _ in 0..3 {
+            fetcher.update();
+        }
+        assert_eq!(fetcher.take_finished_fetches(), vec![(0, true)]);
+
+        source_state.borrow_mut().complete(1);
+        for _ in 0..3 {
+            fetcher.update();
+        }
+        assert_eq!(fetcher.take_finished_fetches(), vec![(1, true)]);
+        assert!(!fetcher.busy());
+        assert_eq!(target_dev.metrics.read().unwrap().writes, 3);
     }
 }


### PR DESCRIPTION
This is a draft. The fix is complete and tested, but the after-fix measurement on the same EC2 setup as the numbers below is still pending. I will add the demand-fetch throughput after the change (MiB/s and per-stripe latency under the same random 8 KiB read load at QD1 and QD16) to this description before marking it ready.

## What happens today

A stripe fetched on demand becomes readable by the guest only once its FETCHED header is durable, and the metadata flusher wrote those headers one at a time. `start_writes` allowed one write per metadata sector to be in flight and stopped at the first queued request whose sector was busy, so nothing behind it was looked at either. A metadata sector holds the headers of 508 consecutive stripes, half a gigabyte of the device at 1 MiB stripes, so every stripe a guest touches in a burst shares a sector with the others and each one paid its own 4 KiB write plus fsync round trip, strictly after the previous one.

The rest of the path was already parallel: the fetcher hands the source every queued stripe up to its 16 buffers, a remote source runs one fetch per connection, and each stripe's write and flush to the local device are submitted as its data arrives. Measured on EC2 against a remote source over 32 connections with 1 MiB stripes, the background sweep moved 117 MiB/s while demand fetches from a guest doing random 8 KiB reads ran at about one stripe per 13 ms, 19 MiB/s, whether the guest had one read or sixteen outstanding. A serial stage of one header write and fsync per stripe behind a parallel fetch has exactly that shape.

## What the fix does

The flusher now keys in-flight work by sector rather than by stripe. One sector write carries every request for that sector that is queued when it starts, one entry per request so a stripe's FETCHED and WRITTEN updates still apply in order, and reports all of them when the one fsync completes. Requests for a sector whose write is already in flight wait for the next write of that sector and share it; they are examined again once it completes, so one made redundant by it is dropped and one whose write failed is retried, as before. Requests for other sectors are no longer held up behind a busy one.

Failure handling is the same in kind: a failed write or flush reverts the bits of every stripe in that sector write, and a failed submit is cleaned up the same way. When a stripe is marked fetched does not change: the fetcher still reports a stripe only after its data is written and flushed to the local device, the header write still follows that, and the fetcher's check that a stripe is never requested twice at once is untouched.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and the full test suite (479 tests) pass.

New tests in `metadata_flusher.rs`:

- `test_same_sector_updates_share_one_write_and_flush`: eight same-sector stripes share one write and one flush.
- `test_requests_behind_a_busy_sector_share_its_next_write`: requests that queue behind an in-flight sector share its next write.
- `test_busy_sector_does_not_hold_up_other_sectors`: a second sector proceeds while the first is busy.
- `test_write_failure_reverts_every_stripe_in_the_sector`: a failed sector write reverts every stripe in it.
- `test_metadata_flusher_coalesces_duplicate_requests` (existing) now expects one write and one flush instead of two.

In `bgworker.rs`, `bg_worker_marks_a_batch_of_fetches_with_one_header_write` drives eight fetches through the whole path and checks that marking them all took one metadata write and one flush.

In `stripe_fetcher.rs`, two tests pin the behaviour the fix relies on: `test_queued_fetches_are_issued_together` (a batch of queued fetches goes to the source in one pass, bounded by the buffer pool) and `test_fetches_finish_in_the_order_the_source_completes_them` (with a source that completes out of order, each stripe is written, flushed and reported on its own completion).

All six tests that concern the change were run against the old flusher and fail there.

## What to look at

The whole behavioural change is in `metadata_flusher.rs`, in `start_writes` and `poll_channel`. Worth checking:

- The deferred-request path in `start_writes`: a request whose sector is in flight goes back on the queue and is re-examined after that write completes. This is what preserves the retry-after-failure and drop-if-redundant behaviour of the old code.
- The per-stripe revert in the failure branch of `poll_channel` and in `cleanup_failed_submission`.
- The completion id on the metadata channel is now the sector number rather than a stripe id.

## Risks and things left alone

- The diagnosis is from the code plus the shape of the before-measurement. If the header write plus fsync round trip is not the dominant per-stripe cost on the target volume, the gain will be smaller than the analysis predicts. The pending measurement settles this.
- Header updates for different metadata sectors can now complete out of arrival order (previously strict FIFO). Same-stripe ordering is preserved, and I found no consumer that depends on cross-stripe ordering; the shared state is per-stripe atomics.
- A failed sector write now reverts and drops every request that shared it rather than one. A failed header write was already not retried on its own (the stripe sat unmarked until re-requested), so this widens that existing window from one stripe to a batch. The new test confirms the in-memory bits are reverted so re-requests go through.
- Deliberately unchanged: the fetcher's `MAX_CONCURRENT_FETCHES` of 16 still caps in-flight fetches below a larger connection pool, and each fetched stripe still gets its own fsync before being reported. Both are candidates for a follow-up once the after-measurement says whether they matter.
- `test_request_serialization` kept its name although it now exercises coalescing, to keep the diff small.
