### PR TITLE
Cover ublk in CI

### DIFF
--- a/.github/workflows/ublk.yaml
+++ b/.github/workflows/ublk.yaml
@@ -1,0 +1,51 @@
+name: ublk
+
+# Brings up a real ublk device and moves data through it. The unit tests never
+# reach a kernel and blkbench drives the vhost backend, so without this a change
+# that stops ublk devices being created at all goes green everywhere else.
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+env:
+  ISA_L_CRYPTO_VERSION: "v2.25.0"
+
+jobs:
+  ublk:
+    runs-on: ubicloud-standard-4
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y autoconf libtool nasm clang build-essential \
+            "linux-modules-extra-$(uname -r)"
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust (registry, git deps, target/)
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ runner.os }}-x86_64-stable-ublk
+          cache-on-failure: true
+
+      - name: Install prebuilt isa-l_crypto
+        run: |
+          set -euo pipefail
+          archive="isa-l_crypto-${ISA_L_CRYPTO_VERSION}-x86_64.tar.gz"
+          url="https://github.com/ubicloud/ubiblk/releases/download/prebuilt-ci-deps/${archive}"
+          curl -fL -o "${archive}" "${url}"
+          sudo tar -xzf "${archive}" -C /
+
+      - name: Build
+        run: cargo build --bin ublk-backend --bin init-metadata
+
+      - name: Run the ublk tests
+        run: python3 tests/ublk/run_all.py

--- a/tests/ublk/README.md
+++ b/tests/ublk/README.md
@@ -1,0 +1,36 @@
+# ublk tests
+
+End-to-end tests that bring up a **real** ublk device over a ubiblk backend and
+move data through it. They are written in Python and drive the `ublk-backend`
+and `init-metadata` binaries — nothing here is a Rust `cargo test`.
+
+They exist because nothing else covers this path: the unit tests never reach a
+kernel, and the blkbench suite drives the vhost-user backend. A change that
+stops ublk devices being created at all is otherwise green everywhere.
+
+## What is covered
+
+| Case | What it checks |
+|------|----------------|
+| `device_appears_with_the_right_size` | A device is created and the kernel reports the size it was configured with. |
+| `data_reads_back_as_written` | 64 MiB written through the device reads back unchanged. |
+| `shutdown_removes_the_device` | SIGINT takes the device node and its symlink away rather than leaving a node nothing serves. |
+
+## Files
+
+- `run_all.py` — launcher. Checks the binaries and the driver, runs the cases,
+  and removes the scratch directory on exit (pass, fail, or cancel).
+- `cases.py` — the cases and their `Device` fixture (config via
+  `scripts/ubiblk-init`, backend lifecycle, read/write helpers).
+
+## Running locally
+
+Needs root for the ublk control device (the tests use `sudo`) and a kernel with
+`ublk_drv`.
+
+```sh
+cargo build --bin ublk-backend --bin init-metadata
+python3 tests/ublk/run_all.py
+```
+
+Override the backend under test with `UBLK_BACKEND_BIN`.

