### PR TITLE
Separate the background worker from what it works on

### DIFF
--- a/src/backends/common/mod.rs
+++ b/src/backends/common/mod.rs
@@ -13,8 +13,8 @@ use ubiblk_macros::error_context;
 
 use crate::{
     block_device::{
-        self, BgWorker, BgWorkerRequest, BlockDevice, SharedMetadataState, StatusReporter,
-        SyncBlockDevice, UbiMetadata, UringBlockDevice,
+        self, BgQueues, BgSender, BgWorker, BgWorkerRequest, BlockDevice, LazyTask,
+        SharedMetadataState, StatusReporter, SyncBlockDevice, UbiMetadata, UringBlockDevice,
     },
     config::v2,
     stripe_source::StripeSourceBuilder,
@@ -39,8 +39,8 @@ struct BgWorkerConfig {
 
 pub struct BackendEnv {
     bdev: Box<dyn BlockDevice>,
-    bgworker_config: Option<BgWorkerConfig>,
-    bgworker_sender: Option<Sender<BgWorkerRequest>>,
+    bgworker: Option<(BgQueues, BgWorkerConfig)>,
+    bgworker_sender: Option<BgSender<BgWorkerRequest>>,
     bgworker_thread: Option<std::thread::JoinHandle<()>>,
     alignment: usize,
     config: v2::Config,
@@ -67,7 +67,7 @@ impl BackendEnv {
         match metadata_device {
             None => Ok(BackendEnv {
                 bdev: disk_device,
-                bgworker_config: None,
+                bgworker: None,
                 bgworker_sender: None,
                 bgworker_thread: None,
                 alignment,
@@ -83,9 +83,10 @@ impl BackendEnv {
 
     #[error_context("Failed to run bgworker thread")]
     pub fn run_bgworker_thread(&mut self) -> Result<()> {
-        if let Some(config) = self.bgworker_config.take() {
+        if let Some((queues, config)) = self.bgworker.take() {
             let (startup_sender, startup_receiver) = channel();
-            self.bgworker_thread = Some(Self::spawn_bgworker_thread(config, startup_sender)?);
+            self.bgworker_thread =
+                Some(Self::spawn_bgworker_thread(queues, config, startup_sender)?);
 
             let startup_status = startup_receiver.recv().map_err(|e| {
                 crate::ubiblk_error!(ChannelError {
@@ -142,7 +143,8 @@ impl BackendEnv {
         let shared_state = SharedMetadataState::new(&metadata);
         let status_reporter = StatusReporter::new(shared_state.clone(), disk_device.sector_count());
 
-        let (bgworker_sender, bgworker_receiver) = channel();
+        let queues = BgQueues::new();
+        let (bgworker_sender, bgworker_receiver) = queues.queue();
 
         let bdev_lazy = Self::build_bdev_lazy(
             disk_device.clone(),
@@ -172,7 +174,7 @@ impl BackendEnv {
 
         Ok(BackendEnv {
             bdev: bdev_lazy,
-            bgworker_config: Some(bgworker_config),
+            bgworker: Some((queues, bgworker_config)),
             bgworker_sender: Some(bgworker_sender),
             bgworker_thread: None,
             alignment,
@@ -197,7 +199,7 @@ impl BackendEnv {
     fn build_bdev_lazy(
         disk_device: Box<dyn BlockDevice>,
         config: &v2::Config,
-        bgworker_sender: Sender<BgWorkerRequest>,
+        bgworker_sender: BgSender<BgWorkerRequest>,
         shared_state: SharedMetadataState,
     ) -> Result<Box<dyn BlockDevice>> {
         let raw_image_device = if config
@@ -228,24 +230,28 @@ impl BackendEnv {
     }
 
     fn spawn_bgworker_thread(
+        queues: BgQueues,
         config: BgWorkerConfig,
         startup_sender: Sender<Result<()>>,
     ) -> Result<std::thread::JoinHandle<()>> {
         std::thread::Builder::new()
             .name("bgworker".to_string())
-            .spawn(move || match Self::build_bgworker(config) {
-                Ok(mut worker) => {
-                    if let Err(send_err) = startup_sender.send(Ok(())) {
-                        error!("Failed to send bgworker startup success: {send_err}");
-                    } else {
-                        info!("Bgworker thread started successfully");
-                        worker.run();
+            .spawn(move || {
+                let mut worker = BgWorker::new(queues);
+                match Self::add_lazy_task(&mut worker, config) {
+                    Ok(()) => {
+                        if let Err(send_err) = startup_sender.send(Ok(())) {
+                            error!("Failed to send bgworker startup success: {send_err}");
+                        } else {
+                            info!("Bgworker thread started successfully");
+                            worker.run();
+                        }
                     }
-                }
-                Err(e) => {
-                    let startup_result = Err(e).context("Failed to build bgworker");
-                    if let Err(send_err) = startup_sender.send(startup_result) {
-                        error!("Failed to send bgworker startup error to main thread: {send_err}. Original error: {:?}", send_err.0);
+                    Err(e) => {
+                        let startup_result = Err(e).context("Failed to build bgworker task");
+                        if let Err(send_err) = startup_sender.send(startup_result) {
+                            error!("Failed to send bgworker startup error to main thread: {send_err}. Original error: {:?}", send_err.0);
+                        }
                     }
                 }
             })
@@ -255,7 +261,7 @@ impl BackendEnv {
             })
     }
 
-    fn build_bgworker(config: BgWorkerConfig) -> Result<BgWorker> {
+    fn add_lazy_task(worker: &mut BgWorker, config: BgWorkerConfig) -> Result<()> {
         let BgWorkerConfig {
             target_dev,
             stripe_source_builder,
@@ -274,15 +280,16 @@ impl BackendEnv {
             }
         };
 
-        BgWorker::new(
+        let task = LazyTask::new(
             stripe_source,
             &*target_dev,
             &*metadata_dev,
             alignment,
             autofetch,
             shared_state,
-            receiver,
-        )
+        )?;
+        worker.add(task, receiver);
+        Ok(())
     }
 }
 
@@ -666,7 +673,7 @@ mod tests {
         );
     }
 
-    fn build_test_bgworker_config() -> (BgWorkerConfig, Sender<BgWorkerRequest>) {
+    fn build_test_bgworker_config() -> (BgQueues, BgWorkerConfig, BgSender<BgWorkerRequest>) {
         let stripe_sector_count_shift = 11;
         let target_dev = TestBlockDevice::new(1024 * 1024);
         let metadata_dev = TestBlockDevice::new(1024 * 1024);
@@ -679,9 +686,11 @@ mod tests {
             shared_state.stripe_sector_count(),
             loaded_metadata.has_fetched_all_stripes(),
         ));
-        let (sender, receiver) = channel();
+        let queues = BgQueues::new();
+        let (sender, receiver) = queues.queue();
 
         (
+            queues,
             BgWorkerConfig {
                 target_dev: Box::new(target_dev),
                 stripe_source_builder,
@@ -697,17 +706,18 @@ mod tests {
 
     #[test]
     fn run_bgworker_handles_shutdown_request() {
-        let (config, sender) = build_test_bgworker_config();
+        let (queues, config, sender) = build_test_bgworker_config();
         sender.send(BgWorkerRequest::Shutdown).unwrap();
-        let mut worker = BackendEnv::build_bgworker(config).unwrap();
+        let mut worker = BgWorker::new(queues);
+        BackendEnv::add_lazy_task(&mut worker, config).unwrap();
         worker.run();
     }
 
     #[test]
     fn spawn_bgworker_thread_runs_and_joins() {
-        let (config, sender) = build_test_bgworker_config();
+        let (queues, config, sender) = build_test_bgworker_config();
         let (startup_sender, startup_receiver) = channel();
-        let handle = BackendEnv::spawn_bgworker_thread(config, startup_sender).unwrap();
+        let handle = BackendEnv::spawn_bgworker_thread(queues, config, startup_sender).unwrap();
         startup_receiver.recv().unwrap().unwrap();
         sender.send(BgWorkerRequest::Shutdown).unwrap();
         handle.join().unwrap();

--- a/src/backends/common/mod.rs
+++ b/src/backends/common/mod.rs
@@ -13,7 +13,7 @@ use ubiblk_macros::error_context;
 
 use crate::{
     block_device::{
-        self, BgQueues, BgSender, BgWorker, BgWorkerRequest, BlockDevice, LazyTask,
+        self, BgQueues, BgSender, BgStopper, BgWorker, BlockDevice, LazyRequest, LazyTask,
         SharedMetadataState, StatusReporter, SyncBlockDevice, UbiMetadata, UringBlockDevice,
     },
     config::v2,
@@ -27,20 +27,20 @@ pub mod rpc;
 
 pub const SECTOR_SIZE: usize = 512;
 
-struct BgWorkerConfig {
+struct LazyTaskConfig {
     target_dev: Box<dyn BlockDevice>,
     stripe_source_builder: Box<StripeSourceBuilder>,
     metadata_dev: Box<dyn BlockDevice>,
     alignment: usize,
     autofetch: bool,
     shared_state: SharedMetadataState,
-    receiver: Receiver<BgWorkerRequest>,
+    receiver: Receiver<LazyRequest>,
 }
 
 pub struct BackendEnv {
     bdev: Box<dyn BlockDevice>,
-    bgworker: Option<(BgQueues, BgWorkerConfig)>,
-    bgworker_sender: Option<BgSender<BgWorkerRequest>>,
+    bgworker: Option<(BgQueues, LazyTaskConfig)>,
+    bgworker_stopper: Option<BgStopper>,
     bgworker_thread: Option<std::thread::JoinHandle<()>>,
     alignment: usize,
     config: v2::Config,
@@ -68,7 +68,7 @@ impl BackendEnv {
             None => Ok(BackendEnv {
                 bdev: disk_device,
                 bgworker: None,
-                bgworker_sender: None,
+                bgworker_stopper: None,
                 bgworker_thread: None,
                 alignment,
                 config: config.clone(),
@@ -100,10 +100,8 @@ impl BackendEnv {
     }
 
     pub fn stop_bgworker_thread(&mut self) {
-        if let Some(ch) = self.bgworker_sender.take() {
-            if let Err(e) = ch.send(BgWorkerRequest::Shutdown) {
-                error!("Failed to send shutdown request to bgworker: {e}");
-            }
+        if let Some(stopper) = self.bgworker_stopper.take() {
+            stopper.stop();
         }
 
         if let Some(handle) = self.bgworker_thread.take() {
@@ -145,6 +143,7 @@ impl BackendEnv {
 
         let queues = BgQueues::new();
         let (bgworker_sender, bgworker_receiver) = queues.queue();
+        let bgworker_stopper = queues.stopper();
 
         let bdev_lazy = Self::build_bdev_lazy(
             disk_device.clone(),
@@ -159,7 +158,7 @@ impl BackendEnv {
             metadata.has_fetched_all_stripes(),
         ));
 
-        let bgworker_config = BgWorkerConfig {
+        let bgworker_config = LazyTaskConfig {
             target_dev: disk_device,
             stripe_source_builder,
             metadata_dev: metadata_device,
@@ -175,7 +174,7 @@ impl BackendEnv {
         Ok(BackendEnv {
             bdev: bdev_lazy,
             bgworker: Some((queues, bgworker_config)),
-            bgworker_sender: Some(bgworker_sender),
+            bgworker_stopper: Some(bgworker_stopper),
             bgworker_thread: None,
             alignment,
             config: config.clone(),
@@ -199,7 +198,7 @@ impl BackendEnv {
     fn build_bdev_lazy(
         disk_device: Box<dyn BlockDevice>,
         config: &v2::Config,
-        bgworker_sender: BgSender<BgWorkerRequest>,
+        bgworker_sender: BgSender<LazyRequest>,
         shared_state: SharedMetadataState,
     ) -> Result<Box<dyn BlockDevice>> {
         let raw_image_device = if config
@@ -231,7 +230,7 @@ impl BackendEnv {
 
     fn spawn_bgworker_thread(
         queues: BgQueues,
-        config: BgWorkerConfig,
+        config: LazyTaskConfig,
         startup_sender: Sender<Result<()>>,
     ) -> Result<std::thread::JoinHandle<()>> {
         std::thread::Builder::new()
@@ -261,8 +260,8 @@ impl BackendEnv {
             })
     }
 
-    fn add_lazy_task(worker: &mut BgWorker, config: BgWorkerConfig) -> Result<()> {
-        let BgWorkerConfig {
+    fn add_lazy_task(worker: &mut BgWorker, config: LazyTaskConfig) -> Result<()> {
+        let LazyTaskConfig {
             target_dev,
             stripe_source_builder,
             metadata_dev,
@@ -673,7 +672,7 @@ mod tests {
         );
     }
 
-    fn build_test_bgworker_config() -> (BgQueues, BgWorkerConfig, BgSender<BgWorkerRequest>) {
+    fn build_test_lazy_task_config() -> (BgQueues, LazyTaskConfig) {
         let stripe_sector_count_shift = 11;
         let target_dev = TestBlockDevice::new(1024 * 1024);
         let metadata_dev = TestBlockDevice::new(1024 * 1024);
@@ -687,11 +686,11 @@ mod tests {
             loaded_metadata.has_fetched_all_stripes(),
         ));
         let queues = BgQueues::new();
-        let (sender, receiver) = queues.queue();
+        let (_sender, receiver) = queues.queue::<LazyRequest>();
 
         (
             queues,
-            BgWorkerConfig {
+            LazyTaskConfig {
                 target_dev: Box::new(target_dev),
                 stripe_source_builder,
                 metadata_dev: Box::new(metadata_dev),
@@ -700,14 +699,13 @@ mod tests {
                 shared_state,
                 receiver,
             },
-            sender,
         )
     }
 
     #[test]
-    fn run_bgworker_handles_shutdown_request() {
-        let (queues, config, sender) = build_test_bgworker_config();
-        sender.send(BgWorkerRequest::Shutdown).unwrap();
+    fn run_bgworker_stops_when_asked() {
+        let (queues, config) = build_test_lazy_task_config();
+        queues.stopper().stop();
         let mut worker = BgWorker::new(queues);
         BackendEnv::add_lazy_task(&mut worker, config).unwrap();
         worker.run();
@@ -715,11 +713,12 @@ mod tests {
 
     #[test]
     fn spawn_bgworker_thread_runs_and_joins() {
-        let (queues, config, sender) = build_test_bgworker_config();
+        let (queues, config) = build_test_lazy_task_config();
+        let stopper = queues.stopper();
         let (startup_sender, startup_receiver) = channel();
         let handle = BackendEnv::spawn_bgworker_thread(queues, config, startup_sender).unwrap();
         startup_receiver.recv().unwrap().unwrap();
-        sender.send(BgWorkerRequest::Shutdown).unwrap();
+        stopper.stop();
         handle.join().unwrap();
     }
 
@@ -962,6 +961,23 @@ mod tests {
             std::fs::metadata(&metadata_path).unwrap().len(),
             (SECTOR_SIZE * 8) as u64
         );
+    }
+
+    #[test]
+    fn backend_env_starts_and_stops_its_bgworker_thread() {
+        let disk_file = tempfile::NamedTempFile::new().unwrap();
+        disk_file.as_file().set_len(10 * 1024 * 1024).unwrap();
+        let metadata_file = tempfile::NamedTempFile::new().unwrap();
+        metadata_file.as_file().set_len(1024 * 1024).unwrap();
+
+        let config = test_config(disk_file.path(), Some(metadata_file.path()), None);
+        init_metadata(&config, 11).unwrap();
+
+        let mut env = BackendEnv::build(&config).unwrap();
+        env.run_bgworker_thread().unwrap();
+        // The device still holds a sender to the lazy task, so the stopper is
+        // the only way the thread ends: hanging here is a broken shutdown.
+        env.stop_bgworker_thread();
     }
 
     #[test]

--- a/src/block_device/bdev_lazy/bdev_lazy_tests.rs
+++ b/src/block_device/bdev_lazy/bdev_lazy_tests.rs
@@ -2,13 +2,14 @@
 mod tests {
     use crate::backends::SECTOR_SIZE;
     use crate::block_device::{
-        bdev_lazy::{BgWorker, LazyBlockDevice, SharedMetadataState, UbiMetadata},
+        bdev_lazy::{LazyBlockDevice, LazyTask, SharedMetadataState, UbiMetadata},
         bdev_test::{TestBlockDevice, TestDeviceMetrics},
+        bgworker::{BgQueues, BgWorker},
         metadata_flags, BlockDevice, IoChannel,
     };
     use crate::block_device::{shared_buffer, SharedBuffer};
     use std::cell::RefCell;
-    use std::sync::{mpsc::channel, Arc, RwLock};
+    use std::sync::{Arc, RwLock};
     use std::thread::sleep;
     use std::time::Duration;
 
@@ -42,7 +43,8 @@ mod tests {
             SharedMetadataState::new(&loaded)
         };
 
-        let (bgworker_ch, bgworker_rx) = channel();
+        let queues = BgQueues::new();
+        let (bgworker_ch, bgworker_rx) = queues.queue();
 
         if with_image {
             let image_dev = TestBlockDevice::new(DEV_SIZE);
@@ -59,16 +61,17 @@ mod tests {
                 image_dev.write(0, &tmp, SECTOR_SIZE);
             }
             let image_metrics = image_dev.metrics.clone();
-            let bgworker = BgWorker::new(
+            let task = LazyTask::new(
                 stripe_source,
                 &target_dev,
                 &metadata_dev,
                 SECTOR_SIZE,
                 false,
                 metadata_state.clone(),
-                bgworker_rx,
             )
             .unwrap();
+            let mut bgworker = BgWorker::new(queues);
+            bgworker.add(task, bgworker_rx);
             let lazy = LazyBlockDevice::new(
                 Box::new(target_dev),
                 Some(Box::new(image_dev)),
@@ -100,16 +103,17 @@ mod tests {
                 tmp[..data.len()].copy_from_slice(data);
                 source_dev.write(0, &tmp, SECTOR_SIZE);
             }
-            let bgworker = BgWorker::new(
+            let task = LazyTask::new(
                 stripe_source,
                 &target_dev,
                 &metadata_dev,
                 SECTOR_SIZE,
                 false,
                 metadata_state.clone(),
-                bgworker_rx,
             )
             .unwrap();
+            let mut bgworker = BgWorker::new(queues);
+            bgworker.add(task, bgworker_rx);
             let lazy = LazyBlockDevice::new(
                 Box::new(target_dev),
                 None,

--- a/src/block_device/bdev_lazy/bgworker.rs
+++ b/src/block_device/bdev_lazy/bgworker.rs
@@ -7,7 +7,6 @@ use crate::block_device::bgworker::BgTask;
 use crate::{block_device::BlockDevice, stripe_source::StripeSource, Result};
 use log::{error, info};
 use std::ops::ControlFlow;
-use std::sync::mpsc::Receiver;
 
 pub enum BgWorkerRequest {
     Fetch { stripe_id: usize },
@@ -61,10 +60,7 @@ impl BgTask for LazyTask {
     }
 }
 
-pub type BgWorker = crate::block_device::bgworker::BgWorker<LazyTask>;
-
-impl BgWorker {
-    #[allow(clippy::too_many_arguments)]
+impl LazyTask {
     pub fn new(
         stripe_source: Box<dyn StripeSource>,
         target_dev: &dyn BlockDevice,
@@ -72,7 +68,6 @@ impl BgWorker {
         alignment: usize,
         autofetch: bool,
         metadata_state: SharedMetadataState,
-        req_receiver: Receiver<BgWorkerRequest>,
     ) -> Result<Self> {
         let source_sector_count = stripe_source.sector_count();
         let metadata_flusher =
@@ -85,18 +80,15 @@ impl BgWorker {
             alignment,
             autofetch,
         )?;
-        Ok(Self::with_task(
-            LazyTask {
-                stripe_fetcher,
-                metadata_flusher,
-                metadata_state,
-            },
-            req_receiver,
-        ))
+        Ok(LazyTask {
+            stripe_fetcher,
+            metadata_flusher,
+            metadata_state,
+        })
     }
 
     pub fn shared_state(&self) -> SharedMetadataState {
-        self.task().metadata_state.clone()
+        self.metadata_state.clone()
     }
 }
 
@@ -105,16 +97,17 @@ mod tests {
     use super::*;
     use crate::{
         block_device::{
-            bdev_lazy::SharedMetadataState, bdev_test::TestBlockDevice, NullBlockDevice,
-            UbiMetadata,
+            bdev_lazy::SharedMetadataState,
+            bdev_test::TestBlockDevice,
+            bgworker::{BgQueues, BgSender, BgWorker},
+            NullBlockDevice, UbiMetadata,
         },
         stripe_source,
     };
-    use std::sync::mpsc::channel;
 
-    fn build_bg_worker_with_source(
+    fn build_worker_with_source(
         stripe_source: Box<dyn StripeSource>,
-    ) -> (BgWorker, std::sync::mpsc::Sender<BgWorkerRequest>) {
+    ) -> (BgWorker, BgSender<BgWorkerRequest>, SharedMetadataState) {
         let stripe_sector_count_shift = 11;
         let target_dev = TestBlockDevice::new(1024 * 1024);
         let metadata_dev = TestBlockDevice::new(1024 * 1024);
@@ -125,24 +118,25 @@ mod tests {
             SharedMetadataState::new(&metadata)
         };
 
-        let (tx, rx) = channel();
-
-        (
-            BgWorker::new(
-                stripe_source,
-                &target_dev,
-                &metadata_dev,
-                4096,
-                false,
-                metadata_state,
-                rx,
-            )
-            .unwrap(),
-            tx,
+        let task = LazyTask::new(
+            stripe_source,
+            &target_dev,
+            &metadata_dev,
+            4096,
+            false,
+            metadata_state.clone(),
         )
+        .unwrap();
+
+        let queues = BgQueues::new();
+        let (sender, requests) = queues.queue();
+        let mut worker = BgWorker::new(queues);
+        worker.add(task, requests);
+
+        (worker, sender, metadata_state)
     }
 
-    fn build_bg_worker() -> (BgWorker, std::sync::mpsc::Sender<BgWorkerRequest>) {
+    fn build_worker() -> (BgWorker, BgSender<BgWorkerRequest>, SharedMetadataState) {
         let stripe_sector_count_shift = 11;
         let stripe_sector_count = 1u64 << stripe_sector_count_shift;
         let source_dev = TestBlockDevice::new(1024 * 1024);
@@ -150,14 +144,14 @@ mod tests {
             stripe_source::BlockDeviceStripeSource::new(source_dev.clone(), stripe_sector_count)
                 .unwrap(),
         );
-        build_bg_worker_with_source(stripe_source)
+        build_worker_with_source(stripe_source)
     }
 
     #[test]
     fn test_bg_worker_shutdown() {
-        let (mut bg_worker, sender) = build_bg_worker();
+        let (mut worker, sender, _) = build_worker();
         sender.send(BgWorkerRequest::Shutdown).unwrap();
-        bg_worker.run();
+        worker.run();
     }
 
     #[test]
@@ -179,18 +173,15 @@ mod tests {
             SharedMetadataState::new(&metadata)
         };
 
-        let (_tx, rx) = channel();
-
-        BgWorker::new(
+        LazyTask::new(
             stripe_source,
             &target_dev,
             &metadata_dev,
             4096,
             false,
             metadata_state,
-            rx,
         )
-        .expect("BgWorker should support null source device");
+        .expect("LazyTask should support null source device");
     }
 
     #[test]
@@ -204,16 +195,16 @@ mod tests {
         let flaky_source =
             stripe_source::FlakyStripeSource::new(Box::new(base_source), vec![(0, 4)]);
 
-        let (mut bg_worker, sender) = build_bg_worker_with_source(Box::new(flaky_source));
+        let (mut worker, sender, metadata_state) = build_worker_with_source(Box::new(flaky_source));
         sender
             .send(BgWorkerRequest::Fetch { stripe_id: 0 })
             .unwrap();
-        bg_worker.receive_requests(false);
+        worker.receive_requests(false);
 
         for _ in 0..100 {
-            bg_worker.update();
+            worker.update();
         }
 
-        assert!(bg_worker.shared_state().is_stripe_failed(0));
+        assert!(metadata_state.is_stripe_failed(0));
     }
 }

--- a/src/block_device/bdev_lazy/bgworker.rs
+++ b/src/block_device/bdev_lazy/bgworker.rs
@@ -5,13 +5,11 @@ use super::{
 
 use crate::block_device::bgworker::BgTask;
 use crate::{block_device::BlockDevice, stripe_source::StripeSource, Result};
-use log::{error, info};
-use std::ops::ControlFlow;
+use log::error;
 
-pub enum BgWorkerRequest {
+pub enum LazyRequest {
     Fetch { stripe_id: usize },
     SetWritten { stripe_id: usize },
-    Shutdown,
 }
 
 /// Fetching stripes and persisting what has been fetched, which is what a lazy
@@ -23,21 +21,13 @@ pub struct LazyTask {
 }
 
 impl BgTask for LazyTask {
-    type Request = BgWorkerRequest;
+    type Request = LazyRequest;
 
-    fn handle(&mut self, request: BgWorkerRequest) -> ControlFlow<()> {
+    fn handle(&mut self, request: LazyRequest) {
         match request {
-            BgWorkerRequest::Fetch { stripe_id } => {
-                self.stripe_fetcher.handle_fetch_request(stripe_id);
-                ControlFlow::Continue(())
-            }
-            BgWorkerRequest::SetWritten { stripe_id } => {
-                self.metadata_flusher.set_stripe_written(stripe_id);
-                ControlFlow::Continue(())
-            }
-            BgWorkerRequest::Shutdown => {
-                info!("Received shutdown request, stopping worker");
-                ControlFlow::Break(())
+            LazyRequest::Fetch { stripe_id } => self.stripe_fetcher.handle_fetch_request(stripe_id),
+            LazyRequest::SetWritten { stripe_id } => {
+                self.metadata_flusher.set_stripe_written(stripe_id)
             }
         }
     }
@@ -99,7 +89,7 @@ mod tests {
         block_device::{
             bdev_lazy::SharedMetadataState,
             bdev_test::TestBlockDevice,
-            bgworker::{BgQueues, BgSender, BgWorker},
+            bgworker::{BgQueues, BgSender, BgStopper, BgWorker},
             NullBlockDevice, UbiMetadata,
         },
         stripe_source,
@@ -107,7 +97,12 @@ mod tests {
 
     fn build_worker_with_source(
         stripe_source: Box<dyn StripeSource>,
-    ) -> (BgWorker, BgSender<BgWorkerRequest>, SharedMetadataState) {
+    ) -> (
+        BgWorker,
+        BgStopper,
+        BgSender<LazyRequest>,
+        SharedMetadataState,
+    ) {
         let stripe_sector_count_shift = 11;
         let target_dev = TestBlockDevice::new(1024 * 1024);
         let metadata_dev = TestBlockDevice::new(1024 * 1024);
@@ -130,13 +125,19 @@ mod tests {
 
         let queues = BgQueues::new();
         let (sender, requests) = queues.queue();
+        let stopper = queues.stopper();
         let mut worker = BgWorker::new(queues);
         worker.add(task, requests);
 
-        (worker, sender, metadata_state)
+        (worker, stopper, sender, metadata_state)
     }
 
-    fn build_worker() -> (BgWorker, BgSender<BgWorkerRequest>, SharedMetadataState) {
+    fn build_worker() -> (
+        BgWorker,
+        BgStopper,
+        BgSender<LazyRequest>,
+        SharedMetadataState,
+    ) {
         let stripe_sector_count_shift = 11;
         let stripe_sector_count = 1u64 << stripe_sector_count_shift;
         let source_dev = TestBlockDevice::new(1024 * 1024);
@@ -149,8 +150,15 @@ mod tests {
 
     #[test]
     fn test_bg_worker_shutdown() {
-        let (mut worker, sender, _) = build_worker();
-        sender.send(BgWorkerRequest::Shutdown).unwrap();
+        let (mut worker, stopper, sender, _) = build_worker();
+        stopper.stop();
+        // The worker stops because it was asked to, not because its queue ran
+        // dry: the delayed drop is only there to keep a regression from
+        // hanging the suite.
+        std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_secs(2));
+            drop(sender);
+        });
         worker.run();
     }
 
@@ -195,10 +203,9 @@ mod tests {
         let flaky_source =
             stripe_source::FlakyStripeSource::new(Box::new(base_source), vec![(0, 4)]);
 
-        let (mut worker, sender, metadata_state) = build_worker_with_source(Box::new(flaky_source));
-        sender
-            .send(BgWorkerRequest::Fetch { stripe_id: 0 })
-            .unwrap();
+        let (mut worker, _stopper, sender, metadata_state) =
+            build_worker_with_source(Box::new(flaky_source));
+        sender.send(LazyRequest::Fetch { stripe_id: 0 }).unwrap();
         worker.receive_requests(false);
 
         for _ in 0..100 {

--- a/src/block_device/bdev_lazy/bgworker.rs
+++ b/src/block_device/bdev_lazy/bgworker.rs
@@ -3,9 +3,11 @@ use super::{
     stripe_fetcher::StripeFetcher,
 };
 
+use crate::block_device::bgworker::BgTask;
 use crate::{block_device::BlockDevice, stripe_source::StripeSource, Result};
 use log::{error, info};
-use std::sync::mpsc::{Receiver, TryRecvError};
+use std::ops::ControlFlow;
+use std::sync::mpsc::Receiver;
 
 pub enum BgWorkerRequest {
     Fetch { stripe_id: usize },
@@ -13,13 +15,53 @@ pub enum BgWorkerRequest {
     Shutdown,
 }
 
-pub struct BgWorker {
+/// Fetching stripes and persisting what has been fetched, which is what a lazy
+/// device has to do away from its I/O path.
+pub struct LazyTask {
     stripe_fetcher: StripeFetcher,
     metadata_flusher: MetadataFlusher,
-    req_receiver: Receiver<BgWorkerRequest>,
     metadata_state: SharedMetadataState,
-    done: bool,
 }
+
+impl BgTask for LazyTask {
+    type Request = BgWorkerRequest;
+
+    fn handle(&mut self, request: BgWorkerRequest) -> ControlFlow<()> {
+        match request {
+            BgWorkerRequest::Fetch { stripe_id } => {
+                self.stripe_fetcher.handle_fetch_request(stripe_id);
+                ControlFlow::Continue(())
+            }
+            BgWorkerRequest::SetWritten { stripe_id } => {
+                self.metadata_flusher.set_stripe_written(stripe_id);
+                ControlFlow::Continue(())
+            }
+            BgWorkerRequest::Shutdown => {
+                info!("Received shutdown request, stopping worker");
+                ControlFlow::Break(())
+            }
+        }
+    }
+
+    fn update(&mut self) {
+        self.stripe_fetcher.update();
+        for (stripe_id, success) in self.stripe_fetcher.take_finished_fetches() {
+            if success {
+                self.metadata_flusher.set_stripe_fetched(stripe_id);
+            } else {
+                error!("Stripe {stripe_id} fetch failed");
+            }
+        }
+        self.metadata_flusher.update();
+        self.stripe_fetcher.disconnect_from_source_if_all_fetched();
+    }
+
+    fn busy(&self) -> bool {
+        self.stripe_fetcher.busy() || self.metadata_flusher.busy()
+    }
+}
+
+pub type BgWorker = crate::block_device::bgworker::BgWorker<LazyTask>;
 
 impl BgWorker {
     #[allow(clippy::too_many_arguments)]
@@ -43,79 +85,18 @@ impl BgWorker {
             alignment,
             autofetch,
         )?;
-        Ok(BgWorker {
-            stripe_fetcher,
-            metadata_flusher,
+        Ok(Self::with_task(
+            LazyTask {
+                stripe_fetcher,
+                metadata_flusher,
+                metadata_state,
+            },
             req_receiver,
-            done: false,
-            metadata_state,
-        })
+        ))
     }
 
     pub fn shared_state(&self) -> SharedMetadataState {
-        self.metadata_state.clone()
-    }
-
-    pub fn process_request(&mut self, req: BgWorkerRequest) {
-        match req {
-            BgWorkerRequest::Fetch { stripe_id } => {
-                self.stripe_fetcher.handle_fetch_request(stripe_id)
-            }
-            BgWorkerRequest::SetWritten { stripe_id } => {
-                self.metadata_flusher.set_stripe_written(stripe_id)
-            }
-            BgWorkerRequest::Shutdown => {
-                info!("Received shutdown request, stopping worker");
-                self.done = true;
-            }
-        }
-    }
-
-    pub fn receive_requests(&mut self, block: bool) {
-        if block {
-            match self.req_receiver.recv() {
-                Ok(req) => self.process_request(req),
-                Err(e) => {
-                    error!("Failed to receive request: {e}, stopping worker");
-                    self.done = true;
-                    return;
-                }
-            }
-        }
-
-        loop {
-            match self.req_receiver.try_recv() {
-                Ok(req) => self.process_request(req),
-                Err(TryRecvError::Disconnected) => {
-                    error!("Request channel disconnected, stopping worker");
-                    self.done = true;
-                    return;
-                }
-                Err(TryRecvError::Empty) => break,
-            }
-        }
-    }
-
-    pub fn update(&mut self) {
-        self.stripe_fetcher.update();
-        for (stripe_id, success) in self.stripe_fetcher.take_finished_fetches() {
-            if success {
-                self.metadata_flusher.set_stripe_fetched(stripe_id);
-            } else {
-                error!("Stripe {stripe_id} fetch failed");
-            }
-        }
-        self.metadata_flusher.update();
-        self.stripe_fetcher.disconnect_from_source_if_all_fetched();
-    }
-
-    pub fn run(&mut self) {
-        while !self.done {
-            let busy = self.stripe_fetcher.busy() || self.metadata_flusher.busy();
-            let block = !busy;
-            self.receive_requests(block);
-            self.update();
-        }
+        self.task().metadata_state.clone()
     }
 }
 

--- a/src/block_device/bdev_lazy/device.rs
+++ b/src/block_device/bdev_lazy/device.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 use super::{
-    bgworker::BgWorkerRequest,
+    bgworker::LazyRequest,
     metadata::{Failed, Fetched, NoSource, NotFetched},
 };
 
@@ -40,7 +40,7 @@ struct LazyIoChannel {
     image: Option<Box<dyn IoChannel>>,
     queued_rw_requests: VecDeque<RWRequest>,
     finished_requests: Vec<(usize, bool)>,
-    bgworker_ch: BgSender<BgWorkerRequest>,
+    bgworker_ch: BgSender<LazyRequest>,
     metadata_state: SharedMetadataState,
     stripe_fetches_requested: HashSet<usize>,
     track_written: bool,
@@ -50,7 +50,7 @@ impl LazyIoChannel {
     fn new(
         base: Box<dyn IoChannel>,
         image: Option<Box<dyn IoChannel>>,
-        bgworker_ch: BgSender<BgWorkerRequest>,
+        bgworker_ch: BgSender<LazyRequest>,
         metadata_state: SharedMetadataState,
         track_written: bool,
     ) -> Self {
@@ -102,7 +102,7 @@ impl LazyIoChannel {
                 && !self.stripe_fetches_requested.contains(&stripe_id)
             {
                 self.bgworker_ch
-                    .send(BgWorkerRequest::Fetch { stripe_id })
+                    .send(LazyRequest::Fetch { stripe_id })
                     .context(format!(
                         "failed to send fetch request for stripe {stripe_id}"
                     ))?;
@@ -116,7 +116,7 @@ impl LazyIoChannel {
         for stripe_id in request.stripe_id_first..=request.stripe_id_last {
             if !self.metadata_state.stripe_written(stripe_id) {
                 self.bgworker_ch
-                    .send(BgWorkerRequest::SetWritten { stripe_id })
+                    .send(LazyRequest::SetWritten { stripe_id })
                     .context(format!(
                         "failed to send set written request for stripe {stripe_id}"
                     ))?;
@@ -326,7 +326,7 @@ impl IoChannel for LazyIoChannel {
 pub struct LazyBlockDevice {
     base: Box<dyn BlockDevice>,
     image: Option<Box<dyn BlockDevice>>,
-    bgworker_ch: BgSender<BgWorkerRequest>,
+    bgworker_ch: BgSender<LazyRequest>,
     metadata_state: SharedMetadataState,
     track_written: bool,
 }
@@ -335,7 +335,7 @@ impl LazyBlockDevice {
     pub fn new(
         base: Box<dyn BlockDevice>,
         image: Option<Box<dyn BlockDevice>>,
-        bgworker_ch: BgSender<BgWorkerRequest>,
+        bgworker_ch: BgSender<LazyRequest>,
         metadata_state: SharedMetadataState,
         track_written: bool,
     ) -> Result<Box<Self>> {

--- a/src/block_device/bdev_lazy/device.rs
+++ b/src/block_device/bdev_lazy/device.rs
@@ -1,5 +1,5 @@
 use crate::{
-    block_device::{BlockDevice, IoChannel, SharedBuffer, SharedMetadataState},
+    block_device::{BgSender, BlockDevice, IoChannel, SharedBuffer, SharedMetadataState},
     Result, ResultExt,
 };
 
@@ -8,10 +8,7 @@ use super::{
     metadata::{Failed, Fetched, NoSource, NotFetched},
 };
 
-use std::{
-    collections::{HashSet, VecDeque},
-    sync::mpsc::Sender,
-};
+use std::collections::{HashSet, VecDeque};
 
 use log::{debug, error};
 
@@ -43,7 +40,7 @@ struct LazyIoChannel {
     image: Option<Box<dyn IoChannel>>,
     queued_rw_requests: VecDeque<RWRequest>,
     finished_requests: Vec<(usize, bool)>,
-    bgworker_ch: Sender<BgWorkerRequest>,
+    bgworker_ch: BgSender<BgWorkerRequest>,
     metadata_state: SharedMetadataState,
     stripe_fetches_requested: HashSet<usize>,
     track_written: bool,
@@ -53,7 +50,7 @@ impl LazyIoChannel {
     fn new(
         base: Box<dyn IoChannel>,
         image: Option<Box<dyn IoChannel>>,
-        bgworker_ch: Sender<BgWorkerRequest>,
+        bgworker_ch: BgSender<BgWorkerRequest>,
         metadata_state: SharedMetadataState,
         track_written: bool,
     ) -> Self {
@@ -329,7 +326,7 @@ impl IoChannel for LazyIoChannel {
 pub struct LazyBlockDevice {
     base: Box<dyn BlockDevice>,
     image: Option<Box<dyn BlockDevice>>,
-    bgworker_ch: Sender<BgWorkerRequest>,
+    bgworker_ch: BgSender<BgWorkerRequest>,
     metadata_state: SharedMetadataState,
     track_written: bool,
 }
@@ -338,7 +335,7 @@ impl LazyBlockDevice {
     pub fn new(
         base: Box<dyn BlockDevice>,
         image: Option<Box<dyn BlockDevice>>,
-        bgworker_ch: Sender<BgWorkerRequest>,
+        bgworker_ch: BgSender<BgWorkerRequest>,
         metadata_state: SharedMetadataState,
         track_written: bool,
     ) -> Result<Box<Self>> {

--- a/src/block_device/bgworker.rs
+++ b/src/block_device/bgworker.rs
@@ -6,7 +6,9 @@
 //! neighbours from sleeping.
 
 use std::ops::ControlFlow;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{channel, Receiver, SendError, Sender, TryRecvError};
+use std::sync::Arc;
 
 use log::error;
 
@@ -14,8 +16,8 @@ use log::error;
 pub trait BgTask {
     type Request;
 
-    /// Act on a request. `Break` retires the task.
-    fn handle(&mut self, request: Self::Request) -> ControlFlow<()>;
+    /// Act on a request.
+    fn handle(&mut self, request: Self::Request);
 
     /// Make progress on whatever is in flight.
     fn update(&mut self);
@@ -65,7 +67,7 @@ impl<T: BgTask> Queued for TaskQueue<T> {
     fn drain(&mut self) -> ControlFlow<()> {
         loop {
             match self.requests.try_recv() {
-                Ok(request) => self.task.handle(request)?,
+                Ok(request) => self.task.handle(request),
                 Err(TryRecvError::Empty) => return ControlFlow::Continue(()),
                 Err(TryRecvError::Disconnected) => {
                     error!("Request channel disconnected, retiring task");
@@ -84,9 +86,24 @@ impl<T: BgTask> Queued for TaskQueue<T> {
     }
 }
 
+/// Ends the run, whatever the tasks are up to.
+#[derive(Clone)]
+pub struct BgStopper {
+    stopped: Arc<AtomicBool>,
+    wakeup: Sender<()>,
+}
+
+impl BgStopper {
+    pub fn stop(&self) {
+        self.stopped.store(true, Ordering::SeqCst);
+        let _ = self.wakeup.send(());
+    }
+}
+
 /// Hands out queues before the worker exists: a device needs its sender at
 /// build time, while the tasks are built on the worker's own thread.
 pub struct BgQueues {
+    stopped: Arc<AtomicBool>,
     wakeup_sender: Sender<()>,
     wakeup: Receiver<()>,
 }
@@ -101,8 +118,16 @@ impl BgQueues {
     pub fn new() -> Self {
         let (wakeup_sender, wakeup) = channel();
         BgQueues {
+            stopped: Arc::new(AtomicBool::new(false)),
             wakeup_sender,
             wakeup,
+        }
+    }
+
+    pub fn stopper(&self) -> BgStopper {
+        BgStopper {
+            stopped: self.stopped.clone(),
+            wakeup: self.wakeup_sender.clone(),
         }
     }
 
@@ -118,6 +143,7 @@ impl BgQueues {
 
 pub struct BgWorker {
     tasks: Vec<Box<dyn Queued>>,
+    stopped: Arc<AtomicBool>,
     wakeup: Receiver<()>,
     /// The queues' side of the wakeup channel, dropped once the worker runs so
     /// that a wait ends when the last sender goes away.
@@ -128,6 +154,7 @@ impl BgWorker {
     pub fn new(queues: BgQueues) -> Self {
         BgWorker {
             tasks: Vec::new(),
+            stopped: queues.stopped,
             wakeup: queues.wakeup,
             wakeup_sender: Some(queues.wakeup_sender),
         }
@@ -156,7 +183,7 @@ impl BgWorker {
 
     pub fn run(&mut self) {
         self.wakeup_sender = None;
-        while !self.tasks.is_empty() {
+        while !self.tasks.is_empty() && !self.stopped.load(Ordering::SeqCst) {
             let block = !self.busy();
             self.receive_requests(block);
             self.update();
@@ -180,10 +207,7 @@ mod tests {
     use std::rc::Rc;
     use std::time::Duration;
 
-    enum Request {
-        Note(u32),
-        Stop,
-    }
+    struct Note(u32);
 
     type Log = Rc<RefCell<Vec<u32>>>;
 
@@ -195,16 +219,10 @@ mod tests {
     }
 
     impl BgTask for Recorder {
-        type Request = Request;
+        type Request = Note;
 
-        fn handle(&mut self, request: Request) -> ControlFlow<()> {
-            match request {
-                Request::Note(n) => {
-                    self.handled.borrow_mut().push(n);
-                    ControlFlow::Continue(())
-                }
-                Request::Stop => ControlFlow::Break(()),
-            }
+        fn handle(&mut self, Note(n): Note) {
+            self.handled.borrow_mut().push(n);
         }
 
         fn update(&mut self) {
@@ -235,46 +253,68 @@ mod tests {
         worker.add(recorder(&first), first_requests);
         worker.add(recorder(&second), second_requests);
 
-        to_first.send(Request::Note(1)).unwrap();
-        to_second.send(Request::Note(2)).unwrap();
-        to_first.send(Request::Note(3)).unwrap();
+        to_first.send(Note(1)).unwrap();
+        to_second.send(Note(2)).unwrap();
+        to_first.send(Note(3)).unwrap();
         worker.receive_requests(false);
 
         assert_eq!(*first.borrow(), vec![1, 3]);
         assert_eq!(*second.borrow(), vec![2]);
     }
 
+    /// Nobody is left to send to that task, and waiting for a request that
+    /// cannot arrive would keep the thread alive for the life of the process.
+    /// The tasks that still have senders carry on.
     #[test]
-    fn a_task_that_asks_to_stop_leaves_the_others_running() {
+    fn a_queue_with_no_senders_retires_only_its_own_task() {
         let queues = BgQueues::new();
-        let (to_quitter, quitter_requests) = queues.queue();
+        let (to_quitter, quitter_requests) = queues.queue::<Note>();
         let (to_survivor, survivor_requests) = queues.queue();
         let survived = Log::default();
         let mut worker = BgWorker::new(queues);
         worker.add(Recorder::default(), quitter_requests);
         worker.add(recorder(&survived), survivor_requests);
 
-        to_quitter.send(Request::Stop).unwrap();
+        drop(to_quitter);
         worker.receive_requests(false);
-        to_survivor.send(Request::Note(1)).unwrap();
+        to_survivor.send(Note(1)).unwrap();
         worker.receive_requests(false);
 
+        assert_eq!(worker.tasks.len(), 1);
         assert_eq!(*survived.borrow(), vec![1]);
     }
 
-    /// Nobody is left to send: waiting for a request that cannot arrive would
-    /// keep the thread alive for the life of the process.
     #[test]
-    fn a_queue_with_no_senders_retires_its_task() {
+    fn a_stopper_ends_the_run_with_its_tasks_still_queued() {
         let queues = BgQueues::new();
-        let (sender, requests) = queues.queue::<Request>();
+        let (sender, requests) = queues.queue::<Note>();
+        // Held no longer than the call: a live stopper is a live wakeup sender.
+        queues.stopper().stop();
         let mut worker = BgWorker::new(queues);
         worker.add(Recorder::default(), requests);
-        drop(sender);
 
+        // A worker that ignores the stop waits here for a request that is not
+        // coming; retiring the task frees it, and the count below then fails
+        // rather than the test hanging.
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_secs(1));
+            drop(sender);
+        });
         worker.run();
 
-        assert!(worker.tasks.is_empty());
+        assert_eq!(worker.tasks.len(), 1);
+    }
+
+    /// Without this the worker would sit in `wait` until something unrelated
+    /// happened to send it a request.
+    #[test]
+    fn stopping_wakes_a_waiting_worker() {
+        let queues = BgQueues::new();
+        let stopper = queues.stopper();
+
+        stopper.stop();
+
+        assert!(queues.wakeup.try_recv().is_ok());
     }
 
     #[test]
@@ -292,11 +332,12 @@ mod tests {
             requests,
         );
 
-        // Nothing is queued yet, so a worker that waits before looking at what
-        // is in flight reaches the stop request without having updated the task.
+        // Nothing is queued, so a worker that waits before looking at what is
+        // in flight is still waiting when its queue is dropped, having never
+        // updated the task.
         std::thread::spawn(move || {
             std::thread::sleep(Duration::from_millis(50));
-            let _ = sender.send(Request::Stop);
+            drop(sender);
         });
         worker.run();
 

--- a/src/block_device/bgworker.rs
+++ b/src/block_device/bgworker.rs
@@ -1,0 +1,190 @@
+//! The thread a block device does its background work on.
+//!
+//! The loop is the same wherever it is used: take requests from a channel,
+//! block when there is nothing in flight and poll when there is, and stop on
+//! shutdown or when the channel goes away. What the requests mean, and what
+//! there is to make progress on, belongs to the device.
+
+use std::ops::ControlFlow;
+use std::sync::mpsc::{Receiver, TryRecvError};
+
+use log::error;
+
+/// One device's background work.
+pub trait BgTask {
+    type Request;
+
+    /// Act on a request. `Break` stops the worker.
+    fn handle(&mut self, request: Self::Request) -> ControlFlow<()>;
+
+    /// Make progress on whatever is in flight.
+    fn update(&mut self);
+
+    /// Whether there is anything in flight to poll for. A worker with nothing
+    /// to do waits on its channel rather than spinning.
+    fn busy(&self) -> bool;
+}
+
+pub struct BgWorker<T: BgTask> {
+    task: T,
+    requests: Receiver<T::Request>,
+    done: bool,
+}
+
+impl<T: BgTask> BgWorker<T> {
+    pub fn with_task(task: T, requests: Receiver<T::Request>) -> Self {
+        BgWorker {
+            task,
+            requests,
+            done: false,
+        }
+    }
+
+    pub fn task(&self) -> &T {
+        &self.task
+    }
+
+    pub fn task_mut(&mut self) -> &mut T {
+        &mut self.task
+    }
+
+    pub fn done(&self) -> bool {
+        self.done
+    }
+
+    pub fn process_request(&mut self, request: T::Request) {
+        if self.task.handle(request).is_break() {
+            self.done = true;
+        }
+    }
+
+    pub fn receive_requests(&mut self, block: bool) {
+        if block {
+            match self.requests.recv() {
+                Ok(request) => self.process_request(request),
+                Err(e) => {
+                    error!("Failed to receive request: {e}, stopping worker");
+                    self.done = true;
+                    return;
+                }
+            }
+        }
+
+        loop {
+            match self.requests.try_recv() {
+                Ok(request) => self.process_request(request),
+                Err(TryRecvError::Disconnected) => {
+                    error!("Request channel disconnected, stopping worker");
+                    self.done = true;
+                    return;
+                }
+                Err(TryRecvError::Empty) => break,
+            }
+        }
+    }
+
+    pub fn update(&mut self) {
+        self.task.update();
+    }
+
+    pub fn run(&mut self) {
+        while !self.done {
+            let block = !self.task.busy();
+            self.receive_requests(block);
+            self.update();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc::channel;
+
+    enum Request {
+        Note(u32),
+        Stop,
+    }
+
+    #[derive(Default)]
+    struct Recorder {
+        handled: Vec<u32>,
+        updates: usize,
+        busy: bool,
+    }
+
+    impl BgTask for Recorder {
+        type Request = Request;
+
+        fn handle(&mut self, request: Request) -> ControlFlow<()> {
+            match request {
+                Request::Note(n) => {
+                    self.handled.push(n);
+                    ControlFlow::Continue(())
+                }
+                Request::Stop => ControlFlow::Break(()),
+            }
+        }
+
+        fn update(&mut self) {
+            self.updates += 1;
+            // One update's worth of work, so `run` has a reason to stop looping.
+            self.busy = false;
+        }
+
+        fn busy(&self) -> bool {
+            self.busy
+        }
+    }
+
+    #[test]
+    fn requests_reach_the_task_in_order() {
+        let (sender, receiver) = channel();
+        let mut worker = BgWorker::with_task(Recorder::default(), receiver);
+        sender.send(Request::Note(1)).unwrap();
+        sender.send(Request::Note(2)).unwrap();
+
+        worker.receive_requests(false);
+
+        assert_eq!(worker.task().handled, vec![1, 2]);
+        assert!(!worker.done());
+    }
+
+    #[test]
+    fn a_task_that_asks_to_stop_stops_the_worker() {
+        let (sender, receiver) = channel();
+        let mut worker = BgWorker::with_task(Recorder::default(), receiver);
+        sender.send(Request::Stop).unwrap();
+
+        // Returns rather than waiting for a request that is not coming.
+        worker.run();
+
+        assert!(worker.done());
+    }
+
+    /// Nobody is left to send: waiting for a request that cannot arrive would
+    /// hang the thread for the life of the process.
+    #[test]
+    fn a_channel_with_no_senders_stops_the_worker() {
+        let (sender, receiver) = channel::<Request>();
+        let mut worker = BgWorker::with_task(Recorder::default(), receiver);
+        drop(sender);
+
+        worker.run();
+
+        assert!(worker.done());
+    }
+
+    #[test]
+    fn a_busy_task_is_polled_rather_than_waited_on() {
+        let (sender, receiver) = channel();
+        let mut worker = BgWorker::with_task(Recorder::default(), receiver);
+        worker.task_mut().busy = true;
+        drop(sender);
+
+        // Would block for ever on an empty channel if `busy` were ignored.
+        worker.run();
+
+        assert!(worker.task().updates >= 1);
+    }
+}

--- a/src/block_device/bgworker.rs
+++ b/src/block_device/bgworker.rs
@@ -1,12 +1,12 @@
-//! The thread a block device does its background work on.
+//! The thread block devices do their background work on.
 //!
-//! The loop is the same wherever it is used: take requests from a channel,
-//! block when there is nothing in flight and poll when there is, and stop on
-//! shutdown or when the channel goes away. What the requests mean, and what
-//! there is to make progress on, belongs to the device.
+//! One thread serves them all. A device registers a task and gets a queue to
+//! send it work on; the loop waits while nothing is in flight and polls while
+//! something is, so an idle task costs nothing and a busy one keeps its
+//! neighbours from sleeping.
 
 use std::ops::ControlFlow;
-use std::sync::mpsc::{Receiver, TryRecvError};
+use std::sync::mpsc::{channel, Receiver, SendError, Sender, TryRecvError};
 
 use log::error;
 
@@ -14,102 +14,183 @@ use log::error;
 pub trait BgTask {
     type Request;
 
-    /// Act on a request. `Break` stops the worker.
+    /// Act on a request. `Break` retires the task.
     fn handle(&mut self, request: Self::Request) -> ControlFlow<()>;
 
     /// Make progress on whatever is in flight.
     fn update(&mut self);
 
-    /// Whether there is anything in flight to poll for. A worker with nothing
-    /// to do waits on its channel rather than spinning.
+    /// Whether there is anything in flight to poll for.
     fn busy(&self) -> bool;
 }
 
-pub struct BgWorker<T: BgTask> {
-    task: T,
-    requests: Receiver<T::Request>,
-    done: bool,
+/// The device end of a task's queue.
+pub struct BgSender<R> {
+    requests: Sender<R>,
+    wakeup: Sender<()>,
 }
 
-impl<T: BgTask> BgWorker<T> {
-    pub fn with_task(task: T, requests: Receiver<T::Request>) -> Self {
-        BgWorker {
-            task,
+impl<R> BgSender<R> {
+    pub fn send(&self, request: R) -> std::result::Result<(), SendError<R>> {
+        self.requests.send(request)?;
+        // After the request, so a waiting worker never misses it.
+        let _ = self.wakeup.send(());
+        Ok(())
+    }
+}
+
+impl<R> Clone for BgSender<R> {
+    fn clone(&self) -> Self {
+        BgSender {
+            requests: self.requests.clone(),
+            wakeup: self.wakeup.clone(),
+        }
+    }
+}
+
+/// A task and its queue with the request type hidden, so that one worker can
+/// hold tasks that take different requests.
+trait Queued {
+    fn drain(&mut self) -> ControlFlow<()>;
+    fn update(&mut self);
+    fn busy(&self) -> bool;
+}
+
+struct TaskQueue<T: BgTask> {
+    task: T,
+    requests: Receiver<T::Request>,
+}
+
+impl<T: BgTask> Queued for TaskQueue<T> {
+    fn drain(&mut self) -> ControlFlow<()> {
+        loop {
+            match self.requests.try_recv() {
+                Ok(request) => self.task.handle(request)?,
+                Err(TryRecvError::Empty) => return ControlFlow::Continue(()),
+                Err(TryRecvError::Disconnected) => {
+                    error!("Request channel disconnected, retiring task");
+                    return ControlFlow::Break(());
+                }
+            }
+        }
+    }
+
+    fn update(&mut self) {
+        self.task.update();
+    }
+
+    fn busy(&self) -> bool {
+        self.task.busy()
+    }
+}
+
+/// Hands out queues before the worker exists: a device needs its sender at
+/// build time, while the tasks are built on the worker's own thread.
+pub struct BgQueues {
+    wakeup_sender: Sender<()>,
+    wakeup: Receiver<()>,
+}
+
+impl Default for BgQueues {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BgQueues {
+    pub fn new() -> Self {
+        let (wakeup_sender, wakeup) = channel();
+        BgQueues {
+            wakeup_sender,
+            wakeup,
+        }
+    }
+
+    pub fn queue<R>(&self) -> (BgSender<R>, Receiver<R>) {
+        let (requests, receiver) = channel();
+        let sender = BgSender {
             requests,
-            done: false,
+            wakeup: self.wakeup_sender.clone(),
+        };
+        (sender, receiver)
+    }
+}
+
+pub struct BgWorker {
+    tasks: Vec<Box<dyn Queued>>,
+    wakeup: Receiver<()>,
+    /// The queues' side of the wakeup channel, dropped once the worker runs so
+    /// that a wait ends when the last sender goes away.
+    wakeup_sender: Option<Sender<()>>,
+}
+
+impl BgWorker {
+    pub fn new(queues: BgQueues) -> Self {
+        BgWorker {
+            tasks: Vec::new(),
+            wakeup: queues.wakeup,
+            wakeup_sender: Some(queues.wakeup_sender),
         }
     }
 
-    pub fn task(&self) -> &T {
-        &self.task
+    pub fn add<T: BgTask + 'static>(&mut self, task: T, requests: Receiver<T::Request>) {
+        self.tasks.push(Box::new(TaskQueue { task, requests }));
     }
 
-    pub fn task_mut(&mut self) -> &mut T {
-        &mut self.task
-    }
-
-    pub fn done(&self) -> bool {
-        self.done
-    }
-
-    pub fn process_request(&mut self, request: T::Request) {
-        if self.task.handle(request).is_break() {
-            self.done = true;
-        }
+    pub fn busy(&self) -> bool {
+        self.tasks.iter().any(|task| task.busy())
     }
 
     pub fn receive_requests(&mut self, block: bool) {
         if block {
-            match self.requests.recv() {
-                Ok(request) => self.process_request(request),
-                Err(e) => {
-                    error!("Failed to receive request: {e}, stopping worker");
-                    self.done = true;
-                    return;
-                }
-            }
+            self.wait();
         }
-
-        loop {
-            match self.requests.try_recv() {
-                Ok(request) => self.process_request(request),
-                Err(TryRecvError::Disconnected) => {
-                    error!("Request channel disconnected, stopping worker");
-                    self.done = true;
-                    return;
-                }
-                Err(TryRecvError::Empty) => break,
-            }
-        }
+        self.tasks.retain_mut(|task| task.drain().is_continue());
     }
 
     pub fn update(&mut self) {
-        self.task.update();
+        for task in &mut self.tasks {
+            task.update();
+        }
     }
 
     pub fn run(&mut self) {
-        while !self.done {
-            let block = !self.task.busy();
+        self.wakeup_sender = None;
+        while !self.tasks.is_empty() {
+            let block = !self.busy();
             self.receive_requests(block);
             self.update();
         }
+    }
+
+    fn wait(&self) {
+        if self.wakeup.recv().is_err() {
+            return;
+        }
+        // Every queue is drained afterwards, so the rest of the tokens say
+        // nothing new.
+        while self.wakeup.try_recv().is_ok() {}
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::mpsc::channel;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+    use std::time::Duration;
 
     enum Request {
         Note(u32),
         Stop,
     }
 
+    type Log = Rc<RefCell<Vec<u32>>>;
+
     #[derive(Default)]
     struct Recorder {
-        handled: Vec<u32>,
-        updates: usize,
+        handled: Log,
+        updates: Rc<RefCell<usize>>,
         busy: bool,
     }
 
@@ -119,7 +200,7 @@ mod tests {
         fn handle(&mut self, request: Request) -> ControlFlow<()> {
             match request {
                 Request::Note(n) => {
-                    self.handled.push(n);
+                    self.handled.borrow_mut().push(n);
                     ControlFlow::Continue(())
                 }
                 Request::Stop => ControlFlow::Break(()),
@@ -127,7 +208,7 @@ mod tests {
         }
 
         fn update(&mut self) {
-            self.updates += 1;
+            *self.updates.borrow_mut() += 1;
             // One update's worth of work, so `run` has a reason to stop looping.
             self.busy = false;
         }
@@ -137,54 +218,88 @@ mod tests {
         }
     }
 
-    #[test]
-    fn requests_reach_the_task_in_order() {
-        let (sender, receiver) = channel();
-        let mut worker = BgWorker::with_task(Recorder::default(), receiver);
-        sender.send(Request::Note(1)).unwrap();
-        sender.send(Request::Note(2)).unwrap();
-
-        worker.receive_requests(false);
-
-        assert_eq!(worker.task().handled, vec![1, 2]);
-        assert!(!worker.done());
+    fn recorder(handled: &Log) -> Recorder {
+        Recorder {
+            handled: handled.clone(),
+            ..Default::default()
+        }
     }
 
     #[test]
-    fn a_task_that_asks_to_stop_stops_the_worker() {
-        let (sender, receiver) = channel();
-        let mut worker = BgWorker::with_task(Recorder::default(), receiver);
-        sender.send(Request::Stop).unwrap();
+    fn each_task_gets_its_own_requests_in_order() {
+        let queues = BgQueues::new();
+        let (to_first, first_requests) = queues.queue();
+        let (to_second, second_requests) = queues.queue();
+        let (first, second) = (Log::default(), Log::default());
+        let mut worker = BgWorker::new(queues);
+        worker.add(recorder(&first), first_requests);
+        worker.add(recorder(&second), second_requests);
 
-        // Returns rather than waiting for a request that is not coming.
-        worker.run();
+        to_first.send(Request::Note(1)).unwrap();
+        to_second.send(Request::Note(2)).unwrap();
+        to_first.send(Request::Note(3)).unwrap();
+        worker.receive_requests(false);
 
-        assert!(worker.done());
+        assert_eq!(*first.borrow(), vec![1, 3]);
+        assert_eq!(*second.borrow(), vec![2]);
+    }
+
+    #[test]
+    fn a_task_that_asks_to_stop_leaves_the_others_running() {
+        let queues = BgQueues::new();
+        let (to_quitter, quitter_requests) = queues.queue();
+        let (to_survivor, survivor_requests) = queues.queue();
+        let survived = Log::default();
+        let mut worker = BgWorker::new(queues);
+        worker.add(Recorder::default(), quitter_requests);
+        worker.add(recorder(&survived), survivor_requests);
+
+        to_quitter.send(Request::Stop).unwrap();
+        worker.receive_requests(false);
+        to_survivor.send(Request::Note(1)).unwrap();
+        worker.receive_requests(false);
+
+        assert_eq!(*survived.borrow(), vec![1]);
     }
 
     /// Nobody is left to send: waiting for a request that cannot arrive would
-    /// hang the thread for the life of the process.
+    /// keep the thread alive for the life of the process.
     #[test]
-    fn a_channel_with_no_senders_stops_the_worker() {
-        let (sender, receiver) = channel::<Request>();
-        let mut worker = BgWorker::with_task(Recorder::default(), receiver);
+    fn a_queue_with_no_senders_retires_its_task() {
+        let queues = BgQueues::new();
+        let (sender, requests) = queues.queue::<Request>();
+        let mut worker = BgWorker::new(queues);
+        worker.add(Recorder::default(), requests);
         drop(sender);
 
         worker.run();
 
-        assert!(worker.done());
+        assert!(worker.tasks.is_empty());
     }
 
     #[test]
     fn a_busy_task_is_polled_rather_than_waited_on() {
-        let (sender, receiver) = channel();
-        let mut worker = BgWorker::with_task(Recorder::default(), receiver);
-        worker.task_mut().busy = true;
-        drop(sender);
+        let queues = BgQueues::new();
+        let (sender, requests) = queues.queue();
+        let updates = Rc::new(RefCell::new(0));
+        let mut worker = BgWorker::new(queues);
+        worker.add(
+            Recorder {
+                updates: updates.clone(),
+                busy: true,
+                ..Default::default()
+            },
+            requests,
+        );
 
-        // Would block for ever on an empty channel if `busy` were ignored.
+        // Nothing is queued yet, so a worker that waits before looking at what
+        // is in flight reaches the stop request without having updated the task.
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(50));
+            let _ = sender.send(Request::Stop);
+        });
         worker.run();
 
-        assert!(worker.task().updates >= 1);
+        assert!(*updates.borrow() >= 1);
     }
 }

--- a/src/block_device/mod.rs
+++ b/src/block_device/mod.rs
@@ -51,7 +51,7 @@ mod wait_for_completion;
 pub(crate) mod bdev_test;
 
 pub use bdev_lazy::{
-    bgworker::{BgWorker, BgWorkerRequest},
+    bgworker::{BgWorkerRequest, LazyTask},
     device::LazyBlockDevice,
     metadata::{
         save::DEFAULT_STRIPE_SECTOR_COUNT_SHIFT,
@@ -65,4 +65,5 @@ pub use bdev_crypt::CryptBlockDevice;
 pub use bdev_null::NullBlockDevice;
 pub use bdev_sync::SyncBlockDevice;
 pub use bdev_uring::UringBlockDevice;
+pub use bgworker::{BgQueues, BgSender, BgWorker};
 pub use wait_for_completion::wait_for_completion;

--- a/src/block_device/mod.rs
+++ b/src/block_device/mod.rs
@@ -44,6 +44,7 @@ mod bdev_lazy;
 mod bdev_null;
 mod bdev_sync;
 mod bdev_uring;
+pub mod bgworker;
 mod wait_for_completion;
 
 #[cfg(test)]

--- a/src/block_device/mod.rs
+++ b/src/block_device/mod.rs
@@ -51,7 +51,7 @@ mod wait_for_completion;
 pub(crate) mod bdev_test;
 
 pub use bdev_lazy::{
-    bgworker::{BgWorkerRequest, LazyTask},
+    bgworker::{LazyRequest, LazyTask},
     device::LazyBlockDevice,
     metadata::{
         save::DEFAULT_STRIPE_SECTOR_COUNT_SHIFT,
@@ -65,5 +65,5 @@ pub use bdev_crypt::CryptBlockDevice;
 pub use bdev_null::NullBlockDevice;
 pub use bdev_sync::SyncBlockDevice;
 pub use bdev_uring::UringBlockDevice;
-pub use bgworker::{BgQueues, BgSender, BgWorker};
+pub use bgworker::{BgQueues, BgSender, BgStopper, BgWorker};
 pub use wait_for_completion::wait_for_completion;


### PR DESCRIPTION
The worker loop is not specific to lazy devices: take requests from a channel, wait when there is nothing in flight and poll when there is, stop on shutdown or when the channel closes. A second device wanting background work would otherwise copy it.

The loop moves to block_device::bgworker behind a BgTask trait. What belongs to a lazy device -- its requests, the stripe fetcher, the metadata flusher -- stays in bdev_lazy as the task the worker drives.

Behaviour is unchanged, including that a queued request is still acted on after a shutdown request that precedes it. Callers see the same BgWorker and BgWorkerRequest and are untouched.