### PR TITLE
Move the background worker out of bdev_lazy 

### DIFF
--- a/src/backends/common/mod.rs
+++ b/src/backends/common/mod.rs
@@ -282,7 +282,9 @@ impl BackendEnv {
             autofetch,
             shared_state,
         )?;
-        Ok(BgWorker::new(lazy, receiver))
+        let mut worker = BgWorker::new(receiver);
+        worker.set_lazy_task(lazy);
+        Ok(worker)
     }
 }
 

--- a/src/backends/common/mod.rs
+++ b/src/backends/common/mod.rs
@@ -13,8 +13,8 @@ use ubiblk_macros::error_context;
 
 use crate::{
     block_device::{
-        self, BgWorker, BgWorkerRequest, BlockDevice, SharedMetadataState, StatusReporter,
-        SyncBlockDevice, UbiMetadata, UringBlockDevice,
+        self, BgWorker, BgWorkerRequest, BlockDevice, LazyTask, SharedMetadataState,
+        StatusReporter, SyncBlockDevice, UbiMetadata, UringBlockDevice,
     },
     config::v2,
     stripe_source::StripeSourceBuilder,
@@ -274,15 +274,15 @@ impl BackendEnv {
             }
         };
 
-        BgWorker::new(
+        let lazy = LazyTask::new(
             stripe_source,
             &*target_dev,
             &*metadata_dev,
             alignment,
             autofetch,
             shared_state,
-            receiver,
-        )
+        )?;
+        Ok(BgWorker::new(lazy, receiver))
     }
 }
 

