### PR TITLE
Fail an I/O that moved fewer bytes than it asked for

### DIFF
--- a/src/archive/archiver.rs
+++ b/src/archive/archiver.rs
@@ -469,6 +469,41 @@ mod tests {
     }
 
     #[test]
+    fn archives_a_final_stripe_the_image_only_partly_holds() {
+        let stripe_len = STRIPE_SECTOR_COUNT as usize * SECTOR_SIZE;
+        let bdev = Box::new(TestBlockDevice::new(2 * stripe_len as u64));
+        let image = Box::new(TestBlockDevice::new(
+            2 * stripe_len as u64 - SECTOR_SIZE as u64,
+        ));
+        image.write(0, &vec![0xAAu8; stripe_len], stripe_len);
+        let tail = vec![0xBBu8; stripe_len - SECTOR_SIZE];
+        image.write(stripe_len, &tail, tail.len());
+
+        let metadata = UbiMetadata::new(STRIPE_SECTOR_COUNT_SHIFT, 2, 2);
+        let stripe_source = BlockDeviceStripeSource::new(image, STRIPE_SECTOR_COUNT).unwrap();
+        let mut store = Box::new(MemStore::default());
+        let mut archiver = StripeArchiver::new(
+            Box::new(stripe_source),
+            bdev.as_ref(),
+            metadata,
+            Box::new(MemStore::new_with_objects(store.objects.clone())),
+            false,
+            ArchiveCompressionAlgorithm::None,
+            KeyEncryptionCipher::default(),
+            1,
+        )
+        .unwrap();
+
+        archiver.archive_all().unwrap();
+
+        let key = archiver.object_key(expect_hash(&archiver.stripe_hashes, 1));
+        let archived = store.get_object(&key, Duration::from_secs(5)).unwrap();
+        let mut expected = tail.clone();
+        expected.extend(vec![0u8; SECTOR_SIZE]);
+        assert_eq!(archived, expected);
+    }
+
+    #[test]
     fn test_archive_all_no_image_stripes() {
         let (mut archiver, mut store) = prep(16, 0, false, Vec::new());
         archiver.metadata.stripe_headers[2] |= metadata_flags::WRITTEN;

--- a/src/archive/archiver.rs
+++ b/src/archive/archiver.rs
@@ -27,6 +27,7 @@ pub struct StripeArchiver {
     block_cipher: Option<XtsBlockCipher>,
     kek: KeyEncryptionCipher,
     buffer_pool: AlignedBufferPool,
+    device_sector_count: u64,
     inflight_puts: usize,
     stripe_fetch_buffers: HashMap<usize, SharedBuffer>,
     seen_object_keys: HashSet<String>,
@@ -74,6 +75,7 @@ impl StripeArchiver {
             kek,
             stripe_count,
             buffer_pool,
+            device_sector_count: bdev.sector_count(),
             inflight_puts: 0,
             stripe_fetch_buffers: HashMap::new(),
             seen_object_keys: HashSet::new(),
@@ -146,12 +148,14 @@ impl StripeArchiver {
     fn start_fetch_stripe(&mut self, stripe_id: usize, buffer: SharedBuffer) -> Result<()> {
         if self.stripe_written(stripe_id) || self.stripe_fetched(stripe_id) {
             debug!("Fetching stripe {} from block device", stripe_id,);
-            self.io_channel.add_read(
-                self.stripe_offset(stripe_id),
-                self.metadata.stripe_sector_count() as u32,
-                buffer,
-                stripe_id,
-            );
+            let offset = self.stripe_offset(stripe_id);
+            let sectors =
+                self.metadata
+                    .stripe_sector_count()
+                    .min(self.device_sector_count.saturating_sub(offset)) as u32;
+            // Pooled buffers come back with the last stripe's bytes in them.
+            buffer.borrow_mut().as_mut_slice()[sectors as usize * SECTOR_SIZE..].fill(0);
+            self.io_channel.add_read(offset, sectors, buffer, stripe_id);
             self.io_channel.submit()?;
         } else {
             debug!("Fetching stripe {} from image", stripe_id,);
@@ -424,6 +428,44 @@ mod tests {
                 assert!(!should_archive);
             }
         }
+    }
+
+    #[test]
+    fn archives_a_final_stripe_the_device_only_partly_holds() {
+        let stripe_len = STRIPE_SECTOR_COUNT as usize * SECTOR_SIZE;
+        let bdev = Box::new(TestBlockDevice::new(
+            2 * stripe_len as u64 - SECTOR_SIZE as u64,
+        ));
+        bdev.write(0, &vec![0xAAu8; stripe_len], stripe_len);
+        let tail = vec![0xBBu8; stripe_len - SECTOR_SIZE];
+        bdev.write(stripe_len, &tail, tail.len());
+
+        let mut metadata = UbiMetadata::new(STRIPE_SECTOR_COUNT_SHIFT, 2, 0);
+        metadata.stripe_headers[0] |= metadata_flags::WRITTEN;
+        metadata.stripe_headers[1] |= metadata_flags::WRITTEN;
+
+        let stripe_source =
+            BlockDeviceStripeSource::new(bdev.clone(), STRIPE_SECTOR_COUNT).unwrap();
+        let mut store = Box::new(MemStore::default());
+        let mut archiver = StripeArchiver::new(
+            Box::new(stripe_source),
+            bdev.as_ref(),
+            metadata,
+            Box::new(MemStore::new_with_objects(store.objects.clone())),
+            false,
+            ArchiveCompressionAlgorithm::None,
+            KeyEncryptionCipher::default(),
+            1,
+        )
+        .unwrap();
+
+        archiver.archive_all().unwrap();
+
+        let key = archiver.object_key(expect_hash(&archiver.stripe_hashes, 1));
+        let archived = store.get_object(&key, Duration::from_secs(5)).unwrap();
+        let mut expected = tail.clone();
+        expected.extend(vec![0u8; SECTOR_SIZE]);
+        assert_eq!(archived, expected);
     }
 
     #[test]

--- a/src/block_device/bdev_lazy/stripe_fetcher.rs
+++ b/src/block_device/bdev_lazy/stripe_fetcher.rs
@@ -373,6 +373,52 @@ mod tests {
         assert_eq!(target_metrics.flushes, 1);
     }
 
+    // Once the pool has cycled, a fetch reuses a dirty buffer: the part of the
+    // last stripe the source does not have must still land as zeroes.
+    #[test]
+    fn a_partial_final_source_stripe_lands_zero_padded() {
+        let shift = 3u8;
+        let stripe_sectors = 1u64 << shift;
+        let stripe_len = stripe_sectors as usize * SECTOR_SIZE;
+        let full = MAX_CONCURRENT_FETCHES;
+
+        let source_dev = Box::new(TestBlockDevice::new(
+            (full * stripe_len) as u64 + SECTOR_SIZE as u64,
+        ));
+        let target_dev = Box::new(TestBlockDevice::new(((full + 1) * stripe_len) as u64));
+        source_dev.write(0, &vec![0xAAu8; full * stripe_len], full * stripe_len);
+        source_dev.write(full * stripe_len, &[0xBBu8; SECTOR_SIZE], SECTOR_SIZE);
+
+        let stripe_source =
+            Box::new(BlockDeviceStripeSource::new(source_dev.clone(), stripe_sectors).unwrap());
+        let metadata = UbiMetadata::new(
+            shift,
+            target_dev.stripe_count(stripe_sectors),
+            source_dev.stripe_count(stripe_sectors),
+        );
+        let mut fetcher = StripeFetcher::new(
+            stripe_source,
+            &*target_dev,
+            stripe_sectors,
+            SharedMetadataState::new(&metadata),
+            SECTOR_SIZE,
+            false,
+        )
+        .unwrap();
+
+        for stripe_id in 0..=full {
+            fetcher.handle_fetch_request(stripe_id);
+            for _ in 0..10 {
+                fetcher.update();
+            }
+        }
+
+        let mut expected = vec![0xBBu8; SECTOR_SIZE];
+        expected.extend(vec![0u8; stripe_len - SECTOR_SIZE]);
+        let mem = target_dev.mem.read().unwrap();
+        assert_eq!(&mem[full * stripe_len..], expected.as_slice());
+    }
+
     #[test]
     fn test_repeat_requests_ignored() {
         let mut state = prep(false);

--- a/src/block_device/bdev_uring.rs
+++ b/src/block_device/bdev_uring.rs
@@ -4,6 +4,7 @@ use io_uring::IoUring;
 use log::error;
 use nix::errno::Errno;
 use std::{
+    collections::HashMap,
     fs::{File, OpenOptions},
     os::fd::AsRawFd,
     os::unix::fs::OpenOptionsExt,
@@ -17,6 +18,7 @@ struct UringIoChannel {
     submissions: u64,
     completions: u64,
     finished_requests: Vec<(usize, bool)>,
+    expected_bytes: HashMap<u64, u32>,
     sync_io: bool,
 }
 
@@ -57,6 +59,7 @@ impl UringIoChannel {
             submissions: 0,
             completions: 0,
             finished_requests: Vec::new(),
+            expected_bytes: HashMap::new(),
             sync_io,
         })
     }
@@ -84,6 +87,7 @@ impl IoChannel for UringIoChannel {
             self.finished_requests.push((id, false));
             return;
         }
+        self.expected_bytes.insert(id as u64, len);
         self.pending += 1;
     }
 
@@ -100,6 +104,7 @@ impl IoChannel for UringIoChannel {
             self.finished_requests.push((id, false));
             return;
         }
+        self.expected_bytes.insert(id as u64, len);
         self.pending += 1;
     }
 
@@ -117,6 +122,7 @@ impl IoChannel for UringIoChannel {
             self.finished_requests.push((id, false));
             return;
         }
+        self.expected_bytes.insert(id as u64, 0);
         self.pending += 1;
     }
 
@@ -141,12 +147,26 @@ impl IoChannel for UringIoChannel {
                 Some(entry) => {
                     let result = entry.result();
                     let id = entry.user_data();
-                    if result < 0 {
-                        finished_requests.push((id as usize, false));
+                    let expected = self.expected_bytes.remove(&id);
+                    let success = if result < 0 {
                         error!("IO request failed: {}", Errno::from_raw(-result));
+                        false
                     } else {
-                        finished_requests.push((id as usize, true));
-                    }
+                        match expected {
+                            Some(expected) if result as u32 == expected => true,
+                            Some(expected) => {
+                                error!(
+                                    "IO request transferred {result} bytes, expected {expected}"
+                                );
+                                false
+                            }
+                            None => {
+                                error!("Completion for request {id}, which is not in flight");
+                                false
+                            }
+                        }
+                    };
+                    finished_requests.push((id as usize, success));
                     self.completions += 1;
                 }
                 None => break,
@@ -298,7 +318,8 @@ mod tests {
     // writes are rejected.
     #[test]
     fn create_channel_and_basic_io_readonly() -> Result<()> {
-        let tmpfile = NamedTempFile::new()?;
+        let mut tmpfile = NamedTempFile::new()?;
+        tmpfile.as_file_mut().set_len(SECTOR_SIZE as u64)?;
         let path = tmpfile.path().to_owned();
         let block_dev = UringBlockDevice::new(path.clone(), 8, true, false, false)?;
         let mut chan = block_dev.create_channel()?;
@@ -318,6 +339,38 @@ mod tests {
         let result = spin_until_complete(&mut chan);
         assert_eq!(result, vec![(1, false)]);
 
+        Ok(())
+    }
+
+    // A read that runs off the end of the file comes back short. Reporting it
+    // as success hands the caller a buffer the disk never filled.
+    #[test]
+    fn a_short_read_fails() -> Result<()> {
+        let mut tmpfile = NamedTempFile::new()?;
+        tmpfile.as_file_mut().set_len(SECTOR_SIZE as u64)?;
+        let block_dev = UringBlockDevice::new(tmpfile.path().to_owned(), 8, true, false, false)?;
+        let mut chan = block_dev.create_channel()?;
+
+        chan.add_read(0, 2, shared_buffer(2 * SECTOR_SIZE), 1);
+        chan.submit()?;
+
+        assert_eq!(spin_until_complete(&mut chan), vec![(1, false)]);
+        Ok(())
+    }
+
+    // The same read moved past the end returns nothing at all, which the
+    // kernel reports as a transfer of zero bytes rather than as an error.
+    #[test]
+    fn a_read_past_the_end_of_the_file_fails() -> Result<()> {
+        let mut tmpfile = NamedTempFile::new()?;
+        tmpfile.as_file_mut().set_len(SECTOR_SIZE as u64)?;
+        let block_dev = UringBlockDevice::new(tmpfile.path().to_owned(), 8, true, false, false)?;
+        let mut chan = block_dev.create_channel()?;
+
+        chan.add_read(4, 1, shared_buffer(SECTOR_SIZE), 1);
+        chan.submit()?;
+
+        assert_eq!(spin_until_complete(&mut chan), vec![(1, false)]);
         Ok(())
     }
 

--- a/src/block_device/bdev_uring.rs
+++ b/src/block_device/bdev_uring.rs
@@ -270,7 +270,7 @@ mod tests {
 
     use super::*;
 
-    use std::{thread::sleep, time::Duration};
+    use std::{io::Write, thread::sleep, time::Duration};
     use tempfile::NamedTempFile;
 
     fn spin_until_complete(chan: &mut Box<dyn IoChannel>) -> Vec<(usize, bool)> {
@@ -342,24 +342,26 @@ mod tests {
         Ok(())
     }
 
-    // A read that runs off the end of the file comes back short. Reporting it
-    // as success hands the caller a buffer the disk never filled.
+    // A read that runs off the end of a file comes back short, not failed.
     #[test]
     fn a_short_read_fails() -> Result<()> {
         let mut tmpfile = NamedTempFile::new()?;
-        tmpfile.as_file_mut().set_len(SECTOR_SIZE as u64)?;
+        let pattern = vec![0xA5u8; SECTOR_SIZE];
+        tmpfile.as_file_mut().write_all(&pattern)?;
         let block_dev = UringBlockDevice::new(tmpfile.path().to_owned(), 8, true, false, false)?;
         let mut chan = block_dev.create_channel()?;
 
-        chan.add_read(0, 2, shared_buffer(2 * SECTOR_SIZE), 1);
+        let buf = shared_buffer(2 * SECTOR_SIZE);
+        chan.add_read(0, 2, buf.clone(), 1);
         chan.submit()?;
 
         assert_eq!(spin_until_complete(&mut chan), vec![(1, false)]);
+        // It failed for being short, not for never having run.
+        assert_eq!(&buf.borrow().as_slice()[..SECTOR_SIZE], pattern.as_slice());
         Ok(())
     }
 
-    // The same read moved past the end returns nothing at all, which the
-    // kernel reports as a transfer of zero bytes rather than as an error.
+    // Moved past the end, it comes back as a transfer of zero bytes.
     #[test]
     fn a_read_past_the_end_of_the_file_fails() -> Result<()> {
         let mut tmpfile = NamedTempFile::new()?;
@@ -367,7 +369,8 @@ mod tests {
         let block_dev = UringBlockDevice::new(tmpfile.path().to_owned(), 8, true, false, false)?;
         let mut chan = block_dev.create_channel()?;
 
-        chan.add_read(4, 1, shared_buffer(SECTOR_SIZE), 1);
+        let buf = shared_buffer(SECTOR_SIZE);
+        chan.add_read(4, 1, buf.clone(), 1);
         chan.submit()?;
 
         assert_eq!(spin_until_complete(&mut chan), vec![(1, false)]);

--- a/src/export_archive.rs
+++ b/src/export_archive.rs
@@ -120,6 +120,55 @@ mod tests {
         Box::new(MemStore::new_with_objects(Rc::clone(&store.objects)))
     }
 
+    // An archive records stripes, not the size of the device they came from, so
+    // a device that ends mid-stripe comes back rounded up to a whole one, with
+    // the tail the archiver zeroed. Nothing here writes past the file it
+    // pre-allocated, because that size is rounded up the same way.
+    #[test]
+    fn an_archive_of_a_device_ending_mid_stripe_rounds_up() {
+        let kek = KeyEncryptionCipher::default();
+        let stripe_len = STRIPE_SECTOR_COUNT as usize * SECTOR_SIZE;
+        let bdev = Box::new(TestBlockDevice::new(
+            2 * stripe_len as u64 - SECTOR_SIZE as u64,
+        ));
+        bdev.write(0, &vec![0xAAu8; stripe_len], stripe_len);
+        let tail = vec![0xBBu8; stripe_len - SECTOR_SIZE];
+        bdev.write(stripe_len, &tail, tail.len());
+
+        let mut metadata = UbiMetadata::new(STRIPE_SECTOR_COUNT_SHIFT, 2, 0);
+        metadata.stripe_headers[0] |= metadata_flags::WRITTEN;
+        metadata.stripe_headers[1] |= metadata_flags::WRITTEN;
+
+        let store = Box::new(MemStore::new());
+        let mut archiver = StripeArchiver::new(
+            Box::new(BlockDeviceStripeSource::new(bdev.clone(), STRIPE_SECTOR_COUNT).unwrap()),
+            bdev.as_ref(),
+            metadata,
+            clone_memstore(store.as_ref()),
+            false,
+            ArchiveCompressionAlgorithm::None,
+            kek.clone(),
+            1,
+        )
+        .unwrap();
+        archiver.archive_all().unwrap();
+
+        let mut source = ArchiveStripeSource::new(clone_memstore(store.as_ref()), kek).unwrap();
+        assert_eq!(source.sector_count(), 2 * STRIPE_SECTOR_COUNT);
+
+        let buffer = shared_buffer(stripe_len);
+        source.request(1, buffer.clone()).unwrap();
+        let mut completions = Vec::new();
+        while completions.is_empty() {
+            completions = source.poll();
+        }
+        assert_eq!(completions, vec![(1, true)]);
+
+        let mut expected = tail.clone();
+        expected.extend(vec![0u8; SECTOR_SIZE]);
+        assert_eq!(buffer.borrow().as_slice(), expected.as_slice());
+    }
+
     #[test]
     fn test_export_archive_roundtrip() {
         let kek = KeyEncryptionCipher::default();

--- a/src/stripe_server/mod.rs
+++ b/src/stripe_server/mod.rs
@@ -42,6 +42,7 @@ pub struct StripeServerSession {
     stream: DynStream,
     metadata: Arc<UbiMetadata>,
     stripe_channel: Box<dyn IoChannel>,
+    device_sector_count: u64,
     source: Option<Box<dyn StripeSource>>,
 }
 
@@ -79,6 +80,7 @@ impl StripeServer {
             stream,
             metadata: self.metadata.clone(),
             stripe_channel,
+            device_sector_count: self.stripe_device.sector_count(),
             source,
         })
     }

--- a/src/stripe_server/session.rs
+++ b/src/stripe_server/session.rs
@@ -153,10 +153,18 @@ impl StripeServerSession {
         let stripe_len_bytes = self.metadata.stripe_size();
 
         let offset = stripe_id * (stripe_sector_count as u64);
+        // A short final stripe keeps the zeros the fresh buffer came with.
+        let sectors = (stripe_sector_count as u64)
+            .min(self.device_sector_count.saturating_sub(offset)) as u32;
+        if sectors == 0 {
+            return Err(crate::ubiblk_error!(InvalidParameter {
+                description: format!("stripe {stripe_id} starts past the end of the device"),
+            }));
+        }
 
         let buffer = shared_buffer(stripe_len_bytes);
         self.stripe_channel
-            .add_read(offset, stripe_sector_count, buffer.clone(), 0);
+            .add_read(offset, sectors, buffer.clone(), 0);
         self.stripe_channel.submit()?;
         wait_for_completion(
             self.stripe_channel.as_mut(),
@@ -196,7 +204,9 @@ mod tests {
 
     use crate::backends::SECTOR_SIZE;
     use crate::block_device::bdev_test::TestBlockDevice;
+    use crate::block_device::{BlockDevice, UringBlockDevice};
     use crate::stripe_server::StripeServer;
+    use tempfile::NamedTempFile;
 
     use super::*;
 
@@ -225,7 +235,7 @@ mod tests {
     fn make_session(
         input: Vec<u8>,
         metadata: Arc<UbiMetadata>,
-        device: Arc<TestBlockDevice>,
+        device: Arc<dyn BlockDevice>,
     ) -> (StripeServerSession, Arc<Mutex<Vec<u8>>>) {
         let writes = Arc::new(Mutex::new(Vec::new()));
         let stream = TestStream {
@@ -318,6 +328,39 @@ mod tests {
         expected.extend_from_slice(&(stripe_size as u64).to_le_bytes());
         expected.extend_from_slice(&pattern);
 
+        assert_eq!(*writes.lock().unwrap(), expected);
+    }
+
+    // File-backed: the in-memory device refuses a read past its end.
+    #[test]
+    fn test_handle_read_stripe_partial_final_stripe() {
+        let mut metadata = UbiMetadata::new(2, 2, 0);
+        metadata.set_stripe_header(1, metadata_flags::WRITTEN);
+        let metadata: Arc<UbiMetadata> = Arc::from(metadata);
+        let stripe_size = metadata.stripe_size();
+
+        let mut tmpfile = NamedTempFile::new().unwrap();
+        let tail = vec![0x7Eu8; SECTOR_SIZE];
+        tmpfile
+            .as_file_mut()
+            .write_all(&vec![0u8; stripe_size])
+            .unwrap();
+        tmpfile.as_file_mut().write_all(&tail).unwrap();
+        let device: Arc<dyn BlockDevice> = Arc::from(
+            UringBlockDevice::new(tmpfile.path().to_owned(), 8, true, false, false).unwrap()
+                as Box<dyn BlockDevice>,
+        );
+
+        let mut input = vec![READ_STRIPE_CMD];
+        input.extend_from_slice(&1u64.to_le_bytes());
+        let (mut session, writes) = make_session(input, metadata, device);
+
+        session.handle_single_request().unwrap();
+
+        let mut expected = vec![STATUS_OK];
+        expected.extend_from_slice(&(stripe_size as u64).to_le_bytes());
+        expected.extend_from_slice(&tail);
+        expected.extend_from_slice(&vec![0u8; stripe_size - SECTOR_SIZE]);
         assert_eq!(*writes.lock().unwrap(), expected);
     }
 

--- a/src/stripe_source/bdev.rs
+++ b/src/stripe_source/bdev.rs
@@ -1,3 +1,4 @@
+use crate::backends::SECTOR_SIZE;
 use crate::block_device::{BlockDevice, IoChannel, SharedBuffer};
 use crate::Result;
 
@@ -32,6 +33,14 @@ impl StripeSource for BlockDeviceStripeSource {
             .stripe_sector_count
             .min(self.source_sector_count - stripe_sector_offset);
 
+        // Callers reuse buffers, so the part of the last stripe the source does
+        // not have would otherwise be the previous stripe's bytes.
+        {
+            let mut buf = buffer.borrow_mut();
+            let read_len = (stripe_sector_count as usize * SECTOR_SIZE).min(buf.len());
+            buf.as_mut_slice()[read_len..].fill(0);
+        }
+
         self.channel.add_read(
             stripe_sector_offset,
             stripe_sector_count as u32,
@@ -63,9 +72,29 @@ impl StripeSource for BlockDeviceStripeSource {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::backends::SECTOR_SIZE;
     use crate::block_device::{bdev_test::TestBlockDevice, shared_buffer};
     use crate::UbiblkError;
+
+    #[test]
+    fn a_stripe_the_source_only_partly_holds_reads_back_zero_padded() {
+        let stripe_sectors = 4u64;
+        let device = Box::new(TestBlockDevice::new(6 * SECTOR_SIZE as u64));
+        device.write(
+            4 * SECTOR_SIZE,
+            &vec![0xBBu8; 2 * SECTOR_SIZE],
+            2 * SECTOR_SIZE,
+        );
+        let mut source = BlockDeviceStripeSource::new(device, stripe_sectors).unwrap();
+
+        let buffer = shared_buffer(stripe_sectors as usize * SECTOR_SIZE);
+        buffer.borrow_mut().as_mut_slice().fill(0xAA);
+        source.request(1, buffer.clone()).unwrap();
+        assert_eq!(source.poll(), vec![(1, true)]);
+
+        let mut expected = vec![0xBBu8; 2 * SECTOR_SIZE];
+        expected.extend(vec![0u8; 2 * SECTOR_SIZE]);
+        assert_eq!(buffer.borrow().as_slice(), expected.as_slice());
+    }
 
     #[test]
     fn test_request_beyond_end_errors() {


### PR DESCRIPTION
io_uring reports bytes, not success: a read off the end of a file completes with a short count, one past the end with zero. Both were reported to the caller as success, leaving it holding a buffer the disk never filled.

Each request now records what a full transfer moves - zero for a flush - and a completion reporting anything else fails, as does one for a request that is not in flight. Short transfers are not resumed; nothing in the tree reads past the end of a device, since the stripe source and the fetcher both clamp to it.

The readonly test read a sector from a file of no length and expected that to succeed; it gets a sector to read now.