--- a/tests/ublk/cases.py
+++ b/tests/ublk/cases.py
@@ -1,0 +1,194 @@
+"""ublk test cases, in Python.
+
+Brings up a real ublk device over a ubiblk backend and exercises it end to end.
+Normally run via run_all.py, which checks the binaries and the driver first.
+Each case gets its own device, so one that leaves the kernel unhappy cannot
+quietly break the next.
+
+Binaries default to target/debug; override with UBLK_BACKEND_BIN.
+"""
+
+import contextlib
+import hashlib
+import os
+import pathlib
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "common"))
+
+from util import r
+from harness import Suite
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+BIN_DIR = ROOT / "target" / "debug"
+BACKEND = os.environ.get("UBLK_BACKEND_BIN", str(BIN_DIR / "ublk-backend"))
+
+DEVICE_MB = 64
+DEVICE_TIMEOUT = 60
+SHUTDOWN_TIMEOUT = 30
+
+
+class Device:
+    """A ubiblk-backed ublk device, for the lifetime of a `with` block."""
+
+    def __init__(self, work):
+        self.work = work
+        self.log = work / "backend.log"
+        self.symlink = work / "dev"
+        self.node = None
+        self.backend = None
+
+    def __enter__(self):
+        self.work.mkdir(parents=True, exist_ok=True)
+        env = dict(os.environ, PATH=f"{BIN_DIR}:{os.environ['PATH']}")
+        r(
+            "python3",
+            str(ROOT / "scripts" / "ubiblk-init"),
+            "--size",
+            f"{DEVICE_MB}M",
+            "--dir",
+            str(self.work),
+            "--force",
+            env=env,
+        )
+        self.backend = subprocess.Popen(
+            ["sudo", BACKEND, "--config", str(self.work / "config.toml"),
+             "--device-symlink", str(self.symlink)],
+            stdout=self.log.open("w"),
+            stderr=subprocess.STDOUT,
+        )
+        self.node = self._wait_for_node()
+        return self
+
+    def __exit__(self, *_):
+        self.stop()
+        return False
+
+    def _wait_for_node(self):
+        deadline = time.monotonic() + DEVICE_TIMEOUT
+        while time.monotonic() < deadline:
+            if self.symlink.exists():
+                return self.symlink.resolve()
+            if not self.alive():
+                raise AssertionError(
+                    f"the backend exited before the device appeared\n{self.tail()}"
+                )
+            time.sleep(0.2)
+        raise AssertionError(f"no device after {DEVICE_TIMEOUT}s\n{self.tail()}")
+
+    def alive(self):
+        """True while the backend is running. It runs under sudo, so a plain
+        kill -0 from this user reports "gone" rather than the truth."""
+        if self.backend.poll() is not None:
+            return False
+        return subprocess.run(
+            ["sudo", "kill", "-0", str(self.backend.pid)],
+            capture_output=True,
+        ).returncode == 0
+
+    def interrupt(self):
+        subprocess.run(["sudo", "kill", "-INT", str(self.backend.pid)], capture_output=True)
+
+    def stop(self):
+        if self.backend is None or self.backend.poll() is not None:
+            return
+        self.interrupt()
+        deadline = time.monotonic() + SHUTDOWN_TIMEOUT
+        while time.monotonic() < deadline and self.alive():
+            time.sleep(0.2)
+        if self.alive():
+            subprocess.run(["sudo", "kill", "-9", str(self.backend.pid)], capture_output=True)
+        with contextlib.suppress(Exception):
+            self.backend.wait(timeout=5)
+
+    def size(self):
+        return int(r("sudo", "blockdev", "--getsize64", str(self.node)).strip())
+
+    def write(self, path, megabytes):
+        r("sudo", "dd", f"if={path}", f"of={self.node}", "bs=1M",
+          f"count={megabytes}", "oflag=direct", "status=none")
+
+    def read_digest(self, megabytes):
+        out = subprocess.run(
+            ["sudo", "dd", f"if={self.node}", "bs=1M", f"count={megabytes}",
+             "iflag=direct", "status=none"],
+            capture_output=True,
+        )
+        if out.returncode != 0:
+            raise AssertionError(f"read failed: {out.stderr.decode(errors='replace')}")
+        return hashlib.md5(out.stdout).hexdigest()
+
+    def tail(self, lines=30):
+        if not self.log.exists():
+            return "(no backend log)"
+        return "--- backend log ---\n" + "\n".join(
+            self.log.read_text(errors="replace").splitlines()[-lines:]
+        )
+
+
+def case_device_appears_with_the_right_size(suite):
+    name = "device_appears_with_the_right_size"
+    expected = DEVICE_MB * 1024 * 1024
+    with suite.device(name) as device:
+        size = device.size()
+    if size == expected:
+        suite.ok(name)
+    else:
+        suite.notok(name, f"device is {size} bytes, expected {expected}")
+
+
+def case_data_reads_back_as_written(suite):
+    name = "data_reads_back_as_written"
+    with suite.device(name) as device:
+        pattern = device.work / "pattern"
+        pattern.write_bytes(os.urandom(DEVICE_MB * 1024 * 1024))
+        device.write(pattern, DEVICE_MB)
+        want = hashlib.md5(pattern.read_bytes()).hexdigest()
+        got = device.read_digest(DEVICE_MB)
+    if want == got:
+        suite.ok(name)
+    else:
+        suite.notok(name, "what came back is not what went in")
+
+
+def case_shutdown_removes_the_device(suite):
+    name = "shutdown_removes_the_device"
+    with suite.device(name) as device:
+        node, symlink = device.node, device.symlink
+        device.interrupt()
+        deadline = time.monotonic() + SHUTDOWN_TIMEOUT
+        while time.monotonic() < deadline and device.alive():
+            time.sleep(0.2)
+        if device.alive():
+            reason = "the backend did not exit on SIGINT"
+        elif node.exists():
+            reason = f"{node} is still there"
+        elif symlink.exists():
+            reason = "the device symlink was left behind"
+        else:
+            reason = None
+    if reason is None:
+        suite.ok(name)
+    else:
+        suite.notok(name, reason)
+
+
+class Cases(Suite):
+    def __init__(self):
+        super().__init__()
+        self.work = ROOT / "target" / "tests" / "ublk"
+
+    def device(self, name):
+        return Device(self.work / name)
+
+    CASES = [
+        case_device_appears_with_the_right_size,
+        case_data_reads_back_as_written,
+        case_shutdown_removes_the_device,
+    ]
+
+
+if __name__ == "__main__":
+    sys.exit(Cases().run())

