### PR TITLE
Prevent umask changes from breaking parallel tests

### DIFF
--- a/src/backends/common/mod.rs
+++ b/src/backends/common/mod.rs
@@ -524,7 +524,6 @@ mod tests {
     use crate::block_device::bdev_test::TestBlockDevice;
     use crate::config::v2::stripe_source::StripeSourceConfig;
     use crate::config::v2::{self, DeviceSection};
-    use crate::utils::umask_guard::UMASK_LOCK;
     use std::os::unix::fs::symlink;
     use std::os::unix::fs::PermissionsExt;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -575,7 +574,6 @@ mod tests {
 
     #[test]
     fn ensure_metadata_file_creates_with_mode_0600() {
-        let _umask_guard = UMASK_LOCK.lock().unwrap();
         let dir = tempfile::tempdir().unwrap();
         let metadata_path = dir.path().join("metadata.bin");
 
@@ -596,7 +594,6 @@ mod tests {
 
     #[test]
     fn ensure_metadata_file_fixes_existing_mode() {
-        let _umask_guard = UMASK_LOCK.lock().unwrap();
         let dir = tempfile::tempdir().unwrap();
         let metadata_path = dir.path().join("metadata.bin");
         std::fs::write(&metadata_path, []).unwrap();
@@ -618,7 +615,6 @@ mod tests {
 
     #[test]
     fn ensure_metadata_file_clears_special_mode_bits() {
-        let _umask_guard = UMASK_LOCK.lock().unwrap();
         let dir = tempfile::tempdir().unwrap();
         let metadata_path = dir.path().join("metadata.bin");
         std::fs::write(&metadata_path, []).unwrap();
@@ -640,7 +636,6 @@ mod tests {
 
     #[test]
     fn ensure_metadata_file_rejects_symlink_path() {
-        let _umask_guard = UMASK_LOCK.lock().unwrap();
         let dir = tempfile::tempdir().unwrap();
         let target_path = dir.path().join("target.bin");
         let metadata_path = dir.path().join("metadata.bin");
@@ -653,7 +648,6 @@ mod tests {
 
     #[test]
     fn ensure_metadata_file_expands_existing_file_when_too_small() {
-        let _umask_guard = UMASK_LOCK.lock().unwrap();
         let dir = tempfile::tempdir().unwrap();
         let metadata_path = dir.path().join("metadata.bin");
         std::fs::write(&metadata_path, [0u8; 1]).unwrap();
@@ -925,7 +919,6 @@ mod tests {
 
     #[test]
     fn ensure_metadata_file_rejects_non_regular_file() {
-        let _umask_guard = UMASK_LOCK.lock().unwrap();
         // /dev/null can be opened read+write but is not a regular file
         let result = ensure_metadata_file(Path::new("/dev/null"), SECTOR_SIZE);
         assert!(result.is_err());
@@ -938,7 +931,6 @@ mod tests {
 
     #[test]
     fn ensure_metadata_file_preserves_size_when_already_large_enough() {
-        let _umask_guard = UMASK_LOCK.lock().unwrap();
         let dir = tempfile::tempdir().unwrap();
         let metadata_path = dir.path().join("metadata.bin");
         // Create file larger than minimum

--- a/src/backends/common/rpc.rs
+++ b/src/backends/common/rpc.rs
@@ -257,7 +257,6 @@ mod tests {
     use crate::block_device::{
         metadata_flags, SharedMetadataState, UbiMetadata, DEFAULT_STRIPE_SECTOR_COUNT_SHIFT,
     };
-    use crate::utils::umask_guard::UMASK_LOCK;
 
     use super::*;
     use serde_json::Value;
@@ -307,19 +306,10 @@ mod tests {
         read_response(&mut stream)
     }
 
-    fn wrapped_start_rpc_server(
-        path: &Path,
-        status_reporter: Option<StatusReporter>,
-        io_trackers: Vec<IoTracker>,
-    ) -> Result<RpcServerHandle> {
-        let _l = UMASK_LOCK.lock().unwrap();
-        start_rpc_server(path, status_reporter, io_trackers)
-    }
-
     #[test]
     fn test_nonexistent_directory_socket_path() {
         let bad_path = PathBuf::from("/nonexistent_directory/ubiblk_rpc.sock");
-        let result = wrapped_start_rpc_server(&bad_path, None, vec![]);
+        let result = start_rpc_server(&bad_path, None, vec![]);
         assert!(result.is_err());
     }
 
@@ -329,7 +319,7 @@ mod tests {
         // This is reliably not removable via `remove_file()`.
         let bad_path = std::env::current_dir().unwrap();
 
-        let result = wrapped_start_rpc_server(&bad_path, None, vec![]);
+        let result = start_rpc_server(&bad_path, None, vec![]);
         assert!(result.is_err());
         assert!(result
             .err()
@@ -343,8 +333,7 @@ mod tests {
         let path = test_socket_path("version");
 
         // Start server with no trackers and no reporter
-        let handle =
-            wrapped_start_rpc_server(&path, None, vec![]).expect("Failed to start RPC server");
+        let handle = start_rpc_server(&path, None, vec![]).expect("Failed to start RPC server");
 
         let response = rpc_call(&path, "version");
 
@@ -365,8 +354,8 @@ mod tests {
         let shared_state = SharedMetadataState::new(&metadata);
         let reporter = StatusReporter::new(shared_state, 64 * 2048);
 
-        let handle = wrapped_start_rpc_server(&path, Some(reporter), vec![])
-            .expect("Failed to start RPC server");
+        let handle =
+            start_rpc_server(&path, Some(reporter), vec![]).expect("Failed to start RPC server");
 
         let response = rpc_call(&path, "status");
         handle.stop().expect("Failed to stop RPC server");
@@ -385,8 +374,7 @@ mod tests {
         let path = test_socket_path("status_empty");
 
         // Start server with None for status_reporter
-        let handle =
-            wrapped_start_rpc_server(&path, None, vec![]).expect("Failed to start RPC server");
+        let handle = start_rpc_server(&path, None, vec![]).expect("Failed to start RPC server");
 
         let response = rpc_call(&path, "status");
 
@@ -417,7 +405,7 @@ mod tests {
 
         // Start server with multiple trackers and no reporter
         let handle =
-            wrapped_start_rpc_server(&path, None, io_trackers).expect("Failed to start RPC server");
+            start_rpc_server(&path, None, io_trackers).expect("Failed to start RPC server");
 
         let response = rpc_call(&path, "queues");
 
@@ -440,8 +428,7 @@ mod tests {
         let path = test_socket_path("queues_empty");
 
         // Start server with empty trackers vector
-        let handle =
-            wrapped_start_rpc_server(&path, None, vec![]).expect("Failed to start RPC server");
+        let handle = start_rpc_server(&path, None, vec![]).expect("Failed to start RPC server");
 
         let response = rpc_call(&path, "queues");
 
@@ -455,8 +442,7 @@ mod tests {
     #[test]
     fn test_rpc_unknown_command() {
         let path = test_socket_path("unknown");
-        let handle =
-            wrapped_start_rpc_server(&path, None, vec![]).expect("Failed to start RPC server");
+        let handle = start_rpc_server(&path, None, vec![]).expect("Failed to start RPC server");
 
         let response = rpc_call(&path, "destroy_world");
 
@@ -471,8 +457,7 @@ mod tests {
     #[test]
     fn test_ignore_empty_lines() {
         let path = test_socket_path("empty_lines");
-        let handle =
-            wrapped_start_rpc_server(&path, None, vec![]).expect("Failed to start RPC server");
+        let handle = start_rpc_server(&path, None, vec![]).expect("Failed to start RPC server");
 
         let mut stream = connect(&path);
 
@@ -492,8 +477,7 @@ mod tests {
     #[test]
     fn test_rpc_malformed_json() {
         let path = test_socket_path("malformed");
-        let handle =
-            wrapped_start_rpc_server(&path, None, vec![]).expect("Failed to start RPC server");
+        let handle = start_rpc_server(&path, None, vec![]).expect("Failed to start RPC server");
 
         let mut stream = connect(&path);
 
@@ -535,7 +519,7 @@ mod tests {
         let io_trackers = vec![io_tracker_1, io_tracker_2, io_tracker_3];
 
         let handle =
-            wrapped_start_rpc_server(&path, None, io_trackers).expect("Failed to start RPC server");
+            start_rpc_server(&path, None, io_trackers).expect("Failed to start RPC server");
 
         let response = rpc_call(&path, "stats");
 
@@ -575,8 +559,7 @@ mod tests {
         let path = test_socket_path("stats_empty");
 
         // Start server with empty trackers vector
-        let handle =
-            wrapped_start_rpc_server(&path, None, vec![]).expect("Failed to start RPC server");
+        let handle = start_rpc_server(&path, None, vec![]).expect("Failed to start RPC server");
 
         let response = rpc_call(&path, "stats");
 

--- a/src/backends/ublk/mod.rs
+++ b/src/backends/ublk/mod.rs
@@ -409,11 +409,9 @@ fn serve_ublk_queue(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils::umask_guard::UMASK_LOCK;
 
     #[test]
     fn test_create_device_symlink() {
-        let _l = UMASK_LOCK.lock().unwrap();
         let tmp_dir = tempfile::tempdir().expect("Failed to create temp dir");
         let target = tmp_dir.path().join("ublk-target");
         let link = tmp_dir.path().join("ublk-symlink");
@@ -426,7 +424,6 @@ mod tests {
 
     #[test]
     fn test_create_device_symlink_existing() {
-        let _l = UMASK_LOCK.lock().unwrap();
         let tmp_dir = tempfile::tempdir().expect("Failed to create temp dir");
         let target = tmp_dir.path().join("ublk-target");
         let link = tmp_dir.path().join("ublk-symlink");
@@ -438,7 +435,6 @@ mod tests {
 
     #[test]
     fn test_remove_device_symlink() {
-        let _l = UMASK_LOCK.lock().unwrap();
         let tmp_dir = tempfile::tempdir().expect("Failed to create temp dir");
         let link = tmp_dir.path().join("ublk-symlink");
         std::os::unix::fs::symlink("/dev/ublk-target", &link).expect("Failed to create symlink");
@@ -448,7 +444,6 @@ mod tests {
 
     #[test]
     fn test_remove_device_symlink_not_found() {
-        let _l = UMASK_LOCK.lock().unwrap();
         let tmp_dir = tempfile::tempdir().expect("Failed to create temp dir");
         let link = tmp_dir.path().join("nonexistent-symlink");
         // Should succeed silently when path doesn't exist
@@ -457,7 +452,6 @@ mod tests {
 
     #[test]
     fn test_remove_device_symlink_not_a_symlink() {
-        let _l = UMASK_LOCK.lock().unwrap();
         let tmp_dir = tempfile::tempdir().expect("Failed to create temp dir");
         let link = tmp_dir.path().join("regular-file");
         std::fs::write(&link, b"not a symlink").expect("Failed to create file");
@@ -514,7 +508,6 @@ mod tests {
 
     #[test]
     fn test_create_device_symlink_nested_parent() {
-        let _l = UMASK_LOCK.lock().unwrap();
         let tmp_dir = tempfile::tempdir().expect("Failed to create temp dir");
         let target = tmp_dir.path().join("ublk-target");
         let link = tmp_dir.path().join("a/b/c/ublk-symlink");
@@ -525,7 +518,6 @@ mod tests {
 
     #[test]
     fn test_create_device_symlink_replaces_existing_symlink() {
-        let _l = UMASK_LOCK.lock().unwrap();
         let tmp_dir = tempfile::tempdir().expect("Failed to create temp dir");
         let target1 = tmp_dir.path().join("target1");
         let target2 = tmp_dir.path().join("target2");

--- a/src/backends/vhost/backend_loop.rs
+++ b/src/backends/vhost/backend_loop.rs
@@ -86,7 +86,6 @@ fn serve_vhost(backend_env: &BackendEnv) -> Result<()> {
 mod tests {
     use super::*;
     use crate::backends::common::BackendEnv;
-    use crate::utils::umask_guard::UMASK_LOCK;
     use std::os::unix::net::UnixStream;
 
     fn test_danger_zone() -> v2::DangerZone {
@@ -140,8 +139,6 @@ mod tests {
     /// client disconnection gracefully.
     #[test]
     fn serve_vhost_handles_client_disconnect() {
-        let _umask_guard = UMASK_LOCK.lock().unwrap();
-
         let disk_file = tempfile::NamedTempFile::new().unwrap();
         disk_file.as_file().set_len(10 * 1024 * 1024).unwrap();
 

--- a/src/config/v2/load.rs
+++ b/src/config/v2/load.rs
@@ -561,11 +561,10 @@ allow_env_secrets = true
         use std::io::Write;
         use std::os::unix::fs::PermissionsExt;
 
-        let dir = std::env::temp_dir().join("ubiblk-test-perms");
-        let _ = std::fs::create_dir_all(&dir);
+        let dir = tempfile::tempdir().unwrap();
 
         // File with 0644 should be detected as loose
-        let loose_path = dir.join("loose.toml");
+        let loose_path = dir.path().join("loose.toml");
         let mut f = std::fs::File::create(&loose_path).unwrap();
         f.write_all(b"[device]\ndata_path = \"/dev/x\"\n").unwrap();
         std::fs::set_permissions(&loose_path, std::fs::Permissions::from_mode(0o644)).unwrap();
@@ -578,7 +577,7 @@ allow_env_secrets = true
         );
 
         // File with 0600 should not be flagged
-        let tight_path = dir.join("tight.toml");
+        let tight_path = dir.path().join("tight.toml");
         let mut f = std::fs::File::create(&tight_path).unwrap();
         f.write_all(b"[device]\ndata_path = \"/dev/x\"\n").unwrap();
         std::fs::set_permissions(&tight_path, std::fs::Permissions::from_mode(0o600)).unwrap();
@@ -589,8 +588,6 @@ allow_env_secrets = true
         // load_root_toml should succeed (warning only, not error) even with loose perms
         let result = load_root_toml(&loose_path, "test");
         assert!(result.is_ok(), "loose permissions should warn, not error");
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src/utils/umask_guard.rs
+++ b/src/utils/umask_guard.rs
@@ -1,6 +1,3 @@
-#[cfg(test)]
-use std::sync::Mutex;
-
 use nix::sys::stat::{umask, Mode};
 
 /// RAII guard that temporarily sets the process umask.
@@ -14,6 +11,12 @@ pub struct UmaskGuard {
 impl UmaskGuard {
     /// Set the process umask to `mask` and restore it on drop.
     pub fn set(mask: libc::mode_t) -> Self {
+        // Tests run beside unrelated filesystem operations that cannot all
+        // participate in a lock. Keep the real umask syscall, but detach this
+        // thread's filesystem context before changing it.
+        #[cfg(test)]
+        isolate_test_umask();
+
         let previous = umask(Mode::from_bits_retain(mask));
         Self { previous }
     }
@@ -26,15 +29,18 @@ impl Drop for UmaskGuard {
 }
 
 #[cfg(test)]
-pub(crate) static UMASK_LOCK: Mutex<()> = Mutex::new(());
+fn isolate_test_umask() {
+    nix::sched::unshare(nix::sched::CloneFlags::CLONE_FS).expect("isolate the test thread's umask");
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::fs;
-    use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+    use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsExt};
 
     fn get_umask() -> libc::mode_t {
+        isolate_test_umask();
         let cur = umask(Mode::from_bits_retain(0));
         umask(cur);
         cur.bits()
@@ -42,7 +48,6 @@ mod tests {
 
     #[test]
     fn restores_on_drop() {
-        let _l = UMASK_LOCK.lock().unwrap();
         let orig = get_umask();
 
         {
@@ -54,13 +59,8 @@ mod tests {
 
     #[test]
     fn masks_file_creation() {
-        let _l = UMASK_LOCK.lock().unwrap();
-
-        let dir = std::env::temp_dir().join("umaskguard-test");
-        let file = dir.join("f");
-        fs::remove_file(&file).ok();
-        fs::remove_dir(&dir).ok();
-        fs::create_dir_all(&dir).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("f");
 
         {
             let _g = UmaskGuard::set(0o006);
@@ -75,8 +75,35 @@ mod tests {
 
         let mode = fs::metadata(&file).unwrap().mode() & 0o777;
         assert_eq!(mode, 0o666 & !0o006);
+    }
 
-        fs::remove_file(&file).ok();
-        fs::remove_dir(&dir).ok();
+    #[test]
+    fn restrictive_umask_does_not_affect_other_test_threads() {
+        let dir = tempfile::tempdir().unwrap();
+        let child = dir.path().join("child");
+        let (ready_tx, ready_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            let _guard = UmaskGuard::set(0o777);
+            ready_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
+        });
+        ready_rx.recv().unwrap();
+
+        // Hold the restrictive mask until both operations finish. A mutex
+        // around UmaskGuard alone cannot protect these unrelated operations.
+        let result = fs::DirBuilder::new()
+            .mode(0o700)
+            .create(&child)
+            .and_then(|()| fs::write(child.join("file"), b"parallel test"));
+        release_tx.send(()).unwrap();
+        worker.join().unwrap();
+
+        // Also allow cleanup when running this regression against the old code.
+        let mode = fs::metadata(&child).unwrap().mode() & 0o777;
+        fs::set_permissions(&child, fs::Permissions::from_mode(0o700)).unwrap();
+        // Check the mode as well, so this catches the regression even as root.
+        assert_eq!(mode, 0o700);
+        result.expect("another test thread's umask must not prevent file creation");
     }
 }


### PR DESCRIPTION
Keep test umask changes from affecting unrelated filesystem tests. Socket tests could remove directory search permissions during other tests, causing EACCES failures and poisoned-lock cascades. Permission tests could also leave unusable shared directories behind and break later runs.

Give permission tests independent temporary directories and cover concurrent file creation while another test holds a restrictive umask. Production behavior is unchanged.