--- a/src/block_device/bdev_lazy/bdev_lazy_tests.rs
+++ b/src/block_device/bdev_lazy/bdev_lazy_tests.rs
@@ -2,9 +2,9 @@
 mod tests {
     use crate::backends::SECTOR_SIZE;
     use crate::block_device::{
-        bdev_lazy::{BgWorker, LazyBlockDevice, SharedMetadataState, UbiMetadata},
+        bdev_lazy::{LazyBlockDevice, LazyTask, SharedMetadataState, UbiMetadata},
         bdev_test::{TestBlockDevice, TestDeviceMetrics},
-        metadata_flags, BlockDevice, IoChannel,
+        metadata_flags, BgWorker, BlockDevice, IoChannel,
     };
     use crate::block_device::{shared_buffer, SharedBuffer};
     use std::cell::RefCell;
@@ -59,16 +59,16 @@ mod tests {
                 image_dev.write(0, &tmp, SECTOR_SIZE);
             }
             let image_metrics = image_dev.metrics.clone();
-            let bgworker = BgWorker::new(
+            let lazy_task = LazyTask::new(
                 stripe_source,
                 &target_dev,
                 &metadata_dev,
                 SECTOR_SIZE,
                 false,
                 metadata_state.clone(),
-                bgworker_rx,
             )
             .unwrap();
+            let bgworker = BgWorker::new(lazy_task, bgworker_rx);
             let lazy = LazyBlockDevice::new(
                 Box::new(target_dev),
                 Some(Box::new(image_dev)),
@@ -100,16 +100,16 @@ mod tests {
                 tmp[..data.len()].copy_from_slice(data);
                 source_dev.write(0, &tmp, SECTOR_SIZE);
             }
-            let bgworker = BgWorker::new(
+            let lazy_task = LazyTask::new(
                 stripe_source,
                 &target_dev,
                 &metadata_dev,
                 SECTOR_SIZE,
                 false,
                 metadata_state.clone(),
-                bgworker_rx,
             )
             .unwrap();
+            let bgworker = BgWorker::new(lazy_task, bgworker_rx);
             let lazy = LazyBlockDevice::new(
                 Box::new(target_dev),
                 None,

--- a/src/block_device/bdev_lazy/bdev_lazy_tests.rs
+++ b/src/block_device/bdev_lazy/bdev_lazy_tests.rs
@@ -68,7 +68,8 @@ mod tests {
                 metadata_state.clone(),
             )
             .unwrap();
-            let bgworker = BgWorker::new(lazy_task, bgworker_rx);
+            let mut bgworker = BgWorker::new(bgworker_rx);
+            bgworker.set_lazy_task(lazy_task);
             let lazy = LazyBlockDevice::new(
                 Box::new(target_dev),
                 Some(Box::new(image_dev)),
@@ -109,7 +110,8 @@ mod tests {
                 metadata_state.clone(),
             )
             .unwrap();
-            let bgworker = BgWorker::new(lazy_task, bgworker_rx);
+            let mut bgworker = BgWorker::new(bgworker_rx);
+            bgworker.set_lazy_task(lazy_task);
             let lazy = LazyBlockDevice::new(
                 Box::new(target_dev),
                 None,

--- a/src/block_device/bdev_lazy/bgworker.rs
+++ b/src/block_device/bdev_lazy/bgworker.rs
@@ -4,8 +4,7 @@ use super::{
 };
 
 use crate::{block_device::BlockDevice, stripe_source::StripeSource, Result};
-use log::{error, info};
-use std::sync::mpsc::{Receiver, TryRecvError};
+use log::error;
 
 pub enum BgWorkerRequest {
     Fetch { stripe_id: usize },
@@ -13,16 +12,13 @@ pub enum BgWorkerRequest {
     Shutdown,
 }
 
-pub struct BgWorker {
+pub struct LazyTask {
     stripe_fetcher: StripeFetcher,
     metadata_flusher: MetadataFlusher,
-    req_receiver: Receiver<BgWorkerRequest>,
     metadata_state: SharedMetadataState,
-    done: bool,
 }
 
-impl BgWorker {
-    #[allow(clippy::too_many_arguments)]
+impl LazyTask {
     pub fn new(
         stripe_source: Box<dyn StripeSource>,
         target_dev: &dyn BlockDevice,
@@ -30,7 +26,6 @@ impl BgWorker {
         alignment: usize,
         autofetch: bool,
         metadata_state: SharedMetadataState,
-        req_receiver: Receiver<BgWorkerRequest>,
     ) -> Result<Self> {
         let source_sector_count = stripe_source.sector_count();
         let metadata_flusher =
@@ -43,11 +38,9 @@ impl BgWorker {
             alignment,
             autofetch,
         )?;
-        Ok(BgWorker {
+        Ok(LazyTask {
             stripe_fetcher,
             metadata_flusher,
-            req_receiver,
-            done: false,
             metadata_state,
         })
     }
@@ -56,44 +49,12 @@ impl BgWorker {
         self.metadata_state.clone()
     }
 
-    pub fn process_request(&mut self, req: BgWorkerRequest) {
-        match req {
-            BgWorkerRequest::Fetch { stripe_id } => {
-                self.stripe_fetcher.handle_fetch_request(stripe_id)
-            }
-            BgWorkerRequest::SetWritten { stripe_id } => {
-                self.metadata_flusher.set_stripe_written(stripe_id)
-            }
-            BgWorkerRequest::Shutdown => {
-                info!("Received shutdown request, stopping worker");
-                self.done = true;
-            }
-        }
+    pub fn fetch_stripe(&mut self, stripe_id: usize) {
+        self.stripe_fetcher.handle_fetch_request(stripe_id);
     }
 
-    pub fn receive_requests(&mut self, block: bool) {
-        if block {
-            match self.req_receiver.recv() {
-                Ok(req) => self.process_request(req),
-                Err(e) => {
-                    error!("Failed to receive request: {e}, stopping worker");
-                    self.done = true;
-                    return;
-                }
-            }
-        }
-
-        loop {
-            match self.req_receiver.try_recv() {
-                Ok(req) => self.process_request(req),
-                Err(TryRecvError::Disconnected) => {
-                    error!("Request channel disconnected, stopping worker");
-                    self.done = true;
-                    return;
-                }
-                Err(TryRecvError::Empty) => break,
-            }
-        }
+    pub fn set_stripe_written(&mut self, stripe_id: usize) {
+        self.metadata_flusher.set_stripe_written(stripe_id);
     }
 
     pub fn update(&mut self) {
@@ -109,13 +70,8 @@ impl BgWorker {
         self.stripe_fetcher.disconnect_from_source_if_all_fetched();
     }
 
-    pub fn run(&mut self) {
-        while !self.done {
-            let busy = self.stripe_fetcher.busy() || self.metadata_flusher.busy();
-            let block = !busy;
-            self.receive_requests(block);
-            self.update();
-        }
+    pub fn busy(&self) -> bool {
+        self.stripe_fetcher.busy() || self.metadata_flusher.busy()
     }
 }
 
@@ -124,7 +80,7 @@ mod tests {
     use super::*;
     use crate::{
         block_device::{
-            bdev_lazy::SharedMetadataState, bdev_test::TestBlockDevice, NullBlockDevice,
+            bdev_lazy::SharedMetadataState, bdev_test::TestBlockDevice, BgWorker, NullBlockDevice,
             UbiMetadata,
         },
         stripe_source,
@@ -133,7 +89,11 @@ mod tests {
 
     fn build_bg_worker_with_source(
         stripe_source: Box<dyn StripeSource>,
-    ) -> (BgWorker, std::sync::mpsc::Sender<BgWorkerRequest>) {
+    ) -> (
+        BgWorker,
+        std::sync::mpsc::Sender<BgWorkerRequest>,
+        SharedMetadataState,
+    ) {
         let stripe_sector_count_shift = 11;
         let target_dev = TestBlockDevice::new(1024 * 1024);
         let metadata_dev = TestBlockDevice::new(1024 * 1024);
@@ -145,23 +105,24 @@ mod tests {
         };
 
         let (tx, rx) = channel();
-
-        (
-            BgWorker::new(
-                stripe_source,
-                &target_dev,
-                &metadata_dev,
-                4096,
-                false,
-                metadata_state,
-                rx,
-            )
-            .unwrap(),
-            tx,
+        let lazy = LazyTask::new(
+            stripe_source,
+            &target_dev,
+            &metadata_dev,
+            4096,
+            false,
+            metadata_state.clone(),
         )
+        .unwrap();
+
+        (BgWorker::new(lazy, rx), tx, metadata_state)
     }
 
-    fn build_bg_worker() -> (BgWorker, std::sync::mpsc::Sender<BgWorkerRequest>) {
+    fn build_bg_worker() -> (
+        BgWorker,
+        std::sync::mpsc::Sender<BgWorkerRequest>,
+        SharedMetadataState,
+    ) {
         let stripe_sector_count_shift = 11;
         let stripe_sector_count = 1u64 << stripe_sector_count_shift;
         let source_dev = TestBlockDevice::new(1024 * 1024);
@@ -174,7 +135,7 @@ mod tests {
 
     #[test]
     fn test_bg_worker_shutdown() {
-        let (mut bg_worker, sender) = build_bg_worker();
+        let (mut bg_worker, sender, _) = build_bg_worker();
         sender.send(BgWorkerRequest::Shutdown).unwrap();
         bg_worker.run();
     }
@@ -198,18 +159,15 @@ mod tests {
             SharedMetadataState::new(&metadata)
         };
 
-        let (_tx, rx) = channel();
-
-        BgWorker::new(
+        LazyTask::new(
             stripe_source,
             &target_dev,
             &metadata_dev,
             4096,
             false,
             metadata_state,
-            rx,
         )
-        .expect("BgWorker should support null source device");
+        .expect("a lazy task should support a null source device");
     }
 
     #[test]
@@ -223,7 +181,8 @@ mod tests {
         let flaky_source =
             stripe_source::FlakyStripeSource::new(Box::new(base_source), vec![(0, 4)]);
 
-        let (mut bg_worker, sender) = build_bg_worker_with_source(Box::new(flaky_source));
+        let (mut bg_worker, sender, metadata_state) =
+            build_bg_worker_with_source(Box::new(flaky_source));
         sender
             .send(BgWorkerRequest::Fetch { stripe_id: 0 })
             .unwrap();
@@ -233,6 +192,6 @@ mod tests {
             bg_worker.update();
         }
 
-        assert!(bg_worker.shared_state().is_stripe_failed(0));
+        assert!(metadata_state.is_stripe_failed(0));
     }
 }

--- a/src/block_device/bdev_lazy/bgworker.rs
+++ b/src/block_device/bdev_lazy/bgworker.rs
@@ -6,12 +6,6 @@ use super::{
 use crate::{block_device::BlockDevice, stripe_source::StripeSource, Result};
 use log::error;
 
-pub enum BgWorkerRequest {
-    Fetch { stripe_id: usize },
-    SetWritten { stripe_id: usize },
-    Shutdown,
-}
-
 pub struct LazyTask {
     stripe_fetcher: StripeFetcher,
     metadata_flusher: MetadataFlusher,
@@ -80,8 +74,8 @@ mod tests {
     use super::*;
     use crate::{
         block_device::{
-            bdev_lazy::SharedMetadataState, bdev_test::TestBlockDevice, BgWorker, NullBlockDevice,
-            UbiMetadata,
+            bdev_lazy::SharedMetadataState, bdev_test::TestBlockDevice, BgWorker, BgWorkerRequest,
+            NullBlockDevice, UbiMetadata,
         },
         stripe_source,
     };
@@ -115,29 +109,10 @@ mod tests {
         )
         .unwrap();
 
-        (BgWorker::new(lazy, rx), tx, metadata_state)
-    }
+        let mut worker = BgWorker::new(rx);
+        worker.set_lazy_task(lazy);
 
-    fn build_bg_worker() -> (
-        BgWorker,
-        std::sync::mpsc::Sender<BgWorkerRequest>,
-        SharedMetadataState,
-    ) {
-        let stripe_sector_count_shift = 11;
-        let stripe_sector_count = 1u64 << stripe_sector_count_shift;
-        let source_dev = TestBlockDevice::new(1024 * 1024);
-        let stripe_source = Box::new(
-            stripe_source::BlockDeviceStripeSource::new(source_dev.clone(), stripe_sector_count)
-                .unwrap(),
-        );
-        build_bg_worker_with_source(stripe_source)
-    }
-
-    #[test]
-    fn test_bg_worker_shutdown() {
-        let (mut bg_worker, sender, _) = build_bg_worker();
-        sender.send(BgWorkerRequest::Shutdown).unwrap();
-        bg_worker.run();
+        (worker, tx, metadata_state)
     }
 
     #[test]

--- a/src/block_device/bdev_lazy/device.rs
+++ b/src/block_device/bdev_lazy/device.rs
@@ -1,12 +1,9 @@
 use crate::{
-    block_device::{BlockDevice, IoChannel, SharedBuffer, SharedMetadataState},
+    block_device::{BgWorkerRequest, BlockDevice, IoChannel, SharedBuffer, SharedMetadataState},
     Result, ResultExt,
 };
 
-use super::{
-    bgworker::BgWorkerRequest,
-    metadata::{Failed, Fetched, NoSource, NotFetched},
-};
+use super::metadata::{Failed, Fetched, NoSource, NotFetched};
 
 use std::{
     collections::{HashSet, VecDeque},

--- a/src/block_device/bgworker.rs
+++ b/src/block_device/bgworker.rs
@@ -1,0 +1,69 @@
+use std::sync::mpsc::{Receiver, TryRecvError};
+
+use log::{error, info};
+
+use super::bdev_lazy::bgworker::{BgWorkerRequest, LazyTask};
+
+pub struct BgWorker {
+    lazy: LazyTask,
+    requests: Receiver<BgWorkerRequest>,
+    done: bool,
+}
+
+impl BgWorker {
+    pub fn new(lazy: LazyTask, requests: Receiver<BgWorkerRequest>) -> Self {
+        BgWorker {
+            lazy,
+            requests,
+            done: false,
+        }
+    }
+
+    pub fn process_request(&mut self, req: BgWorkerRequest) {
+        match req {
+            BgWorkerRequest::Fetch { stripe_id } => self.lazy.fetch_stripe(stripe_id),
+            BgWorkerRequest::SetWritten { stripe_id } => self.lazy.set_stripe_written(stripe_id),
+            BgWorkerRequest::Shutdown => {
+                info!("Received shutdown request, stopping worker");
+                self.done = true;
+            }
+        }
+    }
+
+    pub fn receive_requests(&mut self, block: bool) {
+        if block {
+            match self.requests.recv() {
+                Ok(req) => self.process_request(req),
+                Err(e) => {
+                    error!("Failed to receive request: {e}, stopping worker");
+                    self.done = true;
+                    return;
+                }
+            }
+        }
+
+        loop {
+            match self.requests.try_recv() {
+                Ok(req) => self.process_request(req),
+                Err(TryRecvError::Disconnected) => {
+                    error!("Request channel disconnected, stopping worker");
+                    self.done = true;
+                    return;
+                }
+                Err(TryRecvError::Empty) => break,
+            }
+        }
+    }
+
+    pub fn update(&mut self) {
+        self.lazy.update();
+    }
+
+    pub fn run(&mut self) {
+        while !self.done {
+            let block = !self.lazy.busy();
+            self.receive_requests(block);
+            self.update();
+        }
+    }
+}

--- a/src/block_device/bgworker.rs
+++ b/src/block_device/bgworker.rs
@@ -2,27 +2,52 @@ use std::sync::mpsc::{Receiver, TryRecvError};
 
 use log::{error, info};
 
-use super::bdev_lazy::bgworker::{BgWorkerRequest, LazyTask};
+use super::bdev_lazy::bgworker::LazyTask;
+
+pub enum BgWorkerRequest {
+    Fetch { stripe_id: usize },
+    SetWritten { stripe_id: usize },
+    Shutdown,
+}
 
 pub struct BgWorker {
-    lazy: LazyTask,
+    lazy: Option<LazyTask>,
     requests: Receiver<BgWorkerRequest>,
     done: bool,
 }
 
 impl BgWorker {
-    pub fn new(lazy: LazyTask, requests: Receiver<BgWorkerRequest>) -> Self {
+    pub fn new(requests: Receiver<BgWorkerRequest>) -> Self {
         BgWorker {
-            lazy,
+            lazy: None,
             requests,
             done: false,
         }
     }
 
-    pub fn process_request(&mut self, req: BgWorkerRequest) {
+    pub fn set_lazy_task(&mut self, lazy: LazyTask) {
+        self.lazy = Some(lazy);
+    }
+
+    fn lazy(&mut self) -> Option<&mut LazyTask> {
+        if self.lazy.is_none() {
+            error!("Request for a lazy task the worker does not have");
+        }
+        self.lazy.as_mut()
+    }
+
+    fn process_request(&mut self, req: BgWorkerRequest) {
         match req {
-            BgWorkerRequest::Fetch { stripe_id } => self.lazy.fetch_stripe(stripe_id),
-            BgWorkerRequest::SetWritten { stripe_id } => self.lazy.set_stripe_written(stripe_id),
+            BgWorkerRequest::Fetch { stripe_id } => {
+                if let Some(lazy) = self.lazy() {
+                    lazy.fetch_stripe(stripe_id);
+                }
+            }
+            BgWorkerRequest::SetWritten { stripe_id } => {
+                if let Some(lazy) = self.lazy() {
+                    lazy.set_stripe_written(stripe_id);
+                }
+            }
             BgWorkerRequest::Shutdown => {
                 info!("Received shutdown request, stopping worker");
                 self.done = true;
@@ -56,14 +81,49 @@ impl BgWorker {
     }
 
     pub fn update(&mut self) {
-        self.lazy.update();
+        if let Some(lazy) = &mut self.lazy {
+            lazy.update();
+        }
+    }
+
+    fn busy(&self) -> bool {
+        self.lazy.as_ref().is_some_and(|lazy| lazy.busy())
     }
 
     pub fn run(&mut self) {
         while !self.done {
-            let block = !self.lazy.busy();
+            let block = !self.busy();
             self.receive_requests(block);
             self.update();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc::channel;
+
+    #[test]
+    fn a_shutdown_request_stops_the_worker() {
+        let (sender, requests) = channel();
+        let mut worker = BgWorker::new(requests);
+        sender.send(BgWorkerRequest::Shutdown).unwrap();
+
+        worker.run();
+
+        assert!(worker.done);
+    }
+
+    /// Otherwise the thread waits for a request that cannot arrive.
+    #[test]
+    fn a_channel_with_no_senders_stops_the_worker() {
+        let (sender, requests) = channel::<BgWorkerRequest>();
+        let mut worker = BgWorker::new(requests);
+        drop(sender);
+
+        worker.run();
+
+        assert!(worker.done);
     }
 }

--- a/src/block_device/mod.rs
+++ b/src/block_device/mod.rs
@@ -51,7 +51,7 @@ mod wait_for_completion;
 pub(crate) mod bdev_test;
 
 pub use bdev_lazy::{
-    bgworker::{BgWorkerRequest, LazyTask},
+    bgworker::LazyTask,
     device::LazyBlockDevice,
     metadata::{
         save::DEFAULT_STRIPE_SECTOR_COUNT_SHIFT,
@@ -65,5 +65,5 @@ pub use bdev_crypt::CryptBlockDevice;
 pub use bdev_null::NullBlockDevice;
 pub use bdev_sync::SyncBlockDevice;
 pub use bdev_uring::UringBlockDevice;
-pub use bgworker::BgWorker;
+pub use bgworker::{BgWorker, BgWorkerRequest};
 pub use wait_for_completion::wait_for_completion;

--- a/src/block_device/mod.rs
+++ b/src/block_device/mod.rs
@@ -44,13 +44,14 @@ mod bdev_lazy;
 mod bdev_null;
 mod bdev_sync;
 mod bdev_uring;
+pub mod bgworker;
 mod wait_for_completion;
 
 #[cfg(test)]
 pub(crate) mod bdev_test;
 
 pub use bdev_lazy::{
-    bgworker::{BgWorker, BgWorkerRequest},
+    bgworker::{BgWorkerRequest, LazyTask},
     device::LazyBlockDevice,
     metadata::{
         save::DEFAULT_STRIPE_SECTOR_COUNT_SHIFT,
@@ -64,4 +65,5 @@ pub use bdev_crypt::CryptBlockDevice;
 pub use bdev_null::NullBlockDevice;
 pub use bdev_sync::SyncBlockDevice;
 pub use bdev_uring::UringBlockDevice;
+pub use bgworker::BgWorker;
 pub use wait_for_completion::wait_for_completion;


### PR DESCRIPTION
### Move the background worker out of bdev_lazy 

The worker was part of the lazy device: it owned the stripe fetcher and the metadata flusher as its own fields. The spill layer will need background work too, and it should share this thread rather than start another.

The loop moves to block_device::bgworker unchanged. What it drives stays in bdev_lazy as LazyTask, which the worker now holds and asks to make progress.

### Make room on the worker for other devices' tasks 

The worker held the lazy device's task and nothing else, and its requests were the lazy device's requests. The spill layer needs a task of its own on this thread, and a device without metadata has no lazy task at all.

Requests are now addressed: BgWorkerRequest::Lazy carries what the lazy device asked for, Shutdown is for the worker itself. The task becomes a slot the backend fills, so a second one is a field and a variant rather than a second thread.