--- a/tests/ublk/run_all.py
+++ b/tests/ublk/run_all.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Run the ublk tests (cases.py) against a real ublk device.
+
+Checks the ubiblk binaries are built and the ublk driver is loadable, then runs
+the cases and removes the scratch directory afterwards, whether they pass, fail,
+or the run is cancelled.
+
+    cargo build --bin ublk-backend --bin init-metadata
+    python3 tests/ublk/run_all.py
+
+Needs root for the ublk control device (it uses sudo), and a kernel with
+ublk_drv. Override the backend with UBLK_BACKEND_BIN.
+"""
+
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "common"))
+
+from harness import install_exit_handler
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+WORK = ROOT / "target" / "tests" / "ublk"
+
+
+def check_binaries():
+    bin_dir = ROOT / "target" / "debug"
+    required = [
+        os.environ.get("UBLK_BACKEND_BIN", str(bin_dir / "ublk-backend")),
+        str(bin_dir / "init-metadata"),
+    ]
+    missing = [path for path in required if not os.path.exists(path)]
+    if missing:
+        sys.exit(
+            "missing binaries: " + ", ".join(missing) + "\n"
+            "build them first: cargo build --bin ublk-backend --bin init-metadata"
+        )
+
+
+def check_driver():
+    if subprocess.run(["sudo", "modprobe", "ublk_drv"], capture_output=True).returncode != 0:
+        sys.exit("ublk_drv could not be loaded; these tests need a kernel with ublk")
+    if not os.path.exists("/dev/ublk-control"):
+        sys.exit("/dev/ublk-control is missing after loading ublk_drv")
+
+
+def main():
+    check_binaries()
+    check_driver()
+
+    shutil.rmtree(WORK, ignore_errors=True)
+    install_exit_handler(lambda: shutil.rmtree(WORK, ignore_errors=True))
+
+    sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+    from cases import Cases
+
+    return Cases().run()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Nothing in CI exercises ublk: the unit tests never reach a kernel and blkbench drives the vhost backend. A change that stops ublk devices being created at all passes every check we have, which is how the breakage currently on main